### PR TITLE
fix: clamp predicted probability when accumulating ReliabilityStat sumProbability

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ReliabilityStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ReliabilityStat.kt
@@ -98,7 +98,7 @@ class ReliabilityStat(
         if (weight == 0.0) return
         val clamped = x.coerceIn(0.0, 1.0)
         val bin = (clamped * numBins).toInt().coerceIn(0, numBins - 1)
-        sumP[bin].add(x * weight)
+        sumP[bin].add(clamped * weight)
         sumO[bin].add(y * weight)
         sumW[bin].add(weight)
     }

--- a/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ReliabilityTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ReliabilityTest.kt
@@ -52,6 +52,11 @@ class ReliabilityTest {
         // Bin 0 picks up the negative; bin 1 picks up the > 1.
         assertEquals(1.0, res.totalWeights[0], DELTA)
         assertEquals(1.0, res.totalWeights[1], DELTA)
+        // Clamping must apply to the accumulated probability too, otherwise meanProbability
+        // can drift outside [0, 1] and corrupt ECE.
+        assertEquals(0.0, res.meanProbability[0], DELTA)
+        assertEquals(1.0, res.meanProbability[1], DELTA)
+        assertTrue(res.expectedCalibrationError() in 0.0..1.0)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- ReliabilityStat.update now accumulates clamped*weight into sumP instead of raw x*weight.
- Strengthened the existing clamp test to assert meanProbability and ECE stay in range.

## Why

The bin index was already chosen from the clamped value, but sumP took raw x. An out-of-range prediction could push meanProbability past 1 and corrupt ECE. The old test only checked totalWeights, so the bug slipped through.

## Testing

The strengthened ReliabilityTest fails on main and passes with the fix. Ran the full ReliabilityTest suite under jvmTest.