### PR TITLE
fix: round fractional weights in SpaceSavingStat instead of truncating to zero

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -85,7 +85,7 @@ class SpaceSavingStat(
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
-        val w = weight.toLong()
+        val w = kotlin.math.round(weight).toLong()
         if (w <= 0L) return
         lock.withLock {
             admit(value, w, 0L)

--- a/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingTest.kt
@@ -103,6 +103,20 @@ class SpaceSavingTest {
     }
 
     @Test
+    fun `fractional weight rounds rather than truncating`() {
+        // Mirrors CountMinSketchStat: weights are rounded so a stream of fractional
+        // weights accumulates into the count instead of being silently dropped.
+        val ss = SpaceSavingStat(capacity = 5)
+        ss.update(7L, weight = 1.7) // rounds to 2
+        ss.update(7L, weight = 0.6) // rounds to 1
+        ss.update(8L, weight = 0.4) // rounds to 0 — dropped, but totalSeen still advances
+        val r = ss.read()
+        val kv = r.keys.zip(r.counts.toList()).toMap()
+        assertEquals(3L, kv[7L])
+        assertTrue(8L !in kv.keys)
+    }
+
+    @Test
     fun `merge combines two summaries`() {
         val a = SpaceSavingStat(capacity = 10)
         val b = SpaceSavingStat(capacity = 10)


### PR DESCRIPTION
## What changed

- SpaceSavingStat.update now does round(weight).toLong() before the zero-check, matching CountMinSketchStat.
- Added a SpaceSavingTest case that drives 1.7, 0.6 and 0.4 weighted updates.

## Why

The old code used weight.toLong(), so weight=0.5 truncated to 0 and the update was silently dropped, and weight=1.7 truncated to 1 (losing 41% of mass). CountMinSketchStat already uses round() for the same reason, so the two sketches gave inconsistent counts on the same input.

## Testing

The new SpaceSavingTest case fails on main and passes with the fix. Full SpaceSavingTest suite green under jvmTest.