### PR TITLE
fix: preserve negative rates when merging DecayingRateStat results

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
@@ -44,8 +44,7 @@ private fun decayingRateDelegate(
             DecayingRateResult(sum.sum * scale, sum.timestampNanos)
         },
         reverse = { rate ->
-            val sum = if (rate.rate <= 0.0) 0.0 else rate.rate / scale
-            DecayingSumResult(sum, rate.timestampNanos)
+            DecayingSumResult(rate.rate / scale, rate.timestampNanos)
         }
     )
 }

--- a/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatsTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatsTest.kt
@@ -231,6 +231,20 @@ class DecayingRateTest {
     }
 
     @Test
+    fun `merge preserves negative rates`() {
+        // DecayingSumStat (the underlying primitive) accepts negative values; the rate
+        // projection must round-trip them through merge instead of clamping to zero.
+        val source = DecayingRateStat(halfLife = 1.seconds)
+        source.update(-1.0, T0)
+        val negative = source.read(T0)
+        assertTrue(negative.rate < 0.0)
+
+        val target = DecayingRateStat(halfLife = 1.seconds)
+        target.merge(negative)
+        assertEquals(negative.rate, target.read(T0).rate, DELTA)
+    }
+
+    @Test
     fun `create produces fresh independent stat`() {
         val r1 = DecayingRateStat(halfLife = 1.seconds)
         r1.update(10.0, T0)


### PR DESCRIPTION
## What changed

- Dropped the `if (rate.rate <= 0.0) 0.0 else ...` clamp from DecayingRateStat's reverse mapResult; it now passes rate.rate / scale unconditionally.
- Added a DecayingRateTest case that drives a negative-value update and merges the result into a fresh stat.

## Why

DecayingSumStat is a generic primitive that accepts negative values (DecayingMeanStat and friends rely on that). The forward projection carries the sign correctly as sum * scale, but the reverse projection clamped any non-positive rate to zero, so merging a result with rate < 0 silently dropped the contribution.

## Testing

The new DecayingRateTest case fails on main and passes with the fix. Full rate test suite green under jvmTest.