### PR TITLE
fix: reject boundary relativeError values in DDSketchStat

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -30,7 +30,9 @@ class DDSketchStat(
 ) : SeriesStat<SketchResult> {
 
     init {
-        require(relativeError in 0.0..1.0) { "Relative error must be between 0.0 and 1.0" }
+        require(relativeError > 0.0 && relativeError < 1.0) {
+            "Relative error must be strictly between 0.0 and 1.0; got $relativeError"
+        }
     }
 
     private val gamma: Double = (1.0 + relativeError) / (1.0 - relativeError)

--- a/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
@@ -130,6 +130,9 @@ class DDSketchTest {
     fun `invalid relative error throws`() {
         assertFailsWith<IllegalArgumentException> { DDSketchStat(relativeError = -0.01) }
         assertFailsWith<IllegalArgumentException> { DDSketchStat(relativeError = 1.1) }
+        // Boundary values are degenerate: 0.0 → multiplier=+∞, 1.0 → div-by-zero in gamma.
+        assertFailsWith<IllegalArgumentException> { DDSketchStat(relativeError = 0.0) }
+        assertFailsWith<IllegalArgumentException> { DDSketchStat(relativeError = 1.0) }
     }
 
     @Test


### PR DESCRIPTION
## What changed

- DDSketchStat's init check now requires relativeError strictly between 0 and 1 instead of allowing the closed interval.
- Extended the existing invalid-relative-error test to cover the 0.0 and 1.0 boundaries.

## Why

The previous bound let degenerate sketches through. relativeError=0.0 gives gamma=1, ln(gamma)=0, multiplier=+∞, so every bin index saturates to Int.MAX_VALUE and the sketch collapses to a single bucket. relativeError=1.0 divides by zero inside gamma=(1+ε)/(1−ε), producing gamma=+∞ and multiplier=0 — also unusable.

## Testing

The extended DDSketchTest case fails on main and passes with the tighter check. Full DDSketchTest suite green under jvmTest.