### PR TITLE
fix: report template concurrency from VectorizedStat and drop redundant override

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -15,13 +15,11 @@ import com.eignex.kumulant.core.VectorStat
  */
 class VectorizedStat<R : Result>(
     val dimensions: Int,
-    template: SeriesStat<R>,
-    private val concurrencyOverride: Concurrency? = null,
+    private val template: SeriesStat<R>,
 ) : VectorStat<ResultList<R>> {
 
-    private val template: SeriesStat<R> = template.create(concurrencyOverride)
     private val stats: Array<SeriesStat<R>> =
-        Array(dimensions) { this.template.create(concurrencyOverride) }
+        Array(dimensions) { template.create(null) }
 
     override val concurrency: Concurrency get() = template.concurrency
 
@@ -42,7 +40,7 @@ class VectorizedStat<R : Result>(
         ResultList(stats.map { it.read(timestampNanos) })
 
     override fun create(concurrency: Concurrency?): VectorStat<ResultList<R>> =
-        VectorizedStat(dimensions, template, concurrency ?: this.concurrencyOverride)
+        VectorizedStat(dimensions, template.create(concurrency))
 
     override fun merge(values: ResultList<R>) {
         require(values.results.size == dimensions)

--- a/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -19,11 +19,11 @@ class VectorizedStat<R : Result>(
     private val concurrencyOverride: Concurrency? = null,
 ) : VectorStat<ResultList<R>> {
 
-    override val concurrency: Concurrency get() = concurrencyOverride ?: Concurrency.None
-
     private val template: SeriesStat<R> = template.create(concurrencyOverride)
     private val stats: Array<SeriesStat<R>> =
         Array(dimensions) { this.template.create(concurrencyOverride) }
+
+    override val concurrency: Concurrency get() = template.concurrency
 
     override fun update(
         vector: DoubleArray,

--- a/src/commonMain/kotlin/com/eignex/kumulant/schema/StatFactory.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/schema/StatFactory.kt
@@ -220,7 +220,7 @@ fun <R : Result> VectorStatSpec<R>.materialize(concurrency: Concurrency = Concur
                 .windowed(durationMillis.milliseconds, slices, concurrency)
         is Vectorized -> {
             val tpl = requireSeries(template, "Vectorized").materialize(concurrency) as SeriesStat<Result>
-            VectorizedStat(dimensions, tpl, concurrency)
+            VectorizedStat(dimensions, tpl)
         }
         is TransformVectorElement -> {
             val m = requireVector(inner, "TransformVectorElement").materialize(concurrency) as VectorStat<Result>

--- a/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.SumResult
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
@@ -50,6 +51,25 @@ class VectorizedStatTest {
         val r = stat.read()
         assertEquals(0.0, r.results[0].sum, DELTA)
         assertEquals(0.0, r.results[1].sum, DELTA)
+    }
+
+    @Test
+    fun `concurrency reflects template when no override is given`() {
+        // Without an explicit override the wrapper must report the template's mode,
+        // not Concurrency.None — children are built from the template and inherit
+        // its mode, so the trait would otherwise lie.
+        val stat = VectorizedStat(2, SumStat(concurrency = Concurrency.Relaxed))
+        assertEquals(Concurrency.Relaxed, stat.concurrency)
+    }
+
+    @Test
+    fun `concurrency override wins over template`() {
+        val stat = VectorizedStat(
+            2,
+            SumStat(concurrency = Concurrency.Relaxed),
+            concurrencyOverride = Concurrency.Strict,
+        )
+        assertEquals(Concurrency.Strict, stat.concurrency)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -63,13 +63,10 @@ class VectorizedStatTest {
     }
 
     @Test
-    fun `concurrency override wins over template`() {
-        val stat = VectorizedStat(
-            2,
-            SumStat(concurrency = Concurrency.Relaxed),
-            concurrencyOverride = Concurrency.Strict,
-        )
-        assertEquals(Concurrency.Strict, stat.concurrency)
+    fun `create propagates a new concurrency mode through the template`() {
+        val original = VectorizedStat(2, SumStat(concurrency = Concurrency.Relaxed))
+        val derived = original.create(Concurrency.Strict)
+        assertEquals(Concurrency.Strict, derived.concurrency)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- VectorizedStat.concurrency now returns template.concurrency instead of concurrencyOverride ?: Concurrency.None.
- Dropped the redundant concurrencyOverride constructor parameter — children are built from the resolved template, which already carries the mode.
- StatFactory no longer passes concurrency twice when materializing a Vectorized spec.
- VectorizedStat.create(c) now propagates c through template.create(c), matching the pattern used elsewhere.
- Added two VectorizedStatTest cases covering the no-override and create-time-override paths.

## Why

The old code reported Concurrency.None whenever concurrencyOverride was null, but the children inherit the template's concurrency, so the trait lied. The override parameter was only ever exercised at the factory site, where the materialized template already had the same mode baked in, so it was redundant. Removing it brings VectorizedStat in line with MapResults and other wrappers that just delegate to the inner stat's mode.

## Testing

The new VectorizedStatTest case fails on main and passes with the fix. Full jvmTest suite green.