### PR TITLE
fix: always finalize hash64 with a tail mix to break chunk-aligned collisions

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stream/Hashes.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stream/Hashes.kt
@@ -65,16 +65,16 @@ object SplitMixChunkHasher : Hasher64 {
             h = splitmix64(h xor chunk)
             i += 8
         }
-        if (i < bytes.size) {
-            var tail = 0L
-            var shift = 0
-            while (i < bytes.size) {
-                tail = tail or ((bytes[i].toLong() and 0xFF) shl shift)
-                shift += 8
-                i++
-            }
-            h = splitmix64(h xor tail)
+        // Always finalize with a tail mix — even when bytes.size is a multiple of 8 —
+        // so chunk-aligned and unaligned inputs that happen to reach the same
+        // intermediate state cannot collide.
+        var tail = 0L
+        var shift = 0
+        while (i < bytes.size) {
+            tail = tail or ((bytes[i].toLong() and 0xFF) shl shift)
+            shift += 8
+            i++
         }
-        return h
+        return splitmix64(h xor tail)
     }
 }

--- a/src/commonTest/kotlin/com/eignex/kumulant/stream/HashesTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stream/HashesTest.kt
@@ -67,13 +67,25 @@ class Hash64Test {
     fun `hash64 ByteArray matches reference vectors across platforms`() {
         // Locked-in outputs from SplitMixChunkHasher. Platform-stable; guards against
         // accidental endianness or chunking changes.
-        assertEquals(0L, hash64(ByteArray(0)))
+        assertEquals(4553024054441242788L, hash64(ByteArray(0)))
         assertEquals(6023229995862221380L, hash64("hello"))
         assertEquals(4208025021734807446L, hash64("the quick brown fox jumps over the lazy dog"))
         assertEquals(
-            -9112064343569154153L,
+            4469830170794531066L,
             hash64(byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)),
         )
+    }
+
+    @Test
+    fun `hash64 does not collide across the chunk boundary`() {
+        // [0x01] and [8, 0, 0, 0, 0, 0, 0, 0] both reach state splitmix64(0) at the
+        // moment the chunk-aligned input runs out of input: the 1-byte input mixes a
+        // tail of 1 against initial state 1, and the 8-byte input mixes a chunk of 8
+        // against initial state 8. Without a finalization step that runs on
+        // chunk-aligned inputs, both return splitmix64(0).
+        val unaligned = byteArrayOf(0x01)
+        val aligned = byteArrayOf(8, 0, 0, 0, 0, 0, 0, 0)
+        assertNotEquals(hash64(unaligned), hash64(aligned))
     }
 
     @Test


### PR DESCRIPTION
## What changed

- SplitMixChunkHasher now runs the tail mix unconditionally so chunk-aligned inputs also get a final splitmix64 step.
- Added a HashesTest case for the [0x01] vs [8, 0, 0, 0, 0, 0, 0, 0] collision.
- Updated the locked reference vectors for ByteArray(0) and the 16-byte aligned input — outputs changed.

## Why

The old hasher skipped the tail mix when bytes.size was a multiple of 8, so a chunk-aligned input could reach the same intermediate state as a shorter unaligned input and return the same hash. Specifically [0x01] and [8, 0, 0, 0, 0, 0, 0, 0] both ended at splitmix64(0). Running the tail mix unconditionally adds one extra splitmix step on chunk-aligned inputs and breaks the collision class. Changes hash outputs for any chunk-aligned input — beta library, acceptable.

## Testing

The new HashesTest case fails on main and passes with the fix. Full jvmTest suite green, including sketch tests (HLL, MinHash, Bloom, CountMin) that consume hash64.