### PR TITLE
fix: widen single-point ReservoirHistogram bucket so upper exceeds lower

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -39,6 +39,13 @@ fun ReservoirResult.quantile(probability: Double): Double {
     return sorted[lo] + frac * (sorted[hi] - sorted[lo])
 }
 
+private fun nextUp(d: Double): Double {
+    if (d.isNaN() || d == Double.POSITIVE_INFINITY) return d
+    if (d == 0.0) return Double.MIN_VALUE
+    val bits = d.toRawBits()
+    return Double.fromBits(if (d > 0.0) bits + 1 else bits - 1)
+}
+
 /** Bucket the retained sample into [binCount] equal-width bins between min and max. */
 fun ReservoirResult.toSparseHistogram(binCount: Int): SparseHistogramResult {
     require(binCount > 0) { "binCount must be > 0" }
@@ -52,9 +59,11 @@ fun ReservoirResult.toSparseHistogram(binCount: Int): SparseHistogramResult {
         if (v > hi) hi = v
     }
     if (lo == hi) {
+        // Preserve the [lower, upper) contract by widening the single-point bucket
+        // by one ULP. Empty intervals would be unbucketed by consumers.
         return SparseHistogramResult(
             doubleArrayOf(lo),
-            doubleArrayOf(lo),
+            doubleArrayOf(nextUp(lo)),
             doubleArrayOf(values.size.toDouble())
         )
     }

--- a/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramTest.kt
@@ -117,7 +117,9 @@ class ReservoirHistogramTest {
         val h = res.read().toSparseHistogram(binCount = 4)
         assertEquals(1, h.lowerBounds.size)
         assertEquals(7.0, h.lowerBounds[0])
-        assertEquals(7.0, h.upperBounds[0])
+        // upper must be strictly greater than lower so the half-open [lower, upper)
+        // interval actually contains the sampled value.
+        assertTrue(h.upperBounds[0] > h.lowerBounds[0])
         assertEquals(5.0, h.weights[0])
     }
 


### PR DESCRIPTION
## What changed

- ReservoirHistogramStat.toSparseHistogram now widens the single-point bucket by one ULP via a local nextUp helper instead of returning lower == upper.
- Loosened the corresponding test assertion to require upper > lower rather than upper == 7.0.

## Why

SparseHistogramResult documents its buckets as [lowerBounds, upperBounds) — a half-open interval. When all reservoir samples were equal, the old code returned a zero-width bucket [lo, lo) that contains no points, so any consumer testing v in [lo, hi) would miss every sample even though the bucket weight was non-zero. LinearHistogram and HdrHistogram both guarantee upper > lower; ReservoirHistogram now matches.

## Testing

The loosened ReservoirHistogramTest case fails against the old source (lower == upper) and passes with the fix. Full ReservoirHistogramTest suite green under jvmTest.