### PR TITLE
fix: use floorDiv in SliceRing to bucket negative timestamps correctly

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -42,10 +42,10 @@ internal class SliceRing<R : Result, S : Stat<R>>(
     }
 
     private fun expectedSliceStart(timestampNanos: Long): Long =
-        (timestampNanos / sliceDurationNanos) * sliceDurationNanos
+        timestampNanos.floorDiv(sliceDurationNanos) * sliceDurationNanos
 
     private fun bucketIndex(expectedStart: Long): Int {
-        val raw = ((expectedStart / sliceDurationNanos) % buckets.size).toInt()
+        val raw = (expectedStart.floorDiv(sliceDurationNanos) % buckets.size).toInt()
         return if (raw < 0) raw + buckets.size else raw
     }
 

--- a/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingTest.kt
@@ -1,0 +1,38 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stat.summary.SumResult
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.seconds
+
+class SliceRingTest {
+
+    private fun newRing() = SliceRing<SumResult, SumStat>(
+        windowDuration = 10.seconds,
+        slices = 10,
+        concurrency = Concurrency.None,
+    ) { c -> SumStat(c) }
+
+    @Test
+    fun `slotFor maps negative timestamps in different slices to different slots`() {
+        // Timestamps -1 and 0 are in different slices ([-1s, 0) and [0, 1s)).
+        // Truncating division collapses both to expected start 0, so the buggy
+        // path returns the same slot for both. floorDiv keeps them apart.
+        val ring = newRing()
+        val slotMinusOne = ring.slotFor(-1L)!!
+        val slotZero = ring.slotFor(0L)!!
+        assertNotSame(slotMinusOne, slotZero)
+    }
+
+    @Test
+    fun `slotFor returns same slot for two timestamps in the same negative slice`() {
+        val ring = newRing()
+        val sliceNanos = 1_000_000_000L // 10s / 10 slices
+        val a = ring.slotFor(-sliceNanos - 5)!!
+        val b = ring.slotFor(-sliceNanos - 200)!!
+        assertSame(a, b)
+    }
+}


### PR DESCRIPTION
## What changed

- SliceRing.expectedSliceStart and bucketIndex now use Long.floorDiv instead of truncating integer division.
- Added a SliceRingTest covering the negative-timestamp slice assignment.

## Why

Truncating division rounds toward zero, so negative timestamps within one slice of zero (e.g. -1ns through -sliceDurationNanos+1) collapsed onto slice 0. Updates at timestamp -1 and timestamp 0 belong to different slices but ended up in the same slot. floorDiv rounds toward negative infinity, which is what slice-start arithmetic actually wants.

## Testing

The new SliceRingTest case fails on main and passes with the fix. jvmTest plus compileKotlinJs and compileKotlinWasmJs all succeed (Long.floorDiv is in kotlin stdlib, not Math.floorDiv).