### PR TITLE
refactor: split SliceRing.mergeNow into mergeAt with explicit timestamp

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -71,7 +71,16 @@ internal class SliceRing<R : Result, S : Stat<R>>(
 
     /** Merge [values] into the slot at "now", rotating the bucket first if needed. */
     fun mergeNow(values: R) {
-        val expectedStart = expectedSliceStart(currentTimeNanos())
+        mergeAt(currentTimeNanos(), values)
+    }
+
+    /**
+     * Merge [values] into the slot that owns [timestampNanos], rotating the bucket
+     * first if needed. Exposed for deterministic time-driven tests; `mergeNow` is
+     * the production entry point.
+     */
+    fun mergeAt(timestampNanos: Long, values: R) {
+        val expectedStart = expectedSliceStart(timestampNanos)
         val bucketRef = buckets[bucketIndex(expectedStart)]
         var currentSlot = bucketRef.load()
         if (currentSlot.startNanos < expectedStart) {


### PR DESCRIPTION
## What changed

- Extracted SliceRing.mergeNow's body into a new internal mergeAt(timestampNanos, values) method.
- mergeNow now delegates to mergeAt(currentTimeNanos(), values).

## Why

slotFor already takes an explicit timestamp; mergeAt mirrors it for symmetry. The real motivation is testability — the follow-up fix for the mergeNow CAS-race needs deterministic time control to drive specific bucket states, which requires bypassing currentTimeNanos.

## Testing

No behavior change. Full jvmTest suite green. The follow-up bug-fix PR will exercise mergeAt directly.