### PR TITLE
fix: skip mergeAt when the bucket has already rotated past expectedStart

### DIFF
--- a/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -71,7 +71,16 @@ internal class SliceRing<R : Result, S : Stat<R>>(
 
     /** Merge [values] into the slot at "now", rotating the bucket first if needed. */
     fun mergeNow(values: R) {
-        val expectedStart = expectedSliceStart(currentTimeNanos())
+        mergeAt(currentTimeNanos(), values)
+    }
+
+    /**
+     * Merge [values] into the slot that owns [timestampNanos], rotating the bucket
+     * first if needed. Exposed for deterministic time-driven tests; `mergeNow` is
+     * the production entry point.
+     */
+    fun mergeAt(timestampNanos: Long, values: R) {
+        val expectedStart = expectedSliceStart(timestampNanos)
         val bucketRef = buckets[bucketIndex(expectedStart)]
         var currentSlot = bucketRef.load()
         if (currentSlot.startNanos < expectedStart) {

--- a/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -82,12 +82,23 @@ internal class SliceRing<R : Result, S : Stat<R>>(
     fun mergeAt(timestampNanos: Long, values: R) {
         val expectedStart = expectedSliceStart(timestampNanos)
         val bucketRef = buckets[bucketIndex(expectedStart)]
-        var currentSlot = bucketRef.load()
-        if (currentSlot.startNanos < expectedStart) {
+        while (true) {
+            val currentSlot = bucketRef.load()
+            if (currentSlot.startNanos == expectedStart) {
+                currentSlot.stat.merge(values)
+                return
+            }
+            if (currentSlot.startNanos > expectedStart) {
+                // Bucket already advanced past us — the slot we'd want has been recycled.
+                return
+            }
             val newSlot = Slot<R, S>(expectedStart, factory(concurrency))
-            currentSlot = if (bucketRef.compareAndSet(currentSlot, newSlot)) newSlot else bucketRef.load()
+            if (bucketRef.compareAndSet(currentSlot, newSlot)) {
+                newSlot.stat.merge(values)
+                return
+            }
+            // Lost CAS — retry; another thread may have installed the same or a newer slot.
         }
-        currentSlot.stat.merge(values)
     }
 
     /** Invoke [action] on each slot stat whose start lies in `[timestampNanos - window, timestampNanos]`. */

--- a/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
+++ b/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
@@ -1,0 +1,61 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stat.summary.SumResult
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+private const val DELTA = 1e-12
+
+class SliceRingMergeAtTest {
+
+    private fun newRing() = SliceRing<SumResult, SumStat>(
+        windowDuration = 10.seconds,
+        slices = 10,
+        concurrency = Concurrency.None,
+    ) { c -> SumStat(c) }
+
+    /**
+     * Two merges into the same slice land in the same slot and sum together.
+     * Sanity check that mergeAt routes by timestamp.
+     */
+    @Test
+    fun `merges within one slice sum into the same slot`() {
+        val ring = newRing()
+        val sliceNanos = 1_000_000_000L // 10s / 10 slices
+        ring.mergeAt(sliceNanos + 100, SumResult(3.0))
+        ring.mergeAt(sliceNanos + 800, SumResult(4.0))
+        var total = 0.0
+        ring.forEachActive(sliceNanos + 1000) { total += it.read().sum }
+        assertEquals(7.0, total, DELTA)
+    }
+
+    /**
+     * If a later thread has already rotated the bucket past expectedStart (so
+     * bucketRef.load() returns a slot whose startNanos > expectedStart), mergeAt
+     * must not merge into that future slot. The pre-fix code's fallback
+     * `bucketRef.load()` would do exactly that. We simulate the post-rotation
+     * state by calling mergeAt on a newer timestamp first to install the future
+     * slot, then mergeAt on an older timestamp that targets the same bucket index.
+     */
+    @Test
+    fun `merge at a stale timestamp does not contaminate a newer slot`() {
+        val ring = newRing()
+        val sliceNanos = 1_000_000_000L
+        // 10 buckets, so slice index 10 collides with index 0 in the ring.
+        // Install slot for slice 10 first (start = 10 * sliceNanos).
+        val newerStart = 10 * sliceNanos
+        ring.mergeAt(newerStart + 100, SumResult(5.0))
+        // Now try to merge at a timestamp belonging to slice 0 (start = 0).
+        // This shares the bucket with slice 10. The slot currently in that
+        // bucket has startNanos = 10*sliceNanos, which is > expectedStart = 0.
+        // mergeAt must skip the merge rather than overwriting the newer slot.
+        ring.mergeAt(50, SumResult(99.0))
+        // Read the newer slice's contents — must still be 5.0, not 5+99.
+        var total = 0.0
+        ring.forEachActive(newerStart + 500) { total += it.read().sum }
+        assertEquals(5.0, total, DELTA)
+    }
+}


### PR DESCRIPTION
## What changed

- SliceRing.mergeAt now loops until it observes a slot whose startNanos matches expectedStart, returns early if the bucket has advanced past us, and retries on a lost CAS.
- Added SliceRingMergeAtTest covering both the happy path and the stale-timestamp case.

## Why

The old code only looked at currentSlot.startNanos < expectedStart and merged unconditionally otherwise. If the bucket had already rotated to a newer slice (startNanos > expectedStart), the merge contaminated that newer slot. The CAS-lose fallback bucketRef.load() had the same hole — the freshly-loaded slot's startNanos could be > expectedStart. Looping like slotFor closes both holes.

## Testing

The new stale-timestamp test fails against the pre-fix mergeAt and passes with the loop. Full jvmTest suite green.

Stacked on top of #9 (refactor: split SliceRing.mergeNow into mergeAt with explicit timestamp).