### PR TITLE
Make discrete sketch hasher a pluggable serializable parameter

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.math
 
-import kotlin.jvm.JvmInline
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 
 // 64-bit hashing primitives used by the cardinality and sketch families.
 //
@@ -69,11 +69,11 @@ interface LongHasher {
 }
 
 /** Canonical name of the default [LongHasher]; the wire default for the sketch specs. */
-const val SplitMix64Name: String = "splitmix64"
+private const val SPLIT_MIX64_NAME: String = "splitmix64"
 
 /** Default [LongHasher]: the library's [splitmix64] mixer. Pre-registered with [Hashers]. */
 val SplitMix64: LongHasher = object : LongHasher {
-    override val name: String = SplitMix64Name
+    override val name: String = SPLIT_MIX64_NAME
     override fun mix(value: Long): Long = splitmix64(value)
 }
 
@@ -86,9 +86,10 @@ val SplitMix64: LongHasher = object : LongHasher {
 @Serializable
 @JvmInline
 value class HasherRef(val name: String) {
+    /** Built-in [HasherRef] constants. */
     companion object {
         /** Reference to the default [SplitMix64] mixer. */
-        val SplitMix64: HasherRef = HasherRef(SplitMix64Name)
+        val SplitMix64: HasherRef = HasherRef(SPLIT_MIX64_NAME)
     }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
@@ -1,5 +1,8 @@
 package com.eignex.kumulant.math
 
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
 // 64-bit hashing primitives used by the cardinality and sketch families.
 //
 // Naming convention for additional algorithms: each algorithm exposes top-level
@@ -44,6 +47,72 @@ fun hash64(value: String): Long = hash64(value.encodeToByteArray())
 fun interface Hasher64 {
     /** Return a 64-bit hash of [bytes]. Equal byte arrays must return equal hashes. */
     fun hash(bytes: ByteArray): Long
+}
+
+/**
+ * Pluggable `Long -> Long` mixer used by the discrete sketch family (HyperLogLog,
+ * LinearCounting, MinHash, BloomFilter, CountMinSketch) to spread a key's bits across
+ * the full 64-bit range before bucketing. Distinct from [Hasher64] (`ByteArray -> Long`):
+ * callers reduce a domain key to a `Long` first (e.g. via [hash64]), and the sketch then
+ * mixes that `Long` through here.
+ *
+ * Implementations must be deterministic and pure, and expose a stable [name] so a sketch
+ * can record which mixer produced its summary on the wire. Register a custom mixer with
+ * [Hashers.register] so [Hashers.resolve] can rebuild it from a name after deserialization.
+ */
+interface LongHasher {
+    /** Stable identifier serialized into specs and results, and used as the registry key. */
+    val name: String
+
+    /** Mix [value] into a uniformly spread 64-bit hash. */
+    fun mix(value: Long): Long
+}
+
+/** Canonical name of the default [LongHasher]; the wire default for the sketch specs. */
+const val SplitMix64Name: String = "splitmix64"
+
+/** Default [LongHasher]: the library's [splitmix64] mixer. Pre-registered with [Hashers]. */
+val SplitMix64: LongHasher = object : LongHasher {
+    override val name: String = SplitMix64Name
+    override fun mix(value: Long): Long = splitmix64(value)
+}
+
+/**
+ * Typed, serializable reference to a [LongHasher] by [name]. Carried by the discrete sketch
+ * specs and results in place of a bare string, and resolved to a live mixer via
+ * [Hashers.resolve]. Serializes transparently as its [name], so the wire form stays a plain
+ * string and needs no custom serializer.
+ */
+@Serializable
+@JvmInline
+value class HasherRef(val name: String) {
+    companion object {
+        /** Reference to the default [SplitMix64] mixer. */
+        val SplitMix64: HasherRef = HasherRef(SplitMix64Name)
+    }
+}
+
+/**
+ * Registry resolving a [LongHasher.name] back to its live implementation. The sketch
+ * families serialize only the mixer's name; [resolve] reconstructs the function when a
+ * spec is materialized or a sketch result is queried. [SplitMix64] is pre-registered.
+ *
+ * Custom mixers are not serializable on their own (a lambda cannot round-trip), so the
+ * wire carries the name and this registry supplies the code. Register a custom mixer at
+ * startup on every process that materializes or queries the affected sketches; the entry
+ * is global and not synchronized, so register before concurrent use.
+ */
+object Hashers {
+    private val registry: MutableMap<String, LongHasher> = mutableMapOf(SplitMix64.name to SplitMix64)
+
+    /** Register [hasher] under its [LongHasher.name], replacing any prior entry of that name. */
+    fun register(hasher: LongHasher) {
+        registry[hasher.name] = hasher
+    }
+
+    /** Resolve the [LongHasher] named by [ref], or throw if no mixer was registered under it. */
+    fun resolve(ref: HasherRef): LongHasher =
+        registry[ref.name] ?: error("Unknown LongHasher '${ref.name}'; register it via Hashers.register before use")
 }
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/StatFactory.kt
@@ -11,6 +11,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
+import com.eignex.kumulant.math.Hashers
 import com.eignex.kumulant.operation.FilterDiscreteStat
 import com.eignex.kumulant.operation.FilterPairedStat
 import com.eignex.kumulant.operation.FilterSeriesStat
@@ -508,15 +509,15 @@ fun <R : Result> VectorStatSpec<R>.materialize(concurrency: Concurrency = Concur
  */
 fun <R : Result> DiscreteStatSpec<R>.materialize(concurrency: Concurrency = Concurrency.None): DiscreteStat<R> {
     val out: DiscreteStat<*> = when (this) {
-        is HyperLogLog -> HyperLogLogStat(precision, concurrency)
+        is HyperLogLog -> HyperLogLogStat(precision, Hashers.resolve(hasher), concurrency)
 
-        is LinearCounting -> LinearCountingStat(bits, concurrency)
+        is LinearCounting -> LinearCountingStat(bits, Hashers.resolve(hasher), concurrency)
 
-        is BloomFilter -> BloomFilterStat(bits, hashes, concurrency)
+        is BloomFilter -> BloomFilterStat(bits, hashes, Hashers.resolve(hasher), concurrency)
 
-        is CountMinSketch -> CountMinSketchStat(depth, width, seed, concurrency)
+        is CountMinSketch -> CountMinSketchStat(depth, width, seed, Hashers.resolve(hasher), concurrency)
 
-        is MinHash -> MinHashStat(numHashes, seed, concurrency)
+        is MinHash -> MinHashStat(numHashes, seed, Hashers.resolve(hasher), concurrency)
 
         is SpaceSaving -> SpaceSavingStat(capacity, concurrency)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.stat.anomaly.FeatureRange
 import com.eignex.kumulant.stat.anomaly.GaussianScoreResult
 import com.eignex.kumulant.stat.anomaly.HalfSpaceTreesResult
@@ -409,6 +410,8 @@ data object Accuracy : PairedStatSpec<WeightedMeanResult>
 data class HyperLogLog(
     /** Number of register-index bits; memory is `2^precision` bytes. */
     val precision: Int = 14,
+    /** Name of the [LongHasher] applied before bucketing; resolved via [Hashers]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<HyperLogLogResult>
 
 /** Spec for `LinearCountingStat`: cardinality estimator backed by a bitset of [bits] cells. */
@@ -417,6 +420,8 @@ data class HyperLogLog(
 data class LinearCounting(
     /** Bitset size; trade-off between memory and accuracy near the saturation cap. */
     val bits: Int = 4096,
+    /** Name of the [LongHasher] applied before indexing; resolved via [Hashers]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<LinearCountingResult>
 
 /** Spec for `BloomFilterStat`: probabilistic set membership. */
@@ -427,6 +432,8 @@ data class BloomFilter(
     val bits: Int = 1 shl 16,
     /** Number of independent hash functions per insert. */
     val hashes: Int = 7,
+    /** Name of the [LongHasher] seeding the double-hashing scheme; resolved via [Hashers]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<BloomFilterResult>
 
 /** Spec for `CountMinSketchStat`: approximate frequency table for unbounded-cardinality streams. */
@@ -439,6 +446,8 @@ data class CountMinSketch(
     val width: Int = 1024,
     /** PRNG seed used to derive the per-row hash salts. */
     val seed: Long = -7046029254386353133L,
+    /** Name of the [LongHasher] applied per row; resolved via [Hashers]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<CountMinSketchResult>
 
 /** Spec for `MinHashStat`: Jaccard-similarity signature over [numHashes] independent hash functions. */
@@ -449,6 +458,8 @@ data class MinHash(
     val numHashes: Int = 128,
     /** PRNG seed used to derive the per-hash salts. */
     val seed: Long = -3724518991637283867L,
+    /** Name of the [LongHasher] applied per signature slot; resolved via [Hashers]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<MinHashResult>
 
 /** Spec for `SojournStat`: per-state time, transition counts, and current dwell over a declared alphabet. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
@@ -410,7 +410,7 @@ data object Accuracy : PairedStatSpec<WeightedMeanResult>
 data class HyperLogLog(
     /** Number of register-index bits; memory is `2^precision` bytes. */
     val precision: Int = 14,
-    /** Name of the [LongHasher] applied before bucketing; resolved via [Hashers]. */
+    /** [HasherRef] for the mixer applied before bucketing; resolved via the Hashers registry. */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<HyperLogLogResult>
 
@@ -420,7 +420,7 @@ data class HyperLogLog(
 data class LinearCounting(
     /** Bitset size; trade-off between memory and accuracy near the saturation cap. */
     val bits: Int = 4096,
-    /** Name of the [LongHasher] applied before indexing; resolved via [Hashers]. */
+    /** [HasherRef] for the mixer applied before indexing; resolved via the Hashers registry. */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<LinearCountingResult>
 
@@ -432,7 +432,7 @@ data class BloomFilter(
     val bits: Int = 1 shl 16,
     /** Number of independent hash functions per insert. */
     val hashes: Int = 7,
-    /** Name of the [LongHasher] seeding the double-hashing scheme; resolved via [Hashers]. */
+    /** [HasherRef] for the mixer seeding the double-hashing scheme; resolved via the Hashers registry. */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<BloomFilterResult>
 
@@ -446,7 +446,7 @@ data class CountMinSketch(
     val width: Int = 1024,
     /** PRNG seed used to derive the per-row hash salts. */
     val seed: Long = -7046029254386353133L,
-    /** Name of the [LongHasher] applied per row; resolved via [Hashers]. */
+    /** [HasherRef] for the mixer applied per row; resolved via the Hashers registry. */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<CountMinSketchResult>
 
@@ -458,7 +458,7 @@ data class MinHash(
     val numHashes: Int = 128,
     /** PRNG seed used to derive the per-hash salts. */
     val seed: Long = -3724518991637283867L,
-    /** Name of the [LongHasher] applied per signature slot; resolved via [Hashers]. */
+    /** [HasherRef] for the mixer applied per signature slot; resolved via the Hashers registry. */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : DiscreteStatSpec<MinHashResult>
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -3,7 +3,8 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.math.splitmix64
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.casMax
@@ -30,8 +31,8 @@ data class HyperLogLogResult(val estimate: Double, val precision: Int, val regis
  * Allocates `m = 2^precision` byte-sized registers and uses the standard
  * `alpha_m * m^2 / Sum 2^-Mj` estimator, switching to linear counting on small inputs
  * (`rawE <= 2.5*m` with at least one empty register) to eliminate the well-known
- * HLL bias near zero. Inputs are run through SplitMix64 before bucketing so
- * callers can pass raw IDs without worrying about hash quality.
+ * HLL bias near zero. Inputs are run through the [hasher] (default [SplitMix64]) before
+ * bucketing so callers can pass raw IDs without worrying about hash quality.
  *
  * Memory: `m` Longs (registers) plus a counter. Standard error is ~ `1.04/sqrtm`
  * (~ 0.81% at the default `precision = 14`). 64-bit hashing makes the original
@@ -61,6 +62,8 @@ data class HyperLogLogResult(val estimate: Double, val precision: Int, val regis
 class HyperLogLogStat(
     /** Number of register-index bits; memory is `2^precision` bytes. */
     val precision: Int = 14,
+    /** Mixer applied to each input before bucketing; defaults to [SplitMix64]. */
+    val hasher: LongHasher = SplitMix64,
     override val concurrency: Concurrency = Concurrency.None,
 ) : DiscreteStat<HyperLogLogResult> {
 
@@ -82,7 +85,7 @@ class HyperLogLogStat(
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
-        val hash = splitmix64(value)
+        val hash = hasher.mix(value)
         val idx = (hash ushr (64 - precision)).toInt() and (m - 1)
         val w = hash shl precision
         val rho = (w.countLeadingZeroBits().coerceAtMost(64 - precision)) + 1
@@ -130,5 +133,5 @@ class HyperLogLogStat(
         )
     }
 
-    override fun create(concurrency: Concurrency?) = HyperLogLogStat(precision, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) = HyperLogLogStat(precision, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -3,7 +3,8 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.math.splitmix64
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.casOr
@@ -35,7 +36,8 @@ data class LinearCountingResult(
 /**
  * Linear-counting cardinality estimator over a fixed [bits]-bit bitset.
  *
- * For each input, sets one bit indexed by `splitmix64(value) mod bits`. The cardinality
+ * For each input, sets one bit indexed by `hasher.mix(value) mod bits` (the [hasher]
+ * defaults to [SplitMix64]). The cardinality
  * estimate is `-bits * ln(unsetBits / bits)`. Cheap and accurate for cardinalities up to
  * roughly [bits]; degrades sharply (and saturates to infinity) when the bitset fills.
  * Prefer [HyperLogLogStat] when the cardinality range is unknown.
@@ -54,8 +56,12 @@ data class LinearCountingResult(
  * independent atomic ops. Lock-free and exact under every [Concurrency]
  * level; bit sets are idempotent and commutative.
  */
-class LinearCountingStat(val bits: Int = 4096, override val concurrency: Concurrency = Concurrency.None) :
-    DiscreteStat<LinearCountingResult> {
+class LinearCountingStat(
+    val bits: Int = 4096,
+    /** Mixer applied to each input before indexing; defaults to [SplitMix64]. */
+    val hasher: LongHasher = SplitMix64,
+    override val concurrency: Concurrency = Concurrency.None,
+) : DiscreteStat<LinearCountingResult> {
 
     init {
         require(bits > 0) { "bits must be > 0" }
@@ -71,7 +77,7 @@ class LinearCountingStat(val bits: Int = 4096, override val concurrency: Concurr
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
-        val hash = splitmix64(value)
+        val hash = hasher.mix(value)
         val pos = hash and mask
         val wordIdx = (pos ushr 6).toInt()
         val bitMask = 1L shl (pos and 63L).toInt()
@@ -118,5 +124,5 @@ class LinearCountingStat(val bits: Int = 4096, override val concurrency: Concurr
         )
     }
 
-    override fun create(concurrency: Concurrency?) = LinearCountingStat(bits, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) = LinearCountingStat(bits, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -136,5 +136,6 @@ class BloomFilterStat(
         )
     }
 
-    override fun create(concurrency: Concurrency?) = BloomFilterStat(bits, hashes, hasher, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) =
+        BloomFilterStat(bits, hashes, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -3,7 +3,10 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.math.splitmix64
+import com.eignex.kumulant.math.HasherRef
+import com.eignex.kumulant.math.Hashers
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.casOr
@@ -26,13 +29,20 @@ data class BloomFilterResult(
     val words: LongArray,
     /** Number of `update(value)` calls absorbed; informational. */
     val totalSeen: Long,
+    /** Reference to the [LongHasher] that produced the bitset; resolved by [contains]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : Result
 
-/** True iff every bit set during an `update(value)` is still set in `words`. */
+/**
+ * True iff every bit set during an `update(value)` is still set in `words`. Re-derives the
+ * bit positions with the same [LongHasher] the filter used (resolved by name via [Hashers]),
+ * so a custom hasher must be registered before querying.
+ */
 fun BloomFilterResult.contains(value: Long): Boolean {
     val mask = (bits - 1).toLong()
-    val h1 = splitmix64(value)
-    val h2 = splitmix64(h1)
+    val mixer = Hashers.resolve(hasher)
+    val h1 = mixer.mix(value)
+    val h2 = mixer.mix(h1)
     for (i in 0 until hashes) {
         val pos = (h1 + i.toLong() * h2) and mask
         val wordIdx = (pos ushr 6).toInt()
@@ -44,8 +54,8 @@ fun BloomFilterResult.contains(value: Long): Boolean {
 
 /**
  * Bloom filter - probabilistic set-membership test with no false negatives. [bits] bits
- * are split across [hashes] positions per insert, derived from `splitmix64` via the
- * Kirsch-Mitzenmacher double-hashing scheme.
+ * are split across [hashes] positions per insert, derived from the [hasher] (default
+ * [SplitMix64]) via the Kirsch-Mitzenmacher double-hashing scheme.
  *
  * False-positive rate is approximately `(1 - e^(-hashes * n / bits))^hashes` where `n` is
  * the number of distinct inserts. Memory is `bits / 64` Longs; mergeable element-wise via
@@ -67,6 +77,8 @@ fun BloomFilterResult.contains(value: Long): Boolean {
 class BloomFilterStat(
     val bits: Int = 1 shl 16,
     val hashes: Int = 7,
+    /** Mixer seeding the double-hashing scheme; defaults to [SplitMix64]. */
+    val hasher: LongHasher = SplitMix64,
     override val concurrency: Concurrency = Concurrency.None,
 ) : DiscreteStat<BloomFilterResult> {
 
@@ -85,8 +97,8 @@ class BloomFilterStat(
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
-        val h1 = splitmix64(value)
-        val h2 = splitmix64(h1)
+        val h1 = hasher.mix(value)
+        val h2 = hasher.mix(h1)
         for (i in 0 until hashes) {
             val pos = (h1 + i.toLong() * h2) and mask
             val wordIdx = (pos ushr 6).toInt()
@@ -120,8 +132,9 @@ class BloomFilterStat(
             hashes = hashes,
             words = snapshot,
             totalSeen = totalSeen.load(),
+            hasher = HasherRef(hasher.name),
         )
     }
 
-    override fun create(concurrency: Concurrency?) = BloomFilterStat(bits, hashes, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) = BloomFilterStat(bits, hashes, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -3,6 +3,10 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.math.HasherRef
+import com.eignex.kumulant.math.Hashers
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.math.splitmix64
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
@@ -25,16 +29,23 @@ data class CountMinSketchResult(
     val seed: Long,
     val counters: LongArray,
     val totalSeen: Long,
+    /** Reference to the [LongHasher] that produced the counters; resolved by [estimate]. */
+    val hasher: HasherRef = HasherRef.SplitMix64,
 ) : Result
 
-/** Estimated weighted count of [value] - the minimum across rows. */
+/**
+ * Estimated weighted count of [value] - the minimum across rows. Re-derives the per-row
+ * index with the same [LongHasher] the sketch used (resolved by name via [Hashers]), so a
+ * custom hasher must be registered before querying.
+ */
 fun CountMinSketchResult.estimate(value: Long): Long {
     if (counters.isEmpty()) return 0L
     val mask = (width - 1).toLong()
+    val mixer = Hashers.resolve(hasher)
     var min = Long.MAX_VALUE
     for (row in 0 until depth) {
         val salt = splitmix64(seed + row.toLong())
-        val idx = (splitmix64(value xor salt) and mask).toInt()
+        val idx = (mixer.mix(value xor salt) and mask).toInt()
         val c = counters[row * width + idx]
         if (c < min) min = c
     }
@@ -44,8 +55,8 @@ fun CountMinSketchResult.estimate(value: Long): Long {
 /**
  * CountStat-MinStat sketch - a probabilistic frequency estimator over a [depth] x [width] matrix
  * of counters. Each update hashes the value with [depth] independent salts (derived from
- * [seed]) and increments one counter per row; the estimated count for any value is the
- * minimum counter across rows.
+ * [seed]) through the [hasher] (default [SplitMix64]) and increments one counter per row;
+ * the estimated count for any value is the minimum counter across rows.
  *
  * Estimates are one-sided overestimates: `estimate(x) >= true count(x)` always, with the
  * overestimate bounded by `2 * totalSeen / width` with high probability over the salt
@@ -69,6 +80,8 @@ class CountMinSketchStat(
     val depth: Int = 5,
     val width: Int = 1024,
     val seed: Long = -7046029254386353133L, // 0x9e3779b97f4a7c15
+    /** Mixer applied to each `value xor rowSalt`; defaults to [SplitMix64]. */
+    val hasher: LongHasher = SplitMix64,
     override val concurrency: Concurrency = Concurrency.None,
 ) : DiscreteStat<CountMinSketchResult> {
 
@@ -90,7 +103,7 @@ class CountMinSketchStat(
         val w = round(weight).toLong()
         if (w <= 0L) return
         for (row in 0 until depth) {
-            val idx = (splitmix64(value xor rowSalts[row]) and mask).toInt()
+            val idx = (hasher.mix(value xor rowSalts[row]) and mask).toInt()
             counters.add(row * width + idx, w)
         }
         totalSeen.add(1L)
@@ -122,6 +135,7 @@ class CountMinSketchStat(
             seed = seed,
             counters = snapshot,
             totalSeen = totalSeen.load(),
+            hasher = HasherRef(hasher.name),
         )
     }
 
@@ -129,6 +143,7 @@ class CountMinSketchStat(
         depth,
         width,
         seed,
+        hasher,
         concurrency ?: this.concurrency,
     )
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -3,6 +3,8 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.math.splitmix64
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
@@ -79,6 +81,8 @@ class MinHashStat(
     val numHashes: Int = 128,
     /** PRNG seed used to derive the per-hash salts; must match across instances to compare. */
     val seed: Long = -3724518991637283867L, // 0xcafef00dd15ea5e5
+    /** Mixer applied to each `value xor salt`; defaults to [SplitMix64]. */
+    val hasher: LongHasher = SplitMix64,
     override val concurrency: Concurrency = Concurrency.None,
 ) : DiscreteStat<MinHashResult> {
 
@@ -94,7 +98,7 @@ class MinHashStat(
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
         for (i in 0 until numHashes) {
-            casMin(signatures, i, splitmix64(value xor salts[i]))
+            casMin(signatures, i, hasher.mix(value xor salts[i]))
         }
         totalSeen.add(1L)
     }
@@ -126,5 +130,5 @@ class MinHashStat(
         )
     }
 
-    override fun create(concurrency: Concurrency?) = MinHashStat(numHashes, seed, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) = MinHashStat(numHashes, seed, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -130,5 +130,6 @@ class MinHashStat(
         )
     }
 
-    override fun create(concurrency: Concurrency?) = MinHashStat(numHashes, seed, hasher, concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) =
+        MinHashStat(numHashes, seed, hasher, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/HasherConfigTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/HasherConfigTest.kt
@@ -1,0 +1,76 @@
+package com.eignex.kumulant.schema
+
+import com.eignex.kumulant.math.HasherRef
+import com.eignex.kumulant.math.Hashers
+import com.eignex.kumulant.math.LongHasher
+import com.eignex.kumulant.math.splitmix64
+import com.eignex.kumulant.stat.sketch.contains
+import com.eignex.kumulant.stat.sketch.estimate
+import com.eignex.skema.SchemaJson
+import kotlinx.serialization.encodeToString
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The discrete sketch specs carry a [LongHasher] by name; a custom mixer is supplied through
+ * the [Hashers] registry and referenced by that name on the wire. These tests cover the full
+ * path: register, serialize, materialize, and re-query via the result-side helpers.
+ */
+class HasherConfigTest {
+
+    private object SaltedSplitMix : LongHasher {
+        override val name: String = "test-salted-splitmix"
+        override fun mix(value: Long): Long = splitmix64(value xor 0x1234_5678_9ABC_DEF0L)
+    }
+
+    @BeforeTest
+    fun registerCustomHasher() {
+        Hashers.register(SaltedSplitMix)
+    }
+
+    @Test
+    fun `specs default to the splitmix64 hasher`() {
+        assertEquals(HasherRef.SplitMix64, HyperLogLog().hasher)
+        assertEquals(HasherRef.SplitMix64, BloomFilter().hasher)
+        assertEquals(HasherRef.SplitMix64, CountMinSketch().hasher)
+    }
+
+    @Test
+    fun `custom hasher name survives the wire as a plain string`() {
+        val spec = CountMinSketch(depth = 5, width = 1024, hasher = HasherRef(SaltedSplitMix.name))
+        val json = SchemaJson.encodeToString<StatSpec>(spec)
+        assertTrue(json.contains(SaltedSplitMix.name), "expected hasher name in $json")
+        assertEquals(spec, SchemaJson.decodeFromString<StatSpec>(json))
+    }
+
+    @Test
+    fun `CountMinSketch materializes with the custom hasher and the result re-resolves it`() {
+        val cms = CountMinSketch(depth = 5, width = 1024, hasher = HasherRef(SaltedSplitMix.name)).materialize()
+        cms.update(42L)
+        val result = cms.read()
+        assertEquals(HasherRef(SaltedSplitMix.name), result.hasher)
+        // estimate() resolves the recorded hasher, so it lands on the same counters as the update.
+        assertEquals(1L, result.estimate(42L))
+    }
+
+    @Test
+    fun `BloomFilter materializes with the custom hasher and contains re-resolves it`() {
+        val bf = BloomFilter(bits = 4096, hashes = 4, hasher = HasherRef(SaltedSplitMix.name)).materialize()
+        bf.update(7L)
+        val result = bf.read()
+        assertEquals(HasherRef(SaltedSplitMix.name), result.hasher)
+        assertTrue(result.contains(7L))
+        assertFalse(result.contains(123_456_789L))
+    }
+
+    @Test
+    fun `unknown hasher name fails fast at materialization`() {
+        assertFailsWith<IllegalStateException> {
+            HyperLogLog(precision = 10, hasher = HasherRef("no-such-hasher")).materialize()
+        }
+    }
+}


### PR DESCRIPTION
The five discrete sketches (HyperLogLog, LinearCounting, MinHash, BloomFilter, CountMinSketch) hardcoded splitmix64 as their internal mixer. This lifts that into a LongHasher seam the stats take as a parameter, defaulting to SplitMix64 so behavior is unchanged.

The schema specs and the two result classes that re-hash on query carry the mixer as a HasherRef, a serializable inline value class that round-trips as a plain string, so there is no custom serializer module. Custom mixers are supplied through a Hashers registry and referenced by name on the wire, which is the only way an opaque function can survive serialization. StatFactory resolves the name at materialization and fails fast on an unregistered one.

Salt derivation in MinHash and CountMinSketch stays on splitmix64; only the per-value mix is routed through the configured hasher. HasherConfigTest covers the default, the wire round-trip, materialization with a registered custom mixer including result-side re-resolution via contains and estimate, and the unknown-name failure. Full JVM suite passes.