### PR TITLE
feat: generic Split<Row> tree engine + public per-node aggregate

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/Stats.kt
@@ -39,7 +39,7 @@ import com.eignex.kumulant.stat.regression.tree.ClassificationTreeConfig
 import com.eignex.kumulant.stat.regression.tree.ForestClassificationResult
 import com.eignex.kumulant.stat.regression.tree.ForestRegressionResult
 import com.eignex.kumulant.stat.regression.tree.RegressionTreeConfig
-import com.eignex.kumulant.stat.regression.tree.Split
+import com.eignex.kumulant.stat.regression.tree.SerializableSplit
 import com.eignex.kumulant.stat.regression.tree.TreeClassificationResult
 import com.eignex.kumulant.stat.regression.tree.TreeRegressionResult
 import com.eignex.kumulant.stat.score.AucResult
@@ -555,7 +555,7 @@ data class DecisionTreeRegression(
     /** Number of input features. */
     val featureSize: Int,
     /** Candidate splits considered at every audit leaf. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** RegressionTree growth tunables. */
     val config: RegressionTreeConfig = RegressionTreeConfig(),
     /** PRNG seed for per-leaf candidate subsampling and bagging. */
@@ -569,7 +569,7 @@ data class RandomForestRegression(
     /** Number of input features. */
     val featureSize: Int,
     /** Candidate split pool. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Trees in the forest. */
     val nbrTrees: Int = 10,
     /** RegressionTree growth tunables (mtry defaults to `ceil(sqrt(p))` when null). */
@@ -589,7 +589,7 @@ data class DecisionTreeClassifier(
     /** Number of classes; `y` must round to `[0, numClasses)`. */
     val numClasses: Int,
     /** Candidate splits considered at every audit leaf. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** RegressionTree growth tunables. */
     val config: ClassificationTreeConfig = ClassificationTreeConfig(),
     /** PRNG seed. */
@@ -605,7 +605,7 @@ data class RandomForestClassifier(
     /** Number of classes. */
     val numClasses: Int,
     /** Candidate split pool. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Trees in the forest. */
     val nbrTrees: Int = 10,
     /** RegressionTree growth tunables (mtry defaults to `ceil(sqrt(p))` when null). */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -27,7 +27,7 @@ import kotlin.random.Random
  */
 class ClassificationTree(
     private val numClasses: Int,
-    private val splitCandidates: List<Split>,
+    private val splitCandidates: List<SerializableSplit>,
     private val config: ClassificationTreeConfig = ClassificationTreeConfig(),
     private val concurrency: Concurrency = Concurrency.None,
     private val leafArmFactory: () -> SeriesStat<ClassCountsResult> = { ClassCountsStat(numClasses, concurrency) },
@@ -208,7 +208,7 @@ class ClassificationTree(
         )
     }
 
-    private fun pickCandidates(): List<Split> {
+    private fun pickCandidates(): List<SerializableSplit> {
         val k = config.mtry ?: return splitCandidates
         if (k >= splitCandidates.size) return splitCandidates
         return splitCandidates.shuffled(random).take(k)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
@@ -21,7 +21,7 @@ sealed interface ClassificationNode {
  *  aggregates produced by mixed-structure merges or pre-split snapshots. */
 class ClassificationSplitNode(
     /** Predicate routing observations into [pos] (true) or [neg] (false). */
-    val split: Split,
+    val split: SerializableSplit,
     pos: ClassificationNode,
     neg: ClassificationNode,
     carryover: SeriesStat<ClassCountsResult>? = null,
@@ -53,7 +53,7 @@ class ClassificationTerminalLeaf(override val arm: SeriesStat<ClassCountsResult>
 class ClassificationAuditLeaf(
     override val arm: SeriesStat<ClassCountsResult>,
     /** Candidate splits being evaluated at this leaf. */
-    val candidates: List<Split>,
+    val candidates: List<SerializableSplit>,
     /** Per-candidate accumulator for observations routing true. */
     val pos: List<SeriesStat<ClassCountsResult>>,
     /** Per-candidate accumulator for observations routing false. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -20,7 +20,7 @@ class DecisionTreeClassifierStat(
     /** Number of classes; the input `y` must round to `[0, numClasses)`. */
     val numClasses: Int,
     /** Candidate splits considered at every audit leaf. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Tunables shared with the underlying [ClassificationTree]. */
     val config: ClassificationTreeConfig = ClassificationTreeConfig(),
     override val concurrency: Concurrency = Concurrency.None,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -50,7 +50,7 @@ class DecisionTreeRegressionStat(
     override val featureSize: Int,
     /** Candidate splits considered at every audit leaf. Pass an empty list to disable
      *  growth; the regressor then degenerates to a single global accumulator. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Tunables shared with the underlying [RegressionTree]. */
     val config: RegressionTreeConfig = RegressionTreeConfig(),
     override val concurrency: Concurrency = Concurrency.None,
@@ -64,9 +64,9 @@ class DecisionTreeRegressionStat(
     }
 
     private val seedRng = Random(randomSeed)
-    private var tree: RegressionTree = newTree()
+    private var tree: RegressionTree<VectorView> = newTree()
 
-    private fun newTree(): RegressionTree = RegressionTree(
+    private fun newTree(): RegressionTree<VectorView> = RegressionTree(
         splitCandidates,
         config,
         concurrency,
@@ -99,5 +99,5 @@ class DecisionTreeRegressionStat(
     )
 
     /** Live underlying tree. Use for inspection / pretty-printing. */
-    fun tree(): RegressionTree = tree
+    fun tree(): RegressionTree<VectorView> = tree
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -23,7 +23,7 @@ class RandomForestClassifierStat(
     /** Number of classes; `y` must round to `[0, numClasses)`. */
     val numClasses: Int,
     /** Candidate split pool. Used by every tree; the per-leaf mtry filter draws from here. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Trees in the forest. */
     val nbrTrees: Int = 10,
     config: ClassificationTreeConfig = ClassificationTreeConfig(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -45,7 +45,7 @@ import kotlin.random.Random
 class RandomForestRegressionStat(
     override val featureSize: Int,
     /** Candidate split pool. Used by every tree; the per-leaf mtry filter draws from here. */
-    val splitCandidates: List<Split>,
+    val splitCandidates: List<SerializableSplit>,
     /** Trees in the forest. */
     val nbrTrees: Int = 10,
     config: RegressionTreeConfig = RegressionTreeConfig(),
@@ -66,9 +66,9 @@ class RandomForestRegressionStat(
 
     private val seedRng = Random(randomSeed)
     private val baggingRng = Random(seedRng.nextInt())
-    private var trees: Array<RegressionTree> = Array(nbrTrees) { newTree() }
+    private var trees: Array<RegressionTree<VectorView>> = Array(nbrTrees) { newTree() }
 
-    private fun newTree(): RegressionTree = RegressionTree(
+    private fun newTree(): RegressionTree<VectorView> = RegressionTree(
         splitCandidates,
         this.config,
         concurrency,
@@ -114,7 +114,7 @@ class RandomForestRegressionStat(
     )
 
     /** Live underlying trees. Use for inspection. */
-    fun trees(): List<RegressionTree> = trees.toList()
+    fun trees(): List<RegressionTree<VectorView>> = trees.toList()
 
     private fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble())).toInt().coerceAtLeast(1)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -4,7 +4,6 @@ package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.math.VectorView
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import com.eignex.kumulant.stream.Mutex
@@ -19,16 +18,23 @@ import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
- * Online VFDT-style decision tree partitioning context vectors. Each leaf carries a
- * weighted-variance accumulator; audit leaves additionally track pos/neg sub-arms per
- * candidate split and, every [RegressionTreeConfig.splitPeriod] observations, evaluate them against
- * the Hoeffding bound to decide whether to convert themselves into a [RegressionSplitNode].
+ * Online VFDT-style decision tree partitioning feature rows of type [Row]. Each leaf
+ * carries a weighted-variance accumulator; audit leaves additionally track pos/neg
+ * sub-arms per candidate split and, every [RegressionTreeConfig.splitPeriod] observations,
+ * evaluate them against the Hoeffding bound to decide whether to convert themselves into
+ * a [RegressionSplitNode].
+ *
+ * The engine is **generic over the feature representation**: it only ever inspects a row
+ * by calling [Split.direction], so any feature type can drive growth by supplying its own
+ * [Split]s (e.g. a dense [com.eignex.kumulant.math.VectorView] for the built-in stats, or
+ * a typed/constraint-coupled row from a downstream library). Wire-portable serialization
+ * of a snapshot is only meaningful for the [com.eignex.kumulant.math.VectorView] case and
+ * lives in `TreeRegressionResult.kt` as `VectorView`-constrained extensions.
  *
  * Internal split nodes hold no live arm; subtree aggregates (`rootSnapshot`, the `value`
- * fields on [TreeSplitResult]) are derived by combining descendants at snapshot/merge
+ * fields on the snapshot results) are derived by combining descendants at snapshot/merge
  * time. The hot update path therefore touches exactly one arm: the leaf the observation
- * routes to. Under [Concurrency.Strict] this removes the root-arm serialization point
- * that previously bottlenecked multi-threaded throughput.
+ * routes to.
  *
  * Concurrency: leaf-arm updates run lock-free (the arms themselves honour [concurrency]).
  * The split-conversion path; the only one that mutates tree structure; is serialised
@@ -36,36 +42,36 @@ import kotlin.random.Random
  * audit leaf. Pointer writes on the hot path are skipped when the child reference is
  * unchanged, so the typical update is pure arm arithmetic.
  */
-class RegressionTree(
-    private val splitCandidates: List<Split>,
+class RegressionTree<Row>(
+    private val splitCandidates: List<Split<Row>>,
     private val config: RegressionTreeConfig = RegressionTreeConfig(),
     private val concurrency: Concurrency = Concurrency.None,
-    private val leafArmFactory: () -> SeriesStat<WeightedVarianceResult> = { VarianceStat(concurrency) },
+    internal val leafArmFactory: () -> SeriesStat<WeightedVarianceResult> = { VarianceStat(concurrency) },
     randomSeed: Int = 0,
 ) {
     private val random = Random(randomSeed)
     private val canGrow: Boolean = splitCandidates.isNotEmpty()
-    private val splitLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
+    internal val splitLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
 
-    private val nbrNodes: AtomicInt = AtomicInt(1)
+    internal val nbrNodes: AtomicInt = AtomicInt(1)
 
     @Volatile
-    private var root: RegressionNode = newLeaf(depth = 0)
+    internal var root: RegressionNode<Row> = newLeaf(depth = 0)
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: VectorView): RegressionLeafNode = root.findLeaf(row)
+    fun findLeaf(row: Row): RegressionLeafNode<Row> = root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
-    fun rootNode(): RegressionNode = root
+    fun rootNode(): RegressionNode<Row> = root
 
     /** Mean of the leaf [row] resolves to. */
-    fun predict(row: VectorView): Double = findLeaf(row).arm.read(0L).mean
+    fun predict(row: Row): Double = findLeaf(row).arm.read(0L).mean
 
     /** Number of internal + leaf nodes currently in the tree. */
     val nodeCount: Int get() = nbrNodes.load()
 
     /** Fold an observation into the tree, possibly growing it. */
-    fun update(row: VectorView, value: Double, weight: Double = 1.0) {
+    fun update(row: Row, value: Double, weight: Double = 1.0) {
         val current = root
         val next = updateNode(current, row, value, weight, depth = 0)
         if (next !== current) root = next
@@ -106,24 +112,14 @@ class RegressionTree(
      * un-routable observations into a single bucket; an honest fallback when the
      * structures don't align.
      */
-    fun merge(other: RegressionTree) {
+    fun merge(other: RegressionTree<Row>) {
         splitLock.withLock {
             root = mergeNodes(root, other.root)
             nbrNodes.store(countNodes(root))
         }
     }
 
-    /** Snapshot merge using only the immutable result. Falls through to the same rules
-     *  as [merge] but the "other" side is a [TreeNodeResult] tree-of-results rather than
-     *  a live RegressionTree. */
-    fun mergeSnapshot(other: TreeNodeResult) {
-        splitLock.withLock {
-            root = mergeNodeWithResult(root, other)
-            nbrNodes.store(countNodes(root))
-        }
-    }
-
-    private fun mergeNodes(a: RegressionNode, b: RegressionNode): RegressionNode {
+    private fun mergeNodes(a: RegressionNode<Row>, b: RegressionNode<Row>): RegressionNode<Row> {
         if (a is RegressionSplitNode && b is RegressionSplitNode && a.split == b.split) {
             a.pos = mergeNodes(a.pos, b.pos)
             a.neg = mergeNodes(a.neg, b.neg)
@@ -144,33 +140,7 @@ class RegressionTree(
         return a
     }
 
-    private fun mergeNodeWithResult(a: RegressionNode, b: TreeNodeResult): RegressionNode {
-        if (a is RegressionSplitNode && b is TreeSplitResult && a.split == b.split) {
-            a.pos = mergeNodeWithResult(a.pos, b.pos)
-            a.neg = mergeNodeWithResult(a.neg, b.neg)
-            // b.value carries the full subtree aggregate; the child recursion already
-            // folded the structurally-aligned portion. Pull only the residual; what b's
-            // value holds beyond the sum of its children; into a's carryover.
-            val childSum = mergeWVR(b.pos.value, b.neg.value)
-            val residual = subtractWVR(b.value, childSum)
-            if (residual.totalWeights > 0.0) foldIntoCarryover(a, residual)
-            return a
-        }
-        if (a is RegressionLeafNode && b is TreeLeafResult) {
-            a.arm.merge(b.value)
-            return a
-        }
-        if (a is RegressionLeafNode && b is TreeSplitResult) {
-            val cloned = cloneFromResult(b, depth = 0) as RegressionSplitNode
-            foldIntoCarryover(cloned, a.arm.read(0L))
-            return cloned
-        }
-        // a split + b leaf, or splits differ: keep a's structure, fold b's aggregate.
-        foldIntoCarryover(a as RegressionSplitNode, b.value)
-        return a
-    }
-
-    private fun foldIntoCarryover(node: RegressionSplitNode, value: WeightedVarianceResult) {
+    internal fun foldIntoCarryover(node: RegressionSplitNode<Row>, value: WeightedVarianceResult) {
         if (value.totalWeights <= 0.0) return
         val existing = node.carryover
         if (existing != null) {
@@ -182,38 +152,12 @@ class RegressionTree(
         }
     }
 
-    private fun cloneFromResult(node: TreeNodeResult, depth: Int): RegressionNode {
-        nbrNodes.addAndFetch(1)
-        return when (node) {
-            is TreeLeafResult -> {
-                val arm = leafArmFactory()
-                arm.merge(node.value)
-                RegressionTerminalLeaf(arm)
-            }
-
-            is TreeSplitResult -> {
-                val pos = cloneFromResult(node.pos, depth + 1)
-                val neg = cloneFromResult(node.neg, depth + 1)
-                // Re-establish any orphan aggregate the snapshot encodes by comparing the
-                // recorded value against the sum of the cloned children's aggregates.
-                val childSum = mergeWVR(node.pos.value, node.neg.value)
-                val residual = subtractWVR(node.value, childSum)
-                val carry = if (residual.totalWeights > 0.0) {
-                    leafArmFactory().also { it.merge(residual) }
-                } else {
-                    null
-                }
-                RegressionSplitNode(split = node.split, pos = pos, neg = neg, carryover = carry)
-            }
-        }
-    }
-
-    private fun countNodes(node: RegressionNode): Int = when (node) {
+    internal fun countNodes(node: RegressionNode<Row>): Int = when (node) {
         is RegressionSplitNode -> 1 + countNodes(node.pos) + countNodes(node.neg)
         is RegressionLeafNode -> 1
     }
 
-    private fun prettyPrintTo(sb: StringBuilder, node: RegressionNode, indent: String) {
+    private fun prettyPrintTo(sb: StringBuilder, node: RegressionNode<Row>, indent: String) {
         when (node) {
             is RegressionSplitNode -> {
                 sb.append(indent).append("if (").append(node.split.toString()).append(") {\n")
@@ -230,7 +174,7 @@ class RegressionTree(
         }
     }
 
-    private fun newLeaf(depth: Int): RegressionLeafNode {
+    private fun newLeaf(depth: Int): RegressionLeafNode<Row> {
         if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
             return RegressionTerminalLeaf(leafArmFactory())
         }
@@ -243,19 +187,19 @@ class RegressionTree(
         )
     }
 
-    private fun pickCandidates(): List<Split> {
+    private fun pickCandidates(): List<Split<Row>> {
         val k = config.mtry ?: return splitCandidates
         if (k >= splitCandidates.size) return splitCandidates
         return splitCandidates.shuffled(random).take(k)
     }
 
     private fun updateNode(
-        node: RegressionNode,
-        row: VectorView,
+        node: RegressionNode<Row>,
+        row: Row,
         value: Double,
         weight: Double,
         depth: Int,
-    ): RegressionNode = when (node) {
+    ): RegressionNode<Row> = when (node) {
         is RegressionSplitNode -> {
             if (node.split.direction(row)) {
                 val child = node.pos
@@ -278,12 +222,12 @@ class RegressionTree(
     }
 
     private fun updateAuditLeaf(
-        leaf: RegressionAuditLeaf,
-        row: VectorView,
+        leaf: RegressionAuditLeaf<Row>,
+        row: Row,
         value: Double,
         weight: Double,
         depth: Int,
-    ): RegressionNode {
+    ): RegressionNode<Row> {
         leaf.arm.update(value, 0L, weight)
         for ((i, split) in leaf.candidates.withIndex()) {
             if (split.direction(row)) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeNodes.kt
@@ -120,6 +120,16 @@ internal fun mergeWVR(a: WeightedVarianceResult, b: WeightedVarianceResult): Wei
     return WeightedVarianceResult(w, mean, sst / w)
 }
 
+/**
+ * Public per-node subtree aggregate over all observations routed through this node
+ * (leaves: the arm snapshot; splits: the exact Chan-merge of both children plus any
+ * [RegressionSplitNode.carryover]). Lets callers score *internal* nodes — e.g. a
+ * Thompson walk-down that picks a branch by its subtree's posterior — without the tree
+ * having to keep a live arm on every split node. Equivalent to a directly-accumulated
+ * internal arm: Chan's parallel merge is exact for weighted-variance aggregates.
+ */
+fun RegressionNode<*>.aggregate(): WeightedVarianceResult = subtreeAggregate()
+
 /** Recursive subtree aggregate; for leaves the arm's snapshot, for splits the merge of
  *  both children's aggregates plus any [RegressionSplitNode.carryover]. Called only on snapshot
  *  and merge paths, never on hot updates. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeNodes.kt
@@ -3,23 +3,22 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.math.VectorView
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
- * Internal tree node. The hot update path touches only the leaf an observation routes
- * to; internal split nodes are never written by [RegressionTree.update]. Splits may carry an
- * optional *carryover* arm: a one-shot snapshot of the pre-split aggregate captured at
- * the moment a leaf converts into a split, plus any orphaned aggregates folded in by
- * mixed-structure merges. Subtree aggregates include the carryover but the hot path
- * never reads or writes it.
+ * Internal tree node, generic over the feature [Row] the tree routes. The hot update path
+ * touches only the leaf an observation routes to; internal split nodes are never written
+ * by [RegressionTree.update]. Splits may carry an optional *carryover* arm: a one-shot
+ * snapshot of the pre-split aggregate captured at the moment a leaf converts into a split,
+ * plus any orphaned aggregates folded in by mixed-structure merges. Subtree aggregates
+ * include the carryover but the hot path never reads or writes it.
  */
-sealed interface RegressionNode {
+sealed interface RegressionNode<Row> {
     /** Walk to the leaf this row resolves to. */
-    fun findLeaf(row: VectorView): RegressionLeafNode
+    fun findLeaf(row: Row): RegressionLeafNode<Row>
 }
 
 /**
@@ -28,18 +27,18 @@ sealed interface RegressionNode {
  * frozen at split time, or orphans absorbed from a mixed merge. Never written by the
  * update hot path; never read by [findLeaf] or `predict`; included by `subtreeAggregate`.
  */
-class RegressionSplitNode(
+class RegressionSplitNode<Row>(
     /** Predicate routing observations into [pos] (true) or [neg] (false). */
-    val split: Split,
-    pos: RegressionNode,
-    neg: RegressionNode,
+    val split: Split<Row>,
+    pos: RegressionNode<Row>,
+    neg: RegressionNode<Row>,
     carryover: SeriesStat<WeightedVarianceResult>? = null,
-) : RegressionNode {
+) : RegressionNode<Row> {
     @Volatile
-    var pos: RegressionNode = pos
+    var pos: RegressionNode<Row> = pos
 
     @Volatile
-    var neg: RegressionNode = neg
+    var neg: RegressionNode<Row> = neg
 
     /** One-shot carry-over aggregate, or null if the split holds no orphan data.
      *  Mutated only under the owning [RegressionTree]'s split lock during merges; volatile so
@@ -47,36 +46,36 @@ class RegressionSplitNode(
     @Volatile
     var carryover: SeriesStat<WeightedVarianceResult>? = carryover
 
-    override fun findLeaf(row: VectorView): RegressionLeafNode =
+    override fun findLeaf(row: Row): RegressionLeafNode<Row> =
         if (split.direction(row)) pos.findLeaf(row) else neg.findLeaf(row)
 }
 
 /** Leaf node; terminus of the tree walk for a given row, and the only node type
  *  that owns a live accumulator. */
-sealed class RegressionLeafNode : RegressionNode {
+sealed class RegressionLeafNode<Row> : RegressionNode<Row> {
     /** The leaf's weighted-variance accumulator. */
     abstract val arm: SeriesStat<WeightedVarianceResult>
 
-    final override fun findLeaf(row: VectorView): RegressionLeafNode = this
+    final override fun findLeaf(row: Row): RegressionLeafNode<Row> = this
 }
 
 /** Frozen leaf; no further splits will be considered. */
-class RegressionTerminalLeaf(override val arm: SeriesStat<WeightedVarianceResult>) : RegressionLeafNode()
+class RegressionTerminalLeaf<Row>(override val arm: SeriesStat<WeightedVarianceResult>) : RegressionLeafNode<Row>()
 
 /**
  * Leaf that tracks per-candidate pos/neg stats. When a candidate clears the Hoeffding-
  * bound test, this leaf is replaced by a [RegressionSplitNode]. The candidate subset is per-leaf
  *; picked at leaf birth; so mtry-style random subspace selection lives at the leaf level.
  */
-class RegressionAuditLeaf(
+class RegressionAuditLeaf<Row>(
     override val arm: SeriesStat<WeightedVarianceResult>,
     /** Candidate splits being evaluated at this leaf. */
-    val candidates: List<Split>,
+    val candidates: List<Split<Row>>,
     /** Per-candidate accumulator for observations that route true. */
     val pos: List<SeriesStat<WeightedVarianceResult>>,
     /** Per-candidate accumulator for observations that route false. */
     val neg: List<SeriesStat<WeightedVarianceResult>>,
-) : RegressionLeafNode() {
+) : RegressionLeafNode<Row>() {
     init {
         require(candidates.size == pos.size && pos.size == neg.size) {
             "candidates/pos/neg must align: ${candidates.size}/${pos.size}/${neg.size}"
@@ -124,7 +123,7 @@ internal fun mergeWVR(a: WeightedVarianceResult, b: WeightedVarianceResult): Wei
 /** Recursive subtree aggregate; for leaves the arm's snapshot, for splits the merge of
  *  both children's aggregates plus any [RegressionSplitNode.carryover]. Called only on snapshot
  *  and merge paths, never on hot updates. */
-internal fun RegressionNode.subtreeAggregate(): WeightedVarianceResult = when (this) {
+internal fun RegressionNode<*>.subtreeAggregate(): WeightedVarianceResult = when (this) {
     is RegressionLeafNode -> arm.read(0L)
 
     is RegressionSplitNode -> {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
@@ -6,19 +6,29 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Binary predicate routing a context vector to "pos" (true) or "neg" (false).
+ * Growth-time routing predicate over a feature [Row]. The tree engine
+ * ([RegressionTree]) only ever calls [direction] to route an observation to a child, so
+ * any feature representation can drive growth by supplying its own [Split]s — for example
+ * a downstream library's typed, constraint-coupled splits over a non-vector row.
  *
- * Built-in implementations: [ThresholdSplit] (numeric `x[i] <= t`) and [ExprSplit]
- * (wrapping a wire-portable [BoolExpr] over the context vector). The interface is
- * sealed so tree snapshots round-trip cleanly through `kotlinx.serialization`;
- * callers needing custom predicates compose them as [BoolExpr] AST nodes and wrap
- * them in [ExprSplit].
+ * The interface is intentionally **open and non-serializable**: it is the in-memory SPI
+ * for growing trees over arbitrary features. Wire-portable splits over a dense
+ * [VectorView] context live under the [SerializableSplit] hierarchy, which the
+ * serializable tree snapshots ([TreeNodeResult]) embed.
+ */
+interface Split<in Row> {
+    /** Evaluate the predicate against the context [row]; true routes "pos", false "neg". */
+    fun direction(row: Row): Boolean
+}
+
+/**
+ * Wire-portable [Split] over a dense [VectorView] context. Sealed + serializable so tree
+ * snapshots round-trip cleanly through `kotlinx.serialization`. Built-in implementations:
+ * [ThresholdSplit] (numeric `x[i] <= t`) and [ExprSplit] (wrapping a [BoolExpr]); callers
+ * needing custom predicates compose them as [BoolExpr] AST nodes and wrap in [ExprSplit].
  */
 @Serializable
-sealed interface Split {
-    /** Evaluate the predicate against the context [row]. */
-    fun direction(row: VectorView): Boolean
-}
+sealed interface SerializableSplit : Split<VectorView>
 
 /** Route by `row[featureIndex] <= threshold`. Threshold is inclusive on the "pos" side. */
 @Serializable
@@ -28,7 +38,7 @@ data class ThresholdSplit(
     val featureIndex: Int,
     /** Inclusive threshold separating pos (<=) from neg (>). */
     val threshold: Double,
-) : Split {
+) : SerializableSplit {
     override fun direction(row: VectorView): Boolean = row[featureIndex] <= threshold
     override fun toString(): String = "x[$featureIndex] <= $threshold"
 }
@@ -44,7 +54,7 @@ data class ThresholdSplit(
 data class ExprSplit(
     /** Predicate expression over the context vector. */
     val expr: BoolExpr,
-) : Split {
+) : SerializableSplit {
     override fun direction(row: VectorView): Boolean {
         val arr = row.toDoubleArray()
         val x = if (arr.isNotEmpty()) arr[0] else 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
@@ -43,7 +43,7 @@ sealed interface TreeClassificationNodeResult {
 @SerialName("TreeClassificationSplitResult")
 data class TreeClassificationSplitResult(
     /** Routing predicate. */
-    val split: Split,
+    val split: SerializableSplit,
     /** Subtree taken when [split] is true. */
     val pos: TreeClassificationNodeResult,
     /** Subtree taken when [split] is false. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,15 +1,23 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.math.VectorView
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Immutable snapshot of a [RegressionTree] at read time. Carries the tree structure (split
- * predicates + per-node weighted-variance aggregates) so callers can route a context
- * vector to its leaf without reaching back into the live stat.
+ * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorView]
+ * context. Carries the tree structure ([SerializableSplit] predicates + per-node
+ * weighted-variance aggregates) so callers can route a context vector to its leaf without
+ * reaching back into the live stat.
+ *
+ * Serialization is only meaningful for the [VectorView] feature representation (the splits
+ * must be wire-portable); trees grown over other [Split] row types use the live
+ * [RegressionTree] directly and are not snapshotted to this type.
  *
  * The root's [WeightedVarianceResult] is exposed as the canonical scalar snapshot;
  * callers wanting context-specific predictions use [findLeaf] or [predict].
@@ -47,8 +55,8 @@ sealed interface TreeNodeResult {
 @Serializable
 @SerialName("TreeSplitResult")
 data class TreeSplitResult(
-    /** Routing predicate. */
-    val split: Split,
+    /** Routing predicate (wire-portable). */
+    val split: SerializableSplit,
     /** Subtree taken when [split] is true. */
     val pos: TreeNodeResult,
     /** Subtree taken when [split] is false. */
@@ -66,18 +74,94 @@ data class TreeLeafResult(override val value: WeightedVarianceResult) : TreeNode
     override fun findLeaf(x: VectorView): WeightedVarianceResult = value
 }
 
-/** Freeze a live tree node into an immutable snapshot. Internal split aggregates are
- *  derived from the snapshotted children so the wire format stays stable even though
- *  live splits hold no arm. */
-fun RegressionNode.snapshot(): TreeNodeResult = when (this) {
+/**
+ * Freeze a live [VectorView] tree node into an immutable, serializable snapshot. Internal
+ * split aggregates are derived from the snapshotted children so the wire format stays
+ * stable even though live splits hold no arm.
+ *
+ * Snapshotting is `VectorView`-only because the wire format requires [SerializableSplit];
+ * a `VectorView` tree is always grown from [SerializableSplit] candidates, so the cast on
+ * each split is safe by construction.
+ */
+fun RegressionNode<VectorView>.snapshot(): TreeNodeResult = when (this) {
     is RegressionSplitNode -> {
         val p = pos.snapshot()
         val n = neg.snapshot()
         val base = mergeWVR(p.value, n.value)
         val carry = carryover
         val value = if (carry != null) mergeWVR(base, carry.read(0L)) else base
-        TreeSplitResult(split, p, n, value)
+        TreeSplitResult(split as SerializableSplit, p, n, value)
     }
 
     is RegressionLeafNode -> TreeLeafResult(arm.read(0L))
+}
+
+/**
+ * Snapshot merge using only the immutable result. Mirrors [RegressionTree.merge] but the
+ * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `VectorView`
+ * only, for the same reason [snapshot] is.
+ */
+fun RegressionTree<VectorView>.mergeSnapshot(other: TreeNodeResult) {
+    splitLock.withLock {
+        root = mergeNodeWithResult(root, other)
+        nbrNodes.store(countNodes(root))
+    }
+}
+
+private fun RegressionTree<VectorView>.mergeNodeWithResult(
+    a: RegressionNode<VectorView>,
+    b: TreeNodeResult,
+): RegressionNode<VectorView> {
+    if (a is RegressionSplitNode && b is TreeSplitResult && a.split == b.split) {
+        a.pos = mergeNodeWithResult(a.pos, b.pos)
+        a.neg = mergeNodeWithResult(a.neg, b.neg)
+        // b.value carries the full subtree aggregate; the child recursion already
+        // folded the structurally-aligned portion. Pull only the residual; what b's
+        // value holds beyond the sum of its children; into a's carryover.
+        val childSum = mergeWVR(b.pos.value, b.neg.value)
+        val residual = subtractWVR(b.value, childSum)
+        if (residual.totalWeights > 0.0) foldIntoCarryover(a, residual)
+        return a
+    }
+    if (a is RegressionLeafNode && b is TreeLeafResult) {
+        a.arm.merge(b.value)
+        return a
+    }
+    if (a is RegressionLeafNode && b is TreeSplitResult) {
+        val cloned = cloneFromResult(b, depth = 0) as RegressionSplitNode
+        foldIntoCarryover(cloned, a.arm.read(0L))
+        return cloned
+    }
+    // a split + b leaf, or splits differ: keep a's structure, fold b's aggregate.
+    foldIntoCarryover(a as RegressionSplitNode, b.value)
+    return a
+}
+
+private fun RegressionTree<VectorView>.cloneFromResult(
+    node: TreeNodeResult,
+    depth: Int,
+): RegressionNode<VectorView> {
+    nbrNodes.addAndFetch(1)
+    return when (node) {
+        is TreeLeafResult -> {
+            val arm = leafArmFactory()
+            arm.merge(node.value)
+            RegressionTerminalLeaf(arm)
+        }
+
+        is TreeSplitResult -> {
+            val pos = cloneFromResult(node.pos, depth + 1)
+            val neg = cloneFromResult(node.neg, depth + 1)
+            // Re-establish any orphan aggregate the snapshot encodes by comparing the
+            // recorded value against the sum of the cloned children's aggregates.
+            val childSum = mergeWVR(node.pos.value, node.neg.value)
+            val residual = subtractWVR(node.value, childSum)
+            val carry = if (residual.totalWeights > 0.0) {
+                leafArmFactory().also { it.merge(residual) }
+            } else {
+                null
+            }
+            RegressionSplitNode(split = node.split, pos = pos, neg = neg, carryover = carry)
+        }
+    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -5,9 +5,9 @@ package com.eignex.kumulant.stat.regression.tree
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.math.VectorView
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorView]
@@ -137,10 +137,7 @@ private fun RegressionTree<VectorView>.mergeNodeWithResult(
     return a
 }
 
-private fun RegressionTree<VectorView>.cloneFromResult(
-    node: TreeNodeResult,
-    depth: Int,
-): RegressionNode<VectorView> {
+private fun RegressionTree<VectorView>.cloneFromResult(node: TreeNodeResult, depth: Int): RegressionNode<VectorView> {
     nbrNodes.addAndFetch(1)
     return when (node) {
         is TreeLeafResult -> {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
@@ -9,8 +9,10 @@ class RegressionTreeTest {
 
     private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
-    private fun newTree(candidates: List<SerializableSplit> = emptyList(), config: RegressionTreeConfig = RegressionTreeConfig()) =
-        RegressionTree(splitCandidates = candidates, config = config, randomSeed = 0)
+    private fun newTree(
+        candidates: List<SerializableSplit> = emptyList(),
+        config: RegressionTreeConfig = RegressionTreeConfig(),
+    ) = RegressionTree(splitCandidates = candidates, config = config, randomSeed = 0)
 
     @Test
     fun `update folds into the root arm even without splits`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
@@ -9,7 +9,7 @@ class RegressionTreeTest {
 
     private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
-    private fun newTree(candidates: List<Split> = emptyList(), config: RegressionTreeConfig = RegressionTreeConfig()) =
+    private fun newTree(candidates: List<SerializableSplit> = emptyList(), config: RegressionTreeConfig = RegressionTreeConfig()) =
         RegressionTree(splitCandidates = candidates, config = config, randomSeed = 0)
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
@@ -3,6 +3,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.math.DenseVector
+import com.eignex.kumulant.math.VectorView
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
@@ -12,7 +13,7 @@ import kotlin.test.assertSame
 
 class TreeNodeTest {
 
-    private fun wvLeaf() = RegressionTerminalLeaf(VarianceStat())
+    private fun wvLeaf(): RegressionTerminalLeaf<VectorView> = RegressionTerminalLeaf(VarianceStat())
     private fun ccLeaf(numClasses: Int = 2) = ClassificationTerminalLeaf(ClassCountsStat(numClasses))
 
     @Test
@@ -39,7 +40,7 @@ class TreeNodeTest {
     @Test
     fun `RegressionAuditLeaf requires aligned candidate sizes`() {
         val arm = VarianceStat()
-        val candidates = listOf<Split>(ThresholdSplit(0, 0.0))
+        val candidates = listOf<SerializableSplit>(ThresholdSplit(0, 0.0))
         assertFailsWith<IllegalArgumentException> {
             RegressionAuditLeaf(
                 arm = arm,


### PR DESCRIPTION
## What

Makes kumulant's online regression-tree engine **generic over the feature representation** so downstream consumers can grow trees over their own row types — not just a dense `VectorView` — while keeping the existing `VectorView` path and its serializable snapshots fully intact.

## Why

The tree engine only ever inspects a feature row by calling `split.direction(row)`; everything else (audit leaves, the Hoeffding-bound split decision, variance-reduction scoring, snapshot/merge) is row-agnostic. Pinning the row type to `VectorView` forced any consumer with a richer/typed feature representation to reimplement the whole growth loop. (Concretely: combo's constraint-aware bandits route klause-handle splits over a typed row and had a full parallel copy of this engine — this lets them delete it and reuse kumulant.)

## Changes

- **`Split` is now `interface Split<in Row> { fun direction(row: Row): Boolean }`** — an open, non-serializable growth-time routing SPI. Any feature type can drive growth by supplying its own `Split`s.
- **New `@Serializable sealed interface SerializableSplit : Split<VectorView>`** carries the wire-portable `ThresholdSplit` / `ExprSplit`. Tree snapshots embed `SerializableSplit`, so **serialization is fully preserved** for the `VectorView` path.
- **`RegressionTree<Row>` / `RegressionNode<Row>`** are genericized. The serialization bridge (`snapshot` / `mergeSnapshot` / clone-from-result) is moved to `VectorView`-constrained extensions, since the wire format is only meaningful for `VectorView`.
- **New public `RegressionNode<*>.aggregate(): WeightedVarianceResult`** — the exact per-node subtree aggregate (Chan-merge of the subtree's leaves plus carryover). Lets callers score *internal* nodes (e.g. a Thompson walk-down that picks a branch by its subtree posterior) without the tree having to keep a live arm on every split node.
- Classification trees and the schema stat-specs are pinned to `SerializableSplit` (mechanical; they remain `VectorView`-only and serializable).

## Breaking changes

Bumps the public tree API (intentional — coordinated with the downstream consumer):

- `Split` → `Split<Row>`; `ThresholdSplit` / `ExprSplit` now implement `SerializableSplit`.
- `splitCandidates` parameters on `DecisionTreeRegressionStat` / `RandomForestRegressionStat` / the classifier stats are now `List<SerializableSplit>` (was `List<Split>`).
- `RegressionTree` → `RegressionTree<VectorView>` at use sites in the built-in stats.

## Tests

The full kumulant JVM suite passes, including the tree/forest serialization round-trip tests. Tree-node and `RegressionTree` tests were updated to spell out the `VectorView` row type.
