### PR TITLE
feat: add ArgMinStat and ArgMaxStat tracking extreme value with timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ which.
 
 | Family       | Stats                                                                          |
 |--------------|--------------------------------------------------------------------------------|
-| Summary      | Sum, Mean, Min, Max, Range, Variance, Moments, Summary, BernoulliSum, Count, Mad |
+| Summary      | Sum, Mean, Min, Max, ArgMin, ArgMax, Range, Variance, Moments, Summary, BernoulliSum, Count, Mad |
 | Event        | Excursion, RunLength, Crossing, Recency, Sojourn                                |
 | Rate         | Rate, CounterRate, DecayingRate                                                 |
 | Change       | Cusum, PageHinkley, Adwin                                                       |

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/StatSpecs.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/StatSpecs.kt
@@ -30,6 +30,8 @@ import com.eignex.kumulant.stat.change.PageHinkleyStat
 import com.eignex.kumulant.stat.rate.CounterRateStat
 import com.eignex.kumulant.stat.rate.DecayingRateStat
 import com.eignex.kumulant.stat.rate.RateStat
+import com.eignex.kumulant.stat.summary.ArgMaxStat
+import com.eignex.kumulant.stat.summary.ArgMinStat
 import com.eignex.kumulant.stat.summary.BernoulliSumStat
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.MadStat
@@ -141,6 +143,22 @@ val minStatSpec = seriesStatSpec(
 val maxStatSpec = seriesStatSpec(
     name = "MaxStat",
     factory = { c -> MaxStat(c) },
+    updates = ::uniformUnitWeights,
+    scalar = { it.max },
+    reference = { seq -> seq.fold(Double.NEGATIVE_INFINITY) { acc, u -> max(acc, u.value) } },
+)
+
+val argMinStatSpec = seriesStatSpec(
+    name = "ArgMinStat",
+    factory = { c -> ArgMinStat(c) },
+    updates = ::uniformUnitWeights,
+    scalar = { it.min },
+    reference = { seq -> seq.fold(Double.POSITIVE_INFINITY) { acc, u -> min(acc, u.value) } },
+)
+
+val argMaxStatSpec = seriesStatSpec(
+    name = "ArgMaxStat",
+    factory = { c -> ArgMaxStat(c) },
     updates = ::uniformUnitWeights,
     scalar = { it.max },
     reference = { seq -> seq.fold(Double.NEGATIVE_INFINITY) { acc, u -> max(acc, u.value) } },
@@ -1014,6 +1032,8 @@ val allSpecs: List<StatSpec<*, *>> = listOf(
     momentsStatSpec,
     minStatSpec,
     maxStatSpec,
+    argMinStatSpec,
+    argMaxStatSpec,
     rangeStatSpec,
     thresholdBucketStatSpec,
     crossingStatSpec,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -116,6 +116,8 @@ import com.eignex.kumulant.stat.sketch.BloomFilterStat
 import com.eignex.kumulant.stat.sketch.CountMinSketchStat
 import com.eignex.kumulant.stat.sketch.MinHashStat
 import com.eignex.kumulant.stat.sketch.SpaceSavingStat
+import com.eignex.kumulant.stat.summary.ArgMaxStat
+import com.eignex.kumulant.stat.summary.ArgMinStat
 import com.eignex.kumulant.stat.summary.BernoulliSumStat
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.MadStat
@@ -149,6 +151,10 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
         Min -> MinStat(concurrency)
 
         Max -> MaxStat(concurrency)
+
+        ArgMin -> ArgMinStat(concurrency)
+
+        ArgMax -> ArgMaxStat(concurrency)
 
         Range -> RangeStat(concurrency)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
@@ -50,6 +50,8 @@ import com.eignex.kumulant.stat.sketch.BloomFilterResult
 import com.eignex.kumulant.stat.sketch.CountMinSketchResult
 import com.eignex.kumulant.stat.sketch.HeavyHittersResult
 import com.eignex.kumulant.stat.sketch.MinHashResult
+import com.eignex.kumulant.stat.summary.ArgMaxResult
+import com.eignex.kumulant.stat.summary.ArgMinResult
 import com.eignex.kumulant.stat.summary.BernoulliSumResult
 import com.eignex.kumulant.stat.summary.MadResult
 import com.eignex.kumulant.stat.summary.MaxResult
@@ -93,6 +95,16 @@ data object Min : SeriesStatSpec<MinResult>
 @Serializable
 @SerialName("Max")
 data object Max : SeriesStatSpec<MaxResult>
+
+/** Spec for `ArgMinStat`: running minimum plus the timestamp at which it occurred. */
+@Serializable
+@SerialName("ArgMin")
+data object ArgMin : SeriesStatSpec<ArgMinResult>
+
+/** Spec for `ArgMaxStat`: running maximum plus the timestamp at which it occurred. */
+@Serializable
+@SerialName("ArgMax")
+data object ArgMax : SeriesStatSpec<ArgMaxResult>
 
 /** Spec for `RangeStat`: running min and max as a pair. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStat.kt
@@ -1,0 +1,67 @@
+package com.eignex.kumulant.stat.summary
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.monotonicMode
+import com.eignex.kumulant.stream.serializedLock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Running maximum of a stream plus the timestamp at which it occurred. */
+@Serializable
+@SerialName("ArgMaxResult")
+data class ArgMaxResult(
+    /** Running maximum value. */
+    val max: Double,
+    /** Timestamp (nanoseconds) at which [max] was observed. */
+    val atTimestampNanos: Long,
+) : Result
+
+/**
+ * Tracks the maximum value seen across a stream together with the timestamp
+ * at which it occurred. On ties the first occurrence wins.
+ *
+ * **Use cases:** best objective and when it was found, peak load and when
+ * it happened, locating the peak of a series in time.
+ *
+ * **Memory:** O(1); a double cell, a long cell, and a lock.
+ *
+ * **Update:** O(1) per observation.
+ *
+ * **Concurrency:** Internal CAS spin-lock (category 3). The (value, timestamp)
+ * pair cannot be made elementwise atomic with a single-cell CAS; the lock
+ * keeps the pair consistent under any [Concurrency] level.
+ */
+class ArgMaxStat(override val concurrency: Concurrency = Concurrency.None) : SeriesStat<ArgMaxResult> {
+
+    private val mode = concurrency.monotonicMode()
+    private val lock = concurrency.serializedLock()
+    private val value = mode.newDouble(Double.NEGATIVE_INFINITY)
+    private val at = mode.newLong(0L)
+
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+        if (value > this.value.load()) {
+            this.value.store(value)
+            at.store(timestampNanos)
+        }
+    }
+
+    override fun merge(values: ArgMaxResult) = lock.withLock {
+        if (values.max > value.load()) {
+            value.store(values.max)
+            at.store(values.atTimestampNanos)
+        }
+    }
+
+    override fun reset() = lock.withLock {
+        value.store(Double.NEGATIVE_INFINITY)
+        at.store(0L)
+    }
+
+    override fun read(timestampNanos: Long) = lock.withLock {
+        ArgMaxResult(value.load(), at.load())
+    }
+
+    override fun create(concurrency: Concurrency?) = ArgMaxStat(concurrency ?: this.concurrency)
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMinStat.kt
@@ -1,0 +1,67 @@
+package com.eignex.kumulant.stat.summary
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.monotonicMode
+import com.eignex.kumulant.stream.serializedLock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Running minimum of a stream plus the timestamp at which it occurred. */
+@Serializable
+@SerialName("ArgMinResult")
+data class ArgMinResult(
+    /** Running minimum value. */
+    val min: Double,
+    /** Timestamp (nanoseconds) at which [min] was observed. */
+    val atTimestampNanos: Long,
+) : Result
+
+/**
+ * Tracks the minimum value seen across a stream together with the timestamp
+ * at which it occurred. On ties the first occurrence wins.
+ *
+ * **Use cases:** best objective and when it was found, lowest latency and
+ * when it happened, locating the trough of a series in time.
+ *
+ * **Memory:** O(1); a double cell, a long cell, and a lock.
+ *
+ * **Update:** O(1) per observation.
+ *
+ * **Concurrency:** Internal CAS spin-lock (category 3). The (value, timestamp)
+ * pair cannot be made elementwise atomic with a single-cell CAS; the lock
+ * keeps the pair consistent under any [Concurrency] level.
+ */
+class ArgMinStat(override val concurrency: Concurrency = Concurrency.None) : SeriesStat<ArgMinResult> {
+
+    private val mode = concurrency.monotonicMode()
+    private val lock = concurrency.serializedLock()
+    private val value = mode.newDouble(Double.POSITIVE_INFINITY)
+    private val at = mode.newLong(0L)
+
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+        if (value < this.value.load()) {
+            this.value.store(value)
+            at.store(timestampNanos)
+        }
+    }
+
+    override fun merge(values: ArgMinResult) = lock.withLock {
+        if (values.min < value.load()) {
+            value.store(values.min)
+            at.store(values.atTimestampNanos)
+        }
+    }
+
+    override fun reset() = lock.withLock {
+        value.store(Double.POSITIVE_INFINITY)
+        at.store(0L)
+    }
+
+    override fun read(timestampNanos: Long) = lock.withLock {
+        ArgMinResult(value.load(), at.load())
+    }
+
+    override fun create(concurrency: Concurrency?) = ArgMinStat(concurrency ?: this.concurrency)
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/package.md
@@ -18,6 +18,12 @@ level via independent commuting cell arithmetic ([SumStat]) or a CAS
 loop on a single cell ([MinStat] / [MaxStat]). [RangeStat] is a
 [MinStat] and [MaxStat] tracked together.
 
+[ArgMinStat] and [ArgMaxStat] extend [MinStat] / [MaxStat] with the
+timestamp at which the extreme was observed. The (value, timestamp) pair
+is coupled, so a single-cell CAS no longer suffices; an internal lock
+keeps the pair consistent under concurrency. Merge keeps the pair from
+the smaller (larger) value.
+
 [CountStat], [TotalWeightsStat], and [BernoulliSumStat] look similar but
 answer different questions. [CountStat] counts updates, ignoring weight.
 [TotalWeightsStat] sums weight, ignoring the value. [BernoulliSumStat]
@@ -95,7 +101,9 @@ stats:
 
 Every entry merges across parallel workers. The additive stats ([SumStat],
 [CountStat], [TotalWeightsStat], [BernoulliSumStat]) sum cell-wise; [MinStat],
-[MaxStat], and [RangeStat] take cell-wise min/max; the Welford family
+[MaxStat], and [RangeStat] take cell-wise min/max; [ArgMinStat] and
+[ArgMaxStat] keep the (value, timestamp) pair from the smaller (larger)
+value; the Welford family
 ([MeanStat], [VarianceStat], [MomentsStat], [SummaryStat]) uses the Chan-style
 parallel recurrence; [PairedSumStat] sums each axis. All of these are exact.
 [MadStat] is the one approximation: the t-digests carry no round-trippable
@@ -107,6 +115,7 @@ state, so merge re-pushes the `(median, MAD)` pair as a single update.
 |------|--------|--------|-------------|
 | [SumStat], [CountStat], [TotalWeightsStat], [BernoulliSumStat] | O(1) | O(1) | striped-additive under HighWrite, atomic otherwise |
 | [MinStat], [MaxStat], [RangeStat] | O(1) | O(1) | CAS loop on a single cell |
+| [ArgMinStat], [ArgMaxStat] | O(1) | O(1) | internal lock keeps the (value, timestamp) pair consistent |
 | [MeanStat] | O(1) | O(1) | Welford-coupled; locked under Strict / HighWrite, racing under Relaxed |
 | [VarianceStat], [SummaryStat] | O(1) | O(1) | Welford-coupled |
 | [MomentsStat] | O(1) | O(1) | Welford-coupled (four cells) |

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
@@ -47,6 +47,14 @@ class StatsRoundTripTest {
         assertEquals(Max, roundTrip(Max))
     }
 
+    @Test fun `argMinConfig round trips`() {
+        assertEquals(ArgMin, roundTrip(ArgMin))
+    }
+
+    @Test fun `argMaxConfig round trips`() {
+        assertEquals(ArgMax, roundTrip(ArgMax))
+    }
+
     @Test fun `rangeConfig round trips`() {
         assertEquals(Range, roundTrip(Range))
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStatTest.kt
@@ -1,0 +1,102 @@
+package com.eignex.kumulant.stat.summary
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val DELTA = 1e-12
+
+class ArgMaxStatTest {
+
+    @Test
+    fun `tracks maximum and its timestamp`() {
+        val m = ArgMaxStat()
+        m.update(3.0, 10L)
+        m.update(5.0, 20L)
+        m.update(1.0, 30L)
+        val r = m.read()
+        assertEquals(5.0, r.max, DELTA)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `tie keeps first occurrence`() {
+        val m = ArgMaxStat()
+        m.update(1.0, 10L)
+        m.update(1.0, 20L)
+        assertEquals(10L, m.read().atTimestampNanos)
+    }
+
+    @Test
+    fun `empty returns negative infinity`() {
+        val r = ArgMaxStat().read()
+        assertEquals(Double.NEGATIVE_INFINITY, r.max)
+        assertEquals(0L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge keeps pair from larger max`() {
+        val m1 = ArgMaxStat().apply { update(2.0, 10L) }
+        val m2 = ArgMaxStat().apply { update(4.0, 20L) }
+        m1.merge(m2.read())
+        val r = m1.read()
+        assertEquals(4.0, r.max, DELTA)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge with smaller max keeps own pair`() {
+        val m1 = ArgMaxStat().apply { update(4.0, 10L) }
+        val m2 = ArgMaxStat().apply { update(2.0, 20L) }
+        m1.merge(m2.read())
+        val r = m1.read()
+        assertEquals(4.0, r.max, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge with empty is a no-op`() {
+        val m = ArgMaxStat().apply { update(2.0, 10L) }
+        m.merge(ArgMaxStat().read())
+        val r = m.read()
+        assertEquals(2.0, r.max, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `reset restores infinity`() {
+        val m = ArgMaxStat().apply { update(3.0, 10L) }
+        m.reset()
+        val r = m.read()
+        assertEquals(Double.NEGATIVE_INFINITY, r.max)
+        assertEquals(0L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `create produces fresh independent stat`() {
+        val m1 = ArgMaxStat().apply { update(1.0, 10L) }
+        val m2 = m1.create()
+        m2.update(5.0, 20L)
+        assertEquals(1.0, m1.read().max, DELTA)
+        assertEquals(5.0, m2.read().max, DELTA)
+    }
+
+    @Test
+    fun `ignores NaN inputs`() {
+        val m = ArgMaxStat()
+        m.update(5.0, 10L)
+        m.update(Double.NaN, 20L)
+        val r = m.read()
+        assertEquals(5.0, r.max, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `accepts positive infinity`() {
+        val m = ArgMaxStat()
+        m.update(0.0, 10L)
+        m.update(Double.POSITIVE_INFINITY, 20L)
+        val r = m.read()
+        assertEquals(Double.POSITIVE_INFINITY, r.max)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMinStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMinStatTest.kt
@@ -1,0 +1,102 @@
+package com.eignex.kumulant.stat.summary
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val DELTA = 1e-12
+
+class ArgMinStatTest {
+
+    @Test
+    fun `tracks minimum and its timestamp`() {
+        val m = ArgMinStat()
+        m.update(3.0, 10L)
+        m.update(1.0, 20L)
+        m.update(5.0, 30L)
+        val r = m.read()
+        assertEquals(1.0, r.min, DELTA)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `tie keeps first occurrence`() {
+        val m = ArgMinStat()
+        m.update(1.0, 10L)
+        m.update(1.0, 20L)
+        assertEquals(10L, m.read().atTimestampNanos)
+    }
+
+    @Test
+    fun `empty returns positive infinity`() {
+        val r = ArgMinStat().read()
+        assertEquals(Double.POSITIVE_INFINITY, r.min)
+        assertEquals(0L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge keeps pair from smaller min`() {
+        val m1 = ArgMinStat().apply { update(4.0, 10L) }
+        val m2 = ArgMinStat().apply { update(2.0, 20L) }
+        m1.merge(m2.read())
+        val r = m1.read()
+        assertEquals(2.0, r.min, DELTA)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge with larger min keeps own pair`() {
+        val m1 = ArgMinStat().apply { update(2.0, 10L) }
+        val m2 = ArgMinStat().apply { update(4.0, 20L) }
+        m1.merge(m2.read())
+        val r = m1.read()
+        assertEquals(2.0, r.min, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `merge with empty is a no-op`() {
+        val m = ArgMinStat().apply { update(2.0, 10L) }
+        m.merge(ArgMinStat().read())
+        val r = m.read()
+        assertEquals(2.0, r.min, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `reset restores infinity`() {
+        val m = ArgMinStat().apply { update(3.0, 10L) }
+        m.reset()
+        val r = m.read()
+        assertEquals(Double.POSITIVE_INFINITY, r.min)
+        assertEquals(0L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `create produces fresh independent stat`() {
+        val m1 = ArgMinStat().apply { update(5.0, 10L) }
+        val m2 = m1.create()
+        m2.update(1.0, 20L)
+        assertEquals(5.0, m1.read().min, DELTA)
+        assertEquals(1.0, m2.read().min, DELTA)
+    }
+
+    @Test
+    fun `ignores NaN inputs`() {
+        val m = ArgMinStat()
+        m.update(5.0, 10L)
+        m.update(Double.NaN, 20L)
+        val r = m.read()
+        assertEquals(5.0, r.min, DELTA)
+        assertEquals(10L, r.atTimestampNanos)
+    }
+
+    @Test
+    fun `accepts negative infinity`() {
+        val m = ArgMinStat()
+        m.update(0.0, 10L)
+        m.update(Double.NEGATIVE_INFINITY, 20L)
+        val r = m.read()
+        assertEquals(Double.NEGATIVE_INFINITY, r.min)
+        assertEquals(20L, r.atTimestampNanos)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
@@ -46,6 +46,28 @@ class SummaryStatConcurrencyTest {
     }
 
     @Test
+    fun `ArgMinStat sequential math equal across modes`() {
+        val reads = Concurrency.entries.associateWith { mode ->
+            val s = ArgMinStat(concurrency = mode)
+            for (i in values.indices) s.update(values[i], i.toLong(), weights[i])
+            s.read(0L)
+        }
+        val ref = reads.getValue(Concurrency.None)
+        for ((mode, r) in reads) assertEquals(ref, r, "ArgMinStat mode=$mode")
+    }
+
+    @Test
+    fun `ArgMaxStat sequential math equal across modes`() {
+        val reads = Concurrency.entries.associateWith { mode ->
+            val s = ArgMaxStat(concurrency = mode)
+            for (i in values.indices) s.update(values[i], i.toLong(), weights[i])
+            s.read(0L)
+        }
+        val ref = reads.getValue(Concurrency.None)
+        for ((mode, r) in reads) assertEquals(ref, r, "ArgMaxStat mode=$mode")
+    }
+
+    @Test
     fun `MeanStat sequential math equal across modes`() {
         val reads = sequentialReads { MeanStat(concurrency = it) }
         val ref = reads.getValue(Concurrency.None)


### PR DESCRIPTION
## What changed

- Added ArgMinStat and ArgMaxStat in stat.summary tracking the extreme value and the timestamp at which it occurred, with ArgMinResult(min, atTimestampNanos) and ArgMaxResult(max, atTimestampNanos).
- Registered ArgMin and ArgMax specs in schema.spec and their materialize branches in StatFactory.
- Added bench catalog entries for both stats.
- Updated README stat table and the summary package docs.

## Why

The (value, at) pair is coupled so a single-cell CAS does not suffice; an internal lock keeps the pair consistent under any concurrency level. Merge keeps the pair from the smaller (larger) value, ties keep the first occurrence.

Closes #19

## Testing

Unit tests for tracking, ties, merge, reset, create, NaN, and infinities; cross-mode concurrency smoke tests; wire round-trip tests. Ran jvmTest for both modules, lintDocs, and the linuxX64 compile locally.