### PR TITLE
feat: expose Mutex + Concurrency.lock() as public API

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
@@ -1,13 +1,27 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.core.Concurrency
+
 /**
  * Mutual-exclusion lock used by stats whose update logic spans multiple cells or
- * multiple steps and therefore can't be made elementwise atomic. Allocate once per
- * stat instance via [PlatformMutex] (or [NoopMutex] when no lock is
- * needed).
+ * multiple steps and therefore can't be made elementwise atomic. Obtain one for a
+ * given [Concurrency] level via [Concurrency.lock]: a no-op under [Concurrency.None]
+ * (single-threaded, zero overhead), a platform mutex otherwise.
  */
-internal interface Mutex {
+interface Mutex {
+    /** Run [block] holding the lock and return its result. */
     fun <R> withLock(block: () -> R): R
+}
+
+/**
+ * The lock for a [Concurrency] level: [NoopMutex] under [Concurrency.None] — a
+ * single-threaded owner pays no synchronization — and a [PlatformMutex] under any
+ * concurrent level. The same contract the per-stat `serializedLock` uses, exposed for
+ * callers that need a coherent lock for their own coupled state.
+ */
+fun Concurrency.lock(): Mutex = when (this) {
+    Concurrency.None -> NoopMutex
+    else -> PlatformMutex()
 }
 
 /** No-op lock used under [com.eignex.kumulant.core.Concurrency.None] and on


### PR DESCRIPTION
Exposes the existing internal `Mutex` abstraction as public API so downstream callers (klause's cross-arm clause-sharing pool) can reuse one coherent, concurrency-parameterized lock instead of hand-rolling atomics.

## What changed
- `Mutex` interface is now `public` (was `internal`); its `withLock` member gains a doc.
- New public factory `fun Concurrency.lock(): Mutex` — `NoopMutex` under `Concurrency.None` (single-threaded, zero synchronization), `PlatformMutex` otherwise. Same contract the internal per-stat `serializedLock()` already uses.

`NoopMutex` and `PlatformMutex` stay `internal` — the factory returns the `Mutex` interface, so callers never name the implementations.

## Why
A consumer building a shared, batch-written buffer wants a real lock (a CAS-on-a-list-reference is copy-on-write, O(n) per publish), parameterized by the same `Concurrency` contract kumulant already defines — and lock-free (`NoopMutex`) when single-threaded.

## Testing
`:kumulant:compileKotlinJvm` + `detektMainJvm` + `dokkaGeneratePublicationHtml` green.
