### PR TITLE
Fix weighted moment recurrences and negative-weight handling

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -16,6 +16,26 @@ import com.eignex.kumulant.stream.currentTimeNanos
  *
  * The full lifecycle (`update` / `read` / `merge`) is shown end-to-end below.
  *
+ * Every modality's `update` takes a per-observation `weight`, interpreted
+ * consistently with the stat's mathematical role: weighted means take it as the
+ * observation weight, sums multiply by it, histograms add it to the destination
+ * bin. A weight of 1 (the default) is the unweighted case.
+ *
+ * Two guarantees hold across every stat:
+ *
+ * - A weight of `0.0` is a no-op. The observation is not folded in and no state
+ *   changes, whatever the modality.
+ * - A negative weight carries whatever meaning is standard for that particular
+ *   statistic. For the accumulating families that is a downdate: it removes an
+ *   observation previously folded in. Where a statistic has no sensible inverse,
+ *   or where the update would corrupt the accumulator rather than merely give a
+ *   surprising answer, it throws [IllegalArgumentException] instead. Each stat's
+ *   own KDoc says which applies; there is deliberately no library-wide answer,
+ *   because subtraction is well defined for some statistics and not others.
+ *
+ * Checks beyond that are the caller's responsibility. Stats validate only where
+ * the alternative is corrupted state, not to police inputs.
+ *
  * @param R The result type returned by [read]; always a [Result] subtype.
  *
  * @sample com.eignex.kumulant.samples.basicMeanLifecycle
@@ -99,11 +119,8 @@ interface Stat<R : Result> {
  * [VarianceStat][com.eignex.kumulant.stat.summary.VarianceStat], the quantile
  * sketches, the rate family, the decay family) implement this shape.
  *
- * Implementations interpret the per-observation `weight` consistently with
- * their mathematical role: weighted means take it as the observation weight,
- * sums multiply by it, histograms add it to the destination bin. A weight of
- * 0 typically drops the observation; a weight of 1 (the default) is the
- * unweighted case.
+ * See [Stat] for the per-observation `weight` contract, which is library-wide:
+ * weights must be non-negative, and zero or negative drops the observation.
  */
 interface SeriesStat<R : Result> : Stat<R> {
     /** Record an observation with the given [weight], stamped at the current time. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
@@ -1,0 +1,30 @@
+package com.eignex.kumulant.core
+
+/**
+ * Guard the one negative-weight case that corrupts a Welford accumulator.
+ *
+ * A negative [weight] is a legitimate downdate: it removes an observation that was
+ * previously folded in, which is how a caller drives a sliding window by hand. The
+ * recurrences invert exactly, so the removal is not an approximation.
+ *
+ * What is not recoverable is a downdate that takes the accumulated weight to zero or
+ * below. Every Welford step divides by the new total, so a total of zero yields an
+ * infinite or NaN mean that survives every later update, and a negative total silently
+ * flips the sign of subsequent corrections. Both are corruption rather than a bad
+ * answer, so this throws instead of letting the state rot.
+ *
+ * Under [Concurrency.Relaxed] the check is best-effort: the read of [currentTotal] and
+ * the write that follows it are not atomic together, so a racing writer can slip
+ * between them. That matches the level's documented contract, which already permits
+ * drift. Every other level holds the stat's lock across both.
+ *
+ * @param currentTotal accumulated weight before this update.
+ * @param weight the incoming observation weight; may be negative.
+ * @throws IllegalArgumentException if the update would leave a non-positive total.
+ */
+internal fun requireLiveWeight(currentTotal: Double, weight: Double) {
+    require(currentTotal + weight > 0.0) {
+        "weight $weight would take the accumulated weight from $currentTotal to " +
+            "${currentTotal + weight}; a downdate must leave a positive total"
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
@@ -44,15 +44,20 @@ data class UnivariateRegressionResult(
     val covariance: Double get() = if (totalWeights > 0.0) sxy / totalWeights else 0.0
 
     /**
-     * Pearson correlation derived from R^2 and the sign of [sxy]. Reuses [sst]/[sse]
-     * rather than storing the raw quantity.
+     * Pearson correlation of the `x` and `y` streams, `sxy / sqrt(sxx * syy)`.
+     *
+     * Computed from the raw cross-deviation rather than from `1 - sse/sst`, because
+     * [sse] is evaluated at the penalised [slope]: under [Penalty.L1] with a lambda
+     * above the soft-thresholding cut the slope is exactly zero, making `sse == sst`
+     * and yielding a correlation of zero for perfectly correlated data. This is a
+     * property of the two streams and so is independent of [penalty].
      */
     val correlation: Double
         get() {
-            if (sst <= 0.0) return 0.0
-            val r2 = (1.0 - (sse / sst)).coerceAtLeast(0.0)
-            val r = sqrt(r2)
-            return if (sxy >= 0.0) r else -r
+            val sxx = x.variance * totalWeights
+            val syy = y.variance * totalWeights
+            if (sxx <= 0.0 || syy <= 0.0) return 0.0
+            return (sxy / sqrt(sxx * syy)).coerceIn(-1.0, 1.0)
         }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.summary
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireLiveWeight
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -36,6 +37,13 @@ data class WeightedMeanResult(
  * with [com.eignex.kumulant.operation.withValue] / `withWeight` to derive
  * other means (event rate, conditional mean, etc.).
  *
+ * **Weights:** zero is a no-op. A negative weight is a downdate: it removes an
+ * observation previously folded in, inverting the update exactly, which is how a
+ * caller drives a sliding window by hand. The one rejected case is a downdate that
+ * would take the accumulated weight to zero or below, since every step divides by
+ * the new total and the accumulator would be left permanently non-finite; that
+ * throws [IllegalArgumentException].
+ *
  * **Memory:** O(1); two doubles plus a lock.
  *
  * **Update:** O(1) per observation.
@@ -55,6 +63,7 @@ class MeanStat(override val concurrency: Concurrency = Concurrency.None) : Serie
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
         if (weight == 0.0) return@withLock
+        requireLiveWeight(totalWeights.load(), weight)
         val nextW = totalWeights.addAndGet(weight)
         val delta = value - mean.load()
         mean.add(delta * (weight / nextW))

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MomentsStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MomentsStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.HasSampleVariance
 import com.eignex.kumulant.core.HasShapeMoments
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireLiveWeight
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -39,6 +40,11 @@ data class MomentsResult(
  * non-Gaussian tail diagnostics). Heavier than [VarianceStat]; reach for it
  * only when third/fourth moments are needed.
  *
+ * **Weights:** the recurrences are the fully weighted Pebay forms, not the
+ * unit-weight specialisations, so any weight is supported. Zero is a no-op. A
+ * negative weight removes a previously folded-in observation and inverts all four
+ * moments exactly; see [MeanStat] for the shared downdate contract.
+ *
  * **Memory:** O(1); five doubles plus a lock.
  *
  * **Update:** O(1) per observation.
@@ -59,8 +65,9 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
     private val m4 = mode.newDouble(0.0)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight <= 0.0) return@withLock
+        if (weight == 0.0) return@withLock
         val oldW = totalWeights.load()
+        requireLiveWeight(oldW, weight)
         val nextW = totalWeights.addAndGet(weight)
 
         val priorMean = mean.load()
@@ -72,10 +79,15 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
         val deltaW2 = deltaW * deltaW
         val term1 = delta * deltaW * oldW
 
-        val m4Delta = term1 * deltaW2 * (nextW * nextW - 3 * nextW + 3) +
+        // Weighted Pebay recurrences: the leading coefficients are the merge formulas
+        // below specialised to a second sample of weight `weight` and zero moments.
+        // They reduce to the familiar (n - 2) and (n^2 - 3n + 3) only at weight == 1.
+        // Written as delta/nextW rather than deltaW/weight so a tiny weight doesn't
+        // divide out.
+        val m4Delta = term1 * delta * delta * (oldW * oldW - oldW * weight + weight * weight) / (nextW * nextW) +
             6 * deltaW2 * priorM2 -
             4 * deltaW * priorM3
-        val m3Delta = term1 * deltaW * (nextW - 2) - 3 * deltaW * priorM2
+        val m3Delta = term1 * delta * (oldW - weight) / nextW - 3 * deltaW * priorM2
 
         m4.add(m4Delta)
         m3.add(m3Delta)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/VarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/VarianceStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasCenterScale
 import com.eignex.kumulant.core.HasSampleVariance
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireLiveWeight
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -45,6 +46,11 @@ data class WeightedVarianceResult(
  * for control charts, anomaly thresholds, and bandit posteriors. Pairs with
  * [MomentsStat] when skewness/kurtosis are also needed.
  *
+ * **Weights:** zero is a no-op; a negative weight downdates. See [MeanStat] for
+ * the shared contract. The `sst` recurrence inverts exactly: removing `(x, w)`
+ * from total `W` subtracts `W * w * delta^2 / (W - w)`, which is algebraically
+ * the same quantity the forward step added.
+ *
  * **Memory:** O(1); three doubles plus a lock.
  *
  * **Update:** O(1) per observation.
@@ -66,6 +72,7 @@ class VarianceStat(override val concurrency: Concurrency = Concurrency.None) : S
     override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
         if (weight == 0.0) return@withLock
         val priorW = totalWeights.load()
+        requireLiveWeight(priorW, weight)
         val nextW = totalWeights.addAndGet(weight)
         val delta = value - mean.load()
         val r = delta * (weight / nextW)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatsTest.kt
@@ -424,6 +424,31 @@ class LassoTest {
     }
 
     @Test
+    fun `correlation describes the streams and ignores the penalty`() {
+        // Correlation is a property of x and y, not of the fitted slope, so a lambda
+        // large enough to soft-threshold the slope to zero must not drag it to zero.
+        val lasso = UnivariateRegressionStat(Penalty.L1(lambda = 1e9))
+        val ols = UnivariateRegressionStat()
+        for (x in 0..9) {
+            lasso.update(x.toDouble(), 2.0 * x + 1.0)
+            ols.update(x.toDouble(), 2.0 * x + 1.0)
+        }
+        val r = lasso.read()
+        assertEquals(0.0, r.slope, EPS, "precondition: lambda should zero the slope")
+        assertEquals(1.0, r.correlation, APPROX)
+        assertEquals(ols.read().correlation, r.correlation, APPROX)
+    }
+
+    @Test
+    fun `correlation stays negative for an anti-correlated stream under L1`() {
+        val lasso = UnivariateRegressionStat(Penalty.L1(lambda = 1e9))
+        for (x in 0..9) lasso.update(x.toDouble(), -3.0 * x + 5.0)
+        val r = lasso.read()
+        assertEquals(0.0, r.slope, EPS)
+        assertEquals(-1.0, r.correlation, APPROX)
+    }
+
+    @Test
     fun `merge of two halves matches a single accumulator`() {
         val full = UnivariateRegressionStat(Penalty.L1(lambda = 1.0)).apply {
             for (x in 0..19) update(x.toDouble(), 3.0 * x + 2.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MeanStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MeanStatTest.kt
@@ -2,6 +2,8 @@ package com.eignex.kumulant.stat.summary
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 private const val DELTA = 1e-12
 
@@ -33,6 +35,45 @@ class MeanStatTest {
         mean.update(100.0, 0.0)
         assertEquals(10.0, mean.read().mean, DELTA)
         assertEquals(1.0, mean.read().totalWeights, DELTA)
+    }
+
+    @Test
+    fun `negative weight downdates back to the prior state`() {
+        val mean = MeanStat()
+        mean.update(10.0, 2.0)
+        mean.update(30.0, 1.5)
+        val before = mean.read()
+
+        mean.update(7.0, 3.0)
+        mean.update(7.0, -3.0)
+
+        val after = mean.read()
+        assertEquals(before.totalWeights, after.totalWeights, DELTA)
+        assertEquals(before.mean, after.mean, DELTA)
+    }
+
+    @Test
+    fun `downdate drives a sliding window`() {
+        val mean = MeanStat()
+        listOf(1.0, 2.0, 3.0, 4.0).forEach { mean.update(it, 1.0) }
+        // Drop the two oldest, leaving mean(3, 4).
+        mean.update(1.0, -1.0)
+        mean.update(2.0, -1.0)
+        val r = mean.read()
+        assertEquals(2.0, r.totalWeights, DELTA)
+        assertEquals(3.5, r.mean, DELTA)
+    }
+
+    @Test
+    fun `a downdate that would exhaust the accumulated weight throws`() {
+        val mean = MeanStat()
+        mean.update(1.0, 1.0)
+        assertFailsWith<IllegalArgumentException> { mean.update(2.0, -1.0) }
+        assertFailsWith<IllegalArgumentException> { mean.update(2.0, -5.0) }
+        val r = mean.read()
+        assertEquals(1.0, r.mean, DELTA)
+        assertEquals(1.0, r.totalWeights, DELTA)
+        assertTrue(r.mean.isFinite())
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MomentsStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MomentsStatTest.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.summary
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class MomentsStatTest {
@@ -159,5 +160,107 @@ class MomentsStatTest {
         val n = r.totalWeights
         val expected = ((n - 1) / ((n - 2) * (n - 3))) * ((n + 1) * r.kurtosis + 6.0)
         assertEquals(expected, r.unbiasedKurtosis, delta)
+    }
+
+    /** Weighted central moments computed directly, as the reference for the recurrences. */
+    private fun reference(points: List<Pair<Double, Double>>): MomentsResult {
+        val w = points.sumOf { it.second }
+        val mean = points.sumOf { it.first * it.second } / w
+        fun central(k: Int) = points.sumOf { (x, wi) ->
+            var acc = wi
+            repeat(k) { acc *= (x - mean) }
+            acc
+        }
+        return MomentsResult(w, mean, central(2), central(3), central(4))
+    }
+
+    private fun assertMomentsEqual(expected: MomentsResult, actual: MomentsResult, tolerance: Double = delta) {
+        assertEquals(expected.totalWeights, actual.totalWeights, tolerance, "totalWeights")
+        assertEquals(expected.mean, actual.mean, tolerance, "mean")
+        assertEquals(expected.m2, actual.m2, tolerance, "m2")
+        assertEquals(expected.m3, actual.m3, tolerance, "m3")
+        assertEquals(expected.m4, actual.m4, tolerance, "m4")
+    }
+
+    @Test
+    fun `higher moments match direct sums under a constant non-unit weight`() {
+        val values = listOf(1.0, 2.0, 4.0, 8.0, 3.0)
+        val stat = MomentsStat()
+        values.forEach { stat.update(it, 2.0) }
+        assertMomentsEqual(reference(values.map { it to 2.0 }), stat.read())
+    }
+
+    @Test
+    fun `higher moments match direct sums under mixed weights`() {
+        val points = listOf(1.0 to 0.5, 2.0 to 0.25, 4.0 to 3.0, 8.0 to 1.5, 3.0 to 0.75)
+        val stat = MomentsStat()
+        points.forEach { (x, w) -> stat.update(x, w) }
+        assertMomentsEqual(reference(points), stat.read())
+    }
+
+    @Test
+    fun `an integer weight equals that many unit-weight updates`() {
+        val weighted = MomentsStat().apply {
+            update(1.0, 3.0)
+            update(5.0, 2.0)
+            update(9.0, 1.0)
+        }
+        val repeated = MomentsStat().apply {
+            repeat(3) { update(1.0, 1.0) }
+            repeat(2) { update(5.0, 1.0) }
+            update(9.0, 1.0)
+        }
+        assertMomentsEqual(repeated.read(), weighted.read())
+    }
+
+    @Test
+    fun `skewness is scale-invariant under a uniform weight rescale`() {
+        val values = listOf(1.0, 1.0, 1.0, 2.0, 10.0)
+        val unit = MomentsStat().apply { values.forEach { update(it, 1.0) } }.read()
+        val scaled = MomentsStat().apply { values.forEach { update(it, 7.0) } }.read()
+        assertEquals(unit.skewness, scaled.skewness, delta)
+        assertEquals(unit.kurtosis, scaled.kurtosis, delta)
+    }
+
+    @Test
+    fun `negative weight downdates all four moments back to the prior state`() {
+        val stat = MomentsStat()
+        listOf(1.0 to 2.0, 5.0 to 0.75, 9.0 to 1.5).forEach { (x, w) -> stat.update(x, w) }
+        val before = stat.read()
+
+        stat.update(4.0, 2.25)
+        stat.update(4.0, -2.25)
+
+        assertMomentsEqual(before, stat.read(), tolerance = 1e-7)
+    }
+
+    @Test
+    fun `downdate matches a fresh accumulator over the retained values`() {
+        val windowed = MomentsStat()
+        val all = listOf(2.0 to 1.0, 4.0 to 1.0, 6.0 to 1.0, 8.0 to 1.0)
+        all.forEach { (x, w) -> windowed.update(x, w) }
+        windowed.update(2.0, -1.0)
+
+        assertMomentsEqual(reference(all.drop(1)), windowed.read(), tolerance = 1e-7)
+    }
+
+    @Test
+    fun `a downdate that would exhaust the accumulated weight throws`() {
+        val stat = MomentsStat()
+        stat.update(1.0, 1.0)
+        val before = stat.read()
+        assertFailsWith<IllegalArgumentException> { stat.update(2.0, -1.0) }
+        assertMomentsEqual(before, stat.read())
+    }
+
+    @Test
+    fun `merge matches a single weighted pass over higher moments`() {
+        val left = listOf(10.0 to 2.0, 12.0 to 0.5, 11.0 to 1.25)
+        val right = listOf(100.0 to 3.0, 120.0 to 0.75)
+
+        val merged = MomentsStat().apply { left.forEach { (x, w) -> update(x, w) } }
+        merged.merge(MomentsStat().apply { right.forEach { (x, w) -> update(x, w) } }.read())
+
+        assertMomentsEqual(reference(left + right), merged.read(), tolerance = 1e-7)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/VarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/VarianceStatTest.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.summary
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -99,6 +100,50 @@ class VarianceStatTest {
         val v = VarianceStat()
         repeat(100) { v.update(7.0) }
         assertEquals(0.0, v.read().variance, 1e-6)
+    }
+
+    @Test
+    fun `negative weight downdates the variance back to the prior state`() {
+        val v = VarianceStat()
+        v.update(1.0, 1.0)
+        v.update(5.0, 2.5)
+        val before = v.read()
+
+        v.update(11.0, 1.75)
+        v.update(11.0, -1.75)
+
+        val after = v.read()
+        assertEquals(before.totalWeights, after.totalWeights, 1e-9)
+        assertEquals(before.mean, after.mean, 1e-9)
+        assertEquals(before.variance, after.variance, 1e-9)
+    }
+
+    @Test
+    fun `downdate matches a fresh accumulator over the retained values`() {
+        val windowed = VarianceStat()
+        listOf(2.0, 4.0, 6.0, 8.0).forEach { windowed.update(it, 1.0) }
+        windowed.update(2.0, -1.0)
+
+        val fresh = VarianceStat()
+        listOf(4.0, 6.0, 8.0).forEach { fresh.update(it, 1.0) }
+
+        assertEquals(fresh.read().mean, windowed.read().mean, 1e-9)
+        assertEquals(fresh.read().variance, windowed.read().variance, 1e-9)
+    }
+
+    @Test
+    fun `a downdate that would exhaust the accumulated weight throws`() {
+        val v = VarianceStat()
+        v.update(1.0, 1.0)
+        v.update(5.0, 1.0)
+        val before = v.read()
+        assertFailsWith<IllegalArgumentException> { v.update(2.0, -2.0) }
+        val after = v.read()
+        assertEquals(before.totalWeights, after.totalWeights, DELTA)
+        assertEquals(before.mean, after.mean, DELTA)
+        assertEquals(before.variance, after.variance, DELTA)
+        assertFalse(after.variance.isNaN())
+        assertFalse(after.variance.isInfinite())
     }
 
     @Test


### PR DESCRIPTION
MomentsStat computed m3 and m4 with the unweighted Pebay coefficients, which are only valid when the incoming observation has weight exactly 1. Deriving the single-point case from the merge formula shows m3 needs a factor of (oldW - w)/w where the code had (nextW - 2), and m4 needs (oldW^2 - oldW*w + w^2)/w^2 where the code had (nextW^2 - 3*nextW + 3). A constant weight of 2.0 was enough to put skewness and kurtosis out by several hundred percent. Mean, m2 and variance were unaffected, which is why nothing downstream complained. Every existing test passed weight 1.0, and the merge test asserted only mean and totalWeights, so the whole weighted path was unguarded. The corrected coefficients are written over nextW rather than over weight so a very small weight does not divide out.

Negative weights now downdate rather than corrupting the accumulator. On MeanStat, VarianceStat and MomentsStat a negative weight removes an observation that was previously folded in, which is how a caller drives a sliding window by hand, and the recurrences invert exactly. VarianceStat needed no formula change: removing (x, w) from total W subtracts W*w*delta^2/(W-w), which is algebraically the same quantity the forward step added. The one rejected case is a downdate that would take the accumulated weight to zero or below, since every step divides by the new total and the accumulator would be left permanently non-finite. That check lives in core/Weights.kt and runs before any cell is mutated, so a throw leaves state intact. It is best effort under Concurrency.Relaxed, where the load and the following write are not atomic together, which matches that level's existing drift contract.

UnivariateRegressionResult.correlation derived r from sse/sst, but sse is evaluated at the penalised slope, so under Penalty.L1 with a lambda above the soft-thresholding cut the slope is exactly zero, sse equals sst, and a perfectly correlated stream reported a correlation of zero. It now computes sxy / sqrt(sxx * syy), which is a property of the two streams and independent of the penalty.

Fourteen tests were added. The moment tests check the recurrences against directly computed weighted central sums at constant and mixed weights, that an integer weight matches that many unit-weight updates, and that merge matches a single weighted pass. I confirmed these are not tautological by reverting the formula and re-running: exactly the five new moment tests fail while all fourteen pre-existing ones still pass. The downdate tests assert that update(x, w) followed by update(x, -w) restores all four moments and that a downdated accumulator matches a fresh one over the retained values, which is also independent evidence that the corrected coefficients are right.

Verified with jvmTest, jsNodeTest, linuxX64Test, lintDocs and checkKdoc.