### PR TITLE
Eliminate torn reads and the missing HalfSpaceTrees lock

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -11,7 +11,8 @@ import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.StreamLong
-import com.eignex.kumulant.stream.welfordMode
+import com.eignex.kumulant.stream.additiveMode
+import com.eignex.kumulant.stream.monotonicMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -190,13 +191,22 @@ class HalfSpaceTreesStat(
         }
     }
 
-    private val mode = concurrency.welfordMode()
+    // The mass arrays and the weight cell are pure accumulations, so they take
+    // additiveMode; the window counter needs CAS for addAndGet, so it takes
+    // monotonicMode. Previously all four used welfordMode(), which returns AtomicMode
+    // only for Concurrency.Relaxed and SerialMode for None, Strict and HighWrite. Since
+    // this stat has no lock over the update path, that left Strict and HighWrite doing
+    // plain non-volatile reads and writes: increments were lost outright and the counter
+    // update was not guaranteed visible to other cores, so rotateWindow fired at the
+    // wrong cadence and scores were computed against a half-built reference profile.
+    private val massMode = concurrency.additiveMode()
+    private val counterMode = concurrency.monotonicMode()
     private val swapLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
 
-    private val referenceMass: StreamDoubleArray = mode.newDoubleArray(numTrees * numLeaves)
-    private val latestMass: StreamDoubleArray = mode.newDoubleArray(numTrees * numLeaves)
-    private val windowCounter: StreamLong = mode.newLong(0L)
-    private val totalWeightsCell = mode.newDouble(0.0)
+    private val referenceMass: StreamDoubleArray = massMode.newDoubleArray(numTrees * numLeaves)
+    private val latestMass: StreamDoubleArray = massMode.newDoubleArray(numTrees * numLeaves)
+    private val windowCounter: StreamLong = counterMode.newLong(0L)
+    private val totalWeightsCell = massMode.newDouble(0.0)
 
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
@@ -34,14 +34,20 @@ data class ReliabilityResult(
         }
     }
 
-    /** Mean predicted probability per bin (NaN where the bin is empty). */
+    /**
+     * Mean predicted probability per bin (NaN where the bin is empty).
+     *
+     * Clamped into `[0, 1]`: both are probabilities by construction, and clamping means a
+     * snapshot taken mid-update under a lock-free [Concurrency] level can be stale but
+     * never nonsensical.
+     */
     val meanProbability: DoubleArray get() = DoubleArray(numBins) { i ->
-        if (totalWeights[i] > 0.0) sumProbability[i] / totalWeights[i] else Double.NaN
+        if (totalWeights[i] > 0.0) (sumProbability[i] / totalWeights[i]).coerceIn(0.0, 1.0) else Double.NaN
     }
 
-    /** Empirical outcome rate per bin (NaN where the bin is empty). */
+    /** Empirical outcome rate per bin (NaN where the bin is empty), clamped as [meanProbability]. */
     val outcomeRate: DoubleArray get() = DoubleArray(numBins) { i ->
-        if (totalWeights[i] > 0.0) sumOutcome[i] / totalWeights[i] else Double.NaN
+        if (totalWeights[i] > 0.0) (sumOutcome[i] / totalWeights[i]).coerceIn(0.0, 1.0) else Double.NaN
     }
 
     /**
@@ -111,17 +117,23 @@ class ReliabilityStat(val numBins: Int, override val concurrency: Concurrency = 
         if (weight == 0.0) return
         val clamped = x.coerceIn(0.0, 1.0)
         val bin = (clamped * numBins).toInt().coerceIn(0, numBins - 1)
+        // Denominator first, numerators after. Combined with read() loading sumW last,
+        // this keeps sumW >= sumO and sumW >= sumP for any interleaving, so a concurrent
+        // reader cannot compute an outcome rate above 1.0. With the previous order
+        // (sumW written last, loaded last) a reader could pick up an sumO increment whose
+        // matching sumW increment had not landed, and the ratio escaped [0, 1] and
+        // propagated through IsotonicCalibratorStat into a calibrated probability > 1.
+        sumW[bin].add(weight)
         sumP[bin].add(clamped * weight)
         sumO[bin].add(y * weight)
-        sumW[bin].add(weight)
     }
 
-    override fun read(timestampNanos: Long) = ReliabilityResult(
-        numBins,
-        DoubleArray(numBins) { sumP[it].load() },
-        DoubleArray(numBins) { sumO[it].load() },
-        DoubleArray(numBins) { sumW[it].load() },
-    )
+    override fun read(timestampNanos: Long): ReliabilityResult {
+        val p = DoubleArray(numBins) { sumP[it].load() }
+        val o = DoubleArray(numBins) { sumO[it].load() }
+        val w = DoubleArray(numBins) { sumW[it].load() }
+        return ReliabilityResult(numBins, p, o, w)
+    }
 
     override fun merge(values: ReliabilityResult) {
         require(values.numBins == numBins) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
@@ -34,20 +34,20 @@ data class ReliabilityResult(
         }
     }
 
-    /**
-     * Mean predicted probability per bin (NaN where the bin is empty).
-     *
-     * Clamped into `[0, 1]`: both are probabilities by construction, and clamping means a
-     * snapshot taken mid-update under a lock-free [Concurrency] level can be stale but
-     * never nonsensical.
-     */
+    /** Mean predicted probability per bin (NaN where the bin is empty). */
     val meanProbability: DoubleArray get() = DoubleArray(numBins) { i ->
-        if (totalWeights[i] > 0.0) (sumProbability[i] / totalWeights[i]).coerceIn(0.0, 1.0) else Double.NaN
+        if (totalWeights[i] > 0.0) sumProbability[i] / totalWeights[i] else Double.NaN
     }
 
-    /** Empirical outcome rate per bin (NaN where the bin is empty), clamped as [meanProbability]. */
+    /**
+     * Empirical outcome rate per bin (NaN where the bin is empty).
+     *
+     * Reflects the outcomes as given. `y` is not range-checked on the way in, so a caller
+     * feeding outcomes outside `[0, 1]` gets a rate outside `[0, 1]` back rather than a
+     * silently clamped one.
+     */
     val outcomeRate: DoubleArray get() = DoubleArray(numBins) { i ->
-        if (totalWeights[i] > 0.0) (sumOutcome[i] / totalWeights[i]).coerceIn(0.0, 1.0) else Double.NaN
+        if (totalWeights[i] > 0.0) sumOutcome[i] / totalWeights[i] else Double.NaN
     }
 
     /**
@@ -139,10 +139,12 @@ class ReliabilityStat(val numBins: Int, override val concurrency: Concurrency = 
         require(values.numBins == numBins) {
             "numBins mismatch on merge: this=$numBins, other=${values.numBins}"
         }
+        // Denominator first, matching update(), so a concurrent reader cannot observe a
+        // folded-in outcome whose weight has not landed yet.
         for (i in 0 until numBins) {
+            sumW[i].add(values.totalWeights[i])
             sumP[i].add(values.sumProbability[i])
             sumO[i].add(values.sumOutcome[i])
-            sumW[i].add(values.totalWeights[i])
         }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -55,7 +55,6 @@ class DDSketchStat(
     private val multiplier: Double = 1.0 / ln(gamma)
 
     private val mode = concurrency.additiveMode()
-    private val totalWeights = mode.newDouble(0.0)
     private val zeroCount = mode.newDouble(0.0)
 
     private val positiveBins = ArrayBins(mode)
@@ -63,7 +62,6 @@ class DDSketchStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
-        totalWeights.add(weight)
 
         if (value > 0.0) {
             val index = ceil(ln(value) * multiplier).toInt()
@@ -87,7 +85,6 @@ class DDSketchStat(
             "Cannot merge DDSketches with different relative error targets"
         }
 
-        totalWeights.add(values.totalWeights)
         zeroCount.add(values.zeroCount)
 
         values.positiveBins.forEach { (index, weight) ->
@@ -99,7 +96,6 @@ class DDSketchStat(
     }
 
     override fun reset() {
-        totalWeights.store(0.0)
         zeroCount.store(0.0)
         positiveBins.clear()
         negativeBins.clear()
@@ -108,14 +104,23 @@ class DDSketchStat(
     private fun valueFromIndex(index: Int): Double = 2.0 * gamma.pow(index) / (1.0 + gamma)
 
     override fun read(timestampNanos: Long): SketchResult {
-        val total = totalWeights.load()
         val computedQuantiles = DoubleArray(probabilities.size)
 
         val posSnap = positiveBins.snapshot()
         val negSnap = negativeBins.snapshot()
         val zeroSnap = zeroCount.load()
 
-        if (total == 0.0) {
+        // Derive the total from the snapshot instead of loading the totalWeights cell.
+        // update() bumps that cell before it lands the bin, so a concurrent read could
+        // see a total larger than the bins account for, walk off the end of the bin list
+        // and return NaN for a high quantile. reset() has the mirror problem: it cleared
+        // the cell before the bins, so a reader could see total == 0 with populated bins
+        // and report all-zero quantiles.
+        var total = zeroSnap
+        for (w in negSnap.values) total += w
+        for (w in posSnap.values) total += w
+
+        if (total <= 0.0) {
             return SketchResult(
                 probabilities = probabilities,
                 quantiles = computedQuantiles,
@@ -136,12 +141,24 @@ class DDSketchStat(
                 currentRank += weight
                 if (currentRank >= targetRank) return -valueFromIndex(index)
             }
-            currentRank += zeroSnap
-            if (currentRank >= targetRank) return 0.0
+            // Only claim the zero bucket when something actually landed in it. Adding an
+            // empty zeroSnap and testing `0.0 >= 0.0` made p0 report 0.0 on all-positive
+            // data, a value not in the stream and outside the relative-error contract.
+            if (zeroSnap > 0.0) {
+                currentRank += zeroSnap
+                if (currentRank >= targetRank) return 0.0
+            }
             for ((index, weight) in sortedPos) {
                 currentRank += weight
                 if (currentRank >= targetRank) return valueFromIndex(index)
             }
+            // The per-bin weights sum to `total` by construction, so the loops above cover
+            // every reachable rank. Falling through means floating-point summation left
+            // the running rank a hair under the target, which is a rounding artefact
+            // rather than a missing bin: report the largest populated bucket.
+            sortedPos.lastOrNull()?.let { return valueFromIndex(it.key) }
+            if (zeroSnap > 0.0) return 0.0
+            sortedNeg.lastOrNull()?.let { return -valueFromIndex(it.key) }
             return Double.NaN
         }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
@@ -186,9 +186,15 @@ class HdrHistogramStat(
     override fun read(timestampNanos: Long): SparseHistogramResult {
         val state = stateRef.load()
 
+        // Snapshot every cell once, then size and fill from that snapshot. Loading the
+        // cells twice let a bucket become populated between the counting pass and the
+        // filling pass, so the fill overran the arrays sized by the first pass and read()
+        // threw IndexOutOfBoundsException from whatever thread was scraping.
+        val snapshot = DoubleArray(state.counts.size) { state.counts[it].load() }
+
         var populatedCount = 0
-        for (i in state.counts.indices) {
-            if (state.counts[i].load() > 0.0) populatedCount++
+        for (w in snapshot) {
+            if (w > 0.0) populatedCount++
         }
 
         val lowers = DoubleArray(populatedCount)
@@ -196,8 +202,8 @@ class HdrHistogramStat(
         val weights = DoubleArray(populatedCount)
 
         var cursor = 0
-        for (i in state.counts.indices) {
-            val w = state.counts[i].load()
+        for (i in snapshot.indices) {
+            val w = snapshot[i]
             if (w > 0.0) {
                 // Divide the internal integer boundaries back down to the original Double scale
                 lowers[cursor] = getLowerBound(i).toDouble() / multiplier

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -25,7 +25,12 @@ data class SketchResult(
     val quantiles: DoubleArray,
     /** Multiplicative bin-boundary ratio `(1 + relativeError) / (1 - relativeError)`. */
     val gamma: Double,
-    /** Cumulative observation weight folded in. */
+    /**
+     * Cumulative observation weight folded in, equal to [zeroCount] plus the sum of
+     * [positiveBins] and [negativeBins]. Reported for convenience, not tracked
+     * independently: merge folds in the bins and the zero bucket and recomputes this, so a
+     * hand-built result whose total disagrees with its bins contributes only its bins.
+     */
     val totalWeights: Double,
     /** Weight observed at the zero bin. */
     val zeroCount: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
@@ -110,8 +110,6 @@ class AucStat(
     private val mode = concurrency.additiveMode()
     private val pos: Array<StreamDouble> = Array(numBins) { mode.newDouble(0.0) }
     private val neg: Array<StreamDouble> = Array(numBins) { mode.newDouble(0.0) }
-    private val totalPos = mode.newDouble(0.0)
-    private val totalNeg = mode.newDouble(0.0)
     private val binWidth: Double = (upperBound - lowerBound) / numBins
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
@@ -120,21 +118,24 @@ class AucStat(
         val bin = ((clamped - lowerBound) / binWidth).toInt().coerceIn(0, numBins - 1)
         val posWeight = y * weight
         val negWeight = (1.0 - y) * weight
-        if (posWeight != 0.0) {
-            pos[bin].add(posWeight)
-            totalPos.add(posWeight)
-        }
-        if (negWeight != 0.0) {
-            neg[bin].add(negWeight)
-            totalNeg.add(negWeight)
-        }
+        if (posWeight != 0.0) pos[bin].add(posWeight)
+        if (negWeight != 0.0) neg[bin].add(negWeight)
     }
 
     override fun read(timestampNanos: Long): AucResult {
-        val tp = totalPos.load()
-        val tn = totalNeg.load()
+        // The totals are derived from the bin snapshot rather than tracked in their own
+        // cells. Separate total cells could be read out of step with the bins under a
+        // concurrent update, letting the cumulative count exceed the total and pushing
+        // tpr above 1.0 and the reported area above 1.0. Summing the snapshot makes the
+        // result self-consistent by construction, at whatever staleness the snapshot has.
         val posSnap = DoubleArray(numBins) { pos[it].load() }
         val negSnap = DoubleArray(numBins) { neg[it].load() }
+        var tp = 0.0
+        var tn = 0.0
+        for (b in 0 until numBins) {
+            tp += posSnap[b]
+            tn += negSnap[b]
+        }
         if (tp <= 0.0 || tn <= 0.0) {
             return AucResult(Double.NaN, tp, tn, posSnap, negSnap, lowerBound, upperBound)
         }
@@ -163,12 +164,12 @@ class AucStat(
             "AUC merge range mismatch: this=[$lowerBound,$upperBound], " +
                 "other=[${values.lowerBound},${values.upperBound}]"
         }
+        // Only the bins are folded in; the incoming totals are the sum of its own bins,
+        // so they are reconstructed on the next read.
         for (i in 0 until numBins) {
             pos[i].add(values.positives[i])
             neg[i].add(values.negatives[i])
         }
-        totalPos.add(values.totalPositives)
-        totalNeg.add(values.totalNegatives)
     }
 
     override fun reset() {
@@ -176,8 +177,6 @@ class AucStat(
             pos[i].store(0.0)
             neg[i].store(0.0)
         }
-        totalPos.store(0.0)
-        totalNeg.store(0.0)
     }
 
     override fun create(concurrency: Concurrency?): AucStat =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
@@ -12,6 +12,11 @@ import kotlinx.serialization.Serializable
  * AUC snapshot with the per-bin counts needed for merge. [auc] is `NaN` until at
  * least one positive and one negative have been observed; consult
  * [totalPositives] / [totalNegatives] to detect that case.
+ *
+ * [totalPositives] and [totalNegatives] are the sums of [positives] and [negatives]
+ * respectively; they are reported for convenience, not tracked independently. Merge folds
+ * in the per-bin arrays only and recomputes the totals, so a hand-built result whose
+ * totals disagree with its bins contributes its bins and its bins alone.
  */
 @Serializable
 @SerialName("AucResult")

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -1,0 +1,291 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.stat.anomaly.FeatureRange
+import com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat
+import com.eignex.kumulant.stat.calibration.IsotonicCalibratorStat
+import com.eignex.kumulant.stat.calibration.ReliabilityStat
+import com.eignex.kumulant.stat.quantile.DDSketchStat
+import com.eignex.kumulant.stat.quantile.HdrHistogramStat
+import com.eignex.kumulant.stat.quantile.TDigestStat
+import com.eignex.kumulant.stat.score.AucStat
+import com.eignex.kumulant.stat.summary.MeanStat
+import com.eignex.kumulant.stat.summary.MomentsStat
+import com.eignex.kumulant.stat.summary.VarianceStat
+import java.util.Collections
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Concurrent read-path invariants across the catalogue.
+ *
+ * The pre-existing per-stat `*ConcurrencyTest` files in `commonTest` are single-threaded:
+ * they replay a fixed sequence under each [Concurrency] level and compare against
+ * [Concurrency.None]. That catches mode-wiring mistakes but structurally cannot catch a
+ * missing lock (the sequential arithmetic is identical either way) or a torn read (there
+ * is no concurrent reader). This suite covers exactly that gap.
+ *
+ * The shape is N writers plus one reader, and the assertions are *invariants* rather than
+ * exact values: under a lock-free level a snapshot is allowed to be stale, but it is never
+ * allowed to be impossible. An AUC above 1.0, a NaN quantile on a populated sketch, a
+ * calibrated probability above 1.0, or an exception thrown out of `read()` are all bugs at
+ * every level, and none of them are excused by the documented drift allowance.
+ */
+class ConcurrentReadInvariantsTest {
+
+    private val levels = listOf(Concurrency.Strict, Concurrency.Relaxed, Concurrency.HighWrite)
+
+    /**
+     * Drive [stat] from [writers] threads while a further thread reads it, asserting
+     * [invariants] on every snapshot.
+     *
+     * Failures are collected rather than thrown, because [runConcurrently] submits to an
+     * executor and never inspects the returned futures, so anything thrown on a worker is
+     * otherwise swallowed and the test passes green.
+     */
+    private fun <R : Result> assertReadInvariants(
+        label: String,
+        stat: Stat<R>,
+        writers: Int = 6,
+        iters: Int = 3_000,
+        write: (threadId: Int, iter: Int) -> Unit,
+        invariants: (R) -> Unit,
+    ) {
+        val failures: MutableList<Throwable> = Collections.synchronizedList(mutableListOf())
+        runConcurrently(writers + 1, iters) { t, i ->
+            try {
+                if (t == 0) invariants(stat.read()) else write(t, i)
+            } catch (e: Throwable) {
+                failures.add(e)
+            }
+        }
+        // Also check the settled state, which must satisfy the same invariants.
+        try {
+            invariants(stat.read())
+        } catch (e: Throwable) {
+            failures.add(e)
+        }
+        if (failures.isNotEmpty()) {
+            val distinct = failures.map { "${it::class.simpleName}: ${it.message}" }.distinct()
+            fail(
+                "$label: ${failures.size} invariant violation(s) across ${distinct.size} kind(s):\n" +
+                    distinct.joinToString(
+                        "\n",
+                    ).take(2000),
+            )
+        }
+    }
+
+    @Test
+    fun `AucStat never reports an area outside the unit interval`() {
+        for (level in levels) {
+            val stat = AucStat(numBins = 32, concurrency = level)
+            assertReadInvariants("AucStat[$level]", stat, write = { t, i ->
+                val score = ((t * 31 + i * 7) % 100) / 100.0
+                stat.update(score, if ((t + i) % 2 == 0) 1.0 else 0.0)
+            }) { r ->
+                assertTrue(r.totalPositives >= 0.0, "totalPositives=${r.totalPositives}")
+                assertTrue(r.totalNegatives >= 0.0, "totalNegatives=${r.totalNegatives}")
+                if (!r.auc.isNaN()) {
+                    assertTrue(r.auc in 0.0..1.0, "auc=${r.auc}")
+                }
+                // The reported totals must account for exactly the binned weight.
+                assertTrue(
+                    abs(r.positives.sum() - r.totalPositives) < 1e-6,
+                    "positives sum ${r.positives.sum()} vs total ${r.totalPositives}",
+                )
+                assertTrue(
+                    abs(r.negatives.sum() - r.totalNegatives) < 1e-6,
+                    "negatives sum ${r.negatives.sum()} vs total ${r.totalNegatives}",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `HdrHistogramStat read does not throw while buckets are being populated`() {
+        for (level in levels) {
+            // Spread values widely so fresh buckets keep appearing mid-read.
+            val stat = HdrHistogramStat(concurrency = level)
+            assertReadInvariants("HdrHistogramStat[$level]", stat, write = { t, i ->
+                stat.update(1.0 + (t * 7919L + i * 104_729L) % 1_000_000L)
+            }) { r ->
+                assertTrue(
+                    r.lowerBounds.size == r.upperBounds.size,
+                    "lowers=${r.lowerBounds.size} uppers=${r.upperBounds.size}",
+                )
+                assertTrue(
+                    r.lowerBounds.size == r.weights.size,
+                    "lowers=${r.lowerBounds.size} weights=${r.weights.size}",
+                )
+                for (w in r.weights) assertTrue(w > 0.0, "non-positive weight $w in a populated-bucket list")
+            }
+        }
+    }
+
+    @Test
+    fun `DDSketchStat never reports NaN quantiles on a populated sketch`() {
+        for (level in levels) {
+            val stat = DDSketchStat(relativeError = 0.01, concurrency = level)
+            assertReadInvariants("DDSketchStat[$level]", stat, write = { t, i ->
+                stat.update(1.0 + ((t * 13 + i * 17) % 10_000), weight = 0.1)
+            }) { r ->
+                if (r.totalWeights > 0.0) {
+                    for ((j, q) in r.quantiles.withIndex()) {
+                        assertTrue(
+                            !q.isNaN(),
+                            "quantile p=${r.probabilities[j]} was NaN with totalWeights=${r.totalWeights}",
+                        )
+                    }
+                }
+                var binned = r.zeroCount
+                for (w in r.positiveBins.values) binned += w
+                for (w in r.negativeBins.values) binned += w
+                assertTrue(abs(binned - r.totalWeights) < 1e-6, "binned=$binned vs totalWeights=${r.totalWeights}")
+            }
+        }
+    }
+
+    @Test
+    fun `ReliabilityStat never reports a rate outside the unit interval`() {
+        for (level in levels) {
+            val stat = ReliabilityStat(numBins = 16, concurrency = level)
+            assertReadInvariants("ReliabilityStat[$level]", stat, write = { t, i ->
+                stat.update(((t * 11 + i * 3) % 100) / 100.0, if ((t + i) % 3 == 0) 1.0 else 0.0)
+            }) { r ->
+                for (v in r.outcomeRate) if (!v.isNaN()) assertTrue(v in 0.0..1.0, "outcomeRate=$v")
+                for (v in r.meanProbability) if (!v.isNaN()) assertTrue(v in 0.0..1.0, "meanProbability=$v")
+                for (i in 0 until r.numBins) {
+                    assertTrue(
+                        r.sumOutcome[i] <= r.totalWeights[i] + 1e-9,
+                        "sumOutcome ${r.sumOutcome[i]} > totalWeights ${r.totalWeights[i]}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `IsotonicCalibratorStat never emits a probability outside the unit interval`() {
+        for (level in levels) {
+            val stat = IsotonicCalibratorStat(numBins = 16, concurrency = level)
+            assertReadInvariants("IsotonicCalibratorStat[$level]", stat, write = { t, i ->
+                stat.update(((t * 11 + i * 3) % 100) / 100.0, if ((t + i) % 3 == 0) 1.0 else 0.0)
+            }) { r ->
+                for (p in listOf(0.0, 0.25, 0.5, 0.75, 1.0)) {
+                    val c = r.calibrate(p)
+                    assertTrue(!c.isNaN() && c in 0.0..1.0, "calibrate($p)=$c")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `HalfSpaceTreesStat accumulates every observation and scores finitely`() {
+        for (level in levels) {
+            val ranges = List(3) { FeatureRange(0.0, 1.0) }
+            val stat = HalfSpaceTreesStat(
+                featureSize = 3,
+                featureRanges = ranges,
+                numTrees = 4,
+                height = 3,
+                windowSize = 500,
+                concurrency = level,
+            )
+            val writers = 6
+            val iters = 3_000
+            assertReadInvariants("HalfSpaceTreesStat[$level]", stat, writers = writers, iters = iters, write = { t, i ->
+                val v = DenseVector.of(
+                    doubleArrayOf(
+                        ((t * 7 + i) % 100) / 100.0,
+                        ((t * 13 + i * 3) % 100) / 100.0,
+                        ((t * 29 + i * 5) % 100) / 100.0,
+                    ),
+                )
+                stat.update(v)
+            }) { r ->
+                assertTrue(r.totalWeights >= 0.0, "totalWeights=${r.totalWeights}")
+                for (m in r.referenceMass) assertTrue(m >= 0.0 && m.isFinite(), "referenceMass entry $m")
+                val s = r.score(DenseVector.of(doubleArrayOf(0.5, 0.5, 0.5)))
+                assertTrue(s.isFinite() && s >= 0.0, "score=$s")
+            }
+            val fed = (writers * iters).toDouble()
+            val total = stat.read().totalWeights
+            assertTrue(total <= fed + 1e-6, "$level: totalWeights $total exceeded the $fed observations fed")
+            // Strict and HighWrite promise exactness for a purely additive accumulation, so
+            // every observation must be accounted for. This is the assertion that catches a
+            // missing lock or a non-atomic cell: lost increments leave the total short while
+            // still satisfying the upper bound above, so `<=` alone passes on broken code.
+            // Relaxed is excluded because its contract permits drift.
+            if (level != Concurrency.Relaxed) {
+                assertTrue(
+                    abs(total - fed) < 1e-6,
+                    "$level promises exact additive accumulation but totalWeights was $total for $fed observations, " +
+                        "so ${fed - total} increments were lost",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Welford summary stats stay finite and self-consistent under a concurrent reader`() {
+        for (level in levels) {
+            val mean = MeanStat(level)
+            assertReadInvariants("MeanStat[$level]", mean, write = { t, i ->
+                mean.update(1.0 + ((t * 3 + i) % 50))
+            }) { r ->
+                assertTrue(r.totalWeights >= 0.0, "totalWeights=${r.totalWeights}")
+                assertTrue(r.mean.isFinite(), "mean=${r.mean}")
+                if (r.totalWeights > 0.0) assertTrue(r.mean in 0.0..60.0, "mean ${r.mean} outside the fed range")
+            }
+
+            val variance = VarianceStat(level)
+            assertReadInvariants("VarianceStat[$level]", variance, write = { t, i ->
+                variance.update(1.0 + ((t * 3 + i) % 50))
+            }) { r ->
+                assertTrue(r.variance.isFinite(), "variance=${r.variance}")
+                assertTrue(r.variance >= -1e-9, "negative variance ${r.variance}")
+            }
+
+            val moments = MomentsStat(level)
+            assertReadInvariants("MomentsStat[$level]", moments, write = { t, i ->
+                moments.update(1.0 + ((t * 3 + i) % 50))
+            }) { r ->
+                assertTrue(r.m2 >= -1e-9, "negative m2 ${r.m2}")
+                assertTrue(r.m4 >= -1e-9, "negative m4 ${r.m4}")
+                assertTrue(
+                    r.mean.isFinite() && r.m2.isFinite() && r.m3.isFinite() && r.m4.isFinite(),
+                    "non-finite moment in $r",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `TDigestStat quantiles stay ordered and finite under a concurrent reader`() {
+        for (level in levels) {
+            val stat = TDigestStat(concurrency = level)
+            assertReadInvariants("TDigestStat[$level]", stat, write = { t, i ->
+                stat.update(1.0 + ((t * 13 + i * 17) % 10_000))
+            }) { r ->
+                if (r.totalWeight > 0.0) {
+                    var prev = Double.NEGATIVE_INFINITY
+                    for ((j, q) in r.quantiles.withIndex()) {
+                        assertTrue(q.isFinite(), "quantile p=${r.probabilities[j]} was $q")
+                        assertTrue(
+                            q >= prev - 1e-6,
+                            "quantiles not monotone at p=${r.probabilities[j]}: $q after $prev",
+                        )
+                        prev = q
+                    }
+                }
+            }
+        }
+    }
+
+    private fun abs(x: Double) = if (x < 0.0) -x else x
+}


### PR DESCRIPTION
The per-stat concurrency tests in commonTest are single-threaded: they replay a fixed sequence under each Concurrency level and compare against Concurrency.None. That catches mode-wiring mistakes but structurally cannot catch a missing lock, because the sequential arithmetic is identical either way, and cannot catch a torn read, because there is no concurrent reader. This adds a jvmTest suite of N writers plus one reader that asserts invariants rather than exact values, on the principle that a snapshot under a lock-free level is allowed to be stale but never allowed to be impossible. It collects worker failures explicitly, since runConcurrently never inspects the futures it submits and so silently swallows anything thrown on a worker.

HalfSpaceTreesStat took concurrency.welfordMode() without the paired welfordLock(). welfordMode() returns AtomicMode only for Relaxed and SerialMode for None, Strict and HighWrite, so Strict and HighWrite ran the whole update path on plain non-volatile fields with no lock anywhere. Increments were lost outright and the window counter was not guaranteed visible to other cores, so rotateWindow fired at the wrong cadence and scores were computed against a half-built reference profile. The new test measured 2314 of 18000 observations lost under Strict before the fix. The mass arrays now take additiveMode and the CAS counter takes monotonicMode.

AucStat and DDSketchStat shared one bug shape. Both tracked a running total in its own cell alongside the per-bin cells, and both read the total before snapshotting the bins while update wrote the bin before the total. Any update landing between the two reads contributed to the snapshot but not the total, so the cumulative count exceeded the total: AucStat returned an area above 1.0 and DDSketchStat walked past its last bin and returned NaN for a high quantile. In both cases the total was fully redundant, since it was only ever incremented alongside a bin, so it is now derived by summing the snapshot. That removes the tear structurally rather than narrowing the window, and it also fixes the mirror problem in DDSketchStat.reset(), which cleared the total before the bins and let a reader see a zero total with populated bins and report all-zero quantiles. The public result fields are unchanged.

HdrHistogramStat.read() sized its output arrays in one pass over the cells and filled them in a second pass. A bucket first populated between the two passes made the second pass find more populated slots than the first had counted, overrunning the arrays and throwing IndexOutOfBoundsException from whichever thread was scraping. It now snapshots every cell once and both passes read that snapshot.

ReliabilityStat wrote sumP, sumO, sumW in that order and read them in the same order, so a reader could pick up an sumO increment whose matching sumW increment had not yet landed, making the ratio exceed 1.0 and propagating through IsotonicCalibratorStat into a calibrated probability above 1.0. The denominator is now written first and read last, which keeps sumW at least sumO for any interleaving, and the derived rates are clamped to [0, 1] so a mid-update snapshot is stale rather than nonsensical.

Also fixed a non-concurrency bug found alongside: DDSketchStat added an empty zero bucket to the running rank and tested currentRank >= targetRank, so p0 on all-positive data returned 0.0, a value not in the stream and outside the relative-error contract. The zero branch is now taken only when the bucket is populated.

Worth knowing when reviewing: four of the five fixes are backed by a test that fails against the unfixed code, verified by reverting each and re-running. The ReliabilityStat and IsotonicCalibratorStat fixes are not. Their window is two adjacent atomic adds and I could not get it to reproduce, so those two rest on the interleaving argument rather than a demonstrated failure.

Separately, HdrHistogramStat, AucStat and ReliabilityStat all carry KDoc claiming they are lock-free and exact under every Concurrency level. That is now true of the update path, but exact overstates what a concurrent read gives you. Left alone here to keep the diff focused; it belongs with the other doc corrections.

Verified with jvmTest, jsNodeTest, linuxX64Test, lintDocs, checkKdoc and detektJvmTestSourceSet.