### PR TITLE
Structural equality for array-bearing results, and IndexedResult annotations

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -4,6 +4,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.Snapshotable
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.exp
@@ -21,7 +22,14 @@ import kotlin.random.Random
 data class Exp4State(
     /** Unnormalised per-expert weights; element `i` is `exp(eta · cumulative gain_i)`. */
     val weights: DoubleArray,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is Exp4State &&
+        weights.contentEquals(other.weights)
+
+    override fun hashCode(): Int = weights.contentHashCode()
+
+    override fun toString(): String = "Exp4State(weights=${weights.preview()})"
+}
 
 /**
  * Maps a context vector to a probability distribution over arms. Implementations are

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.ln
@@ -33,7 +34,31 @@ data class KnnArmResult(
     val weights: DoubleArray,
     /** Cumulative observation weight folded into this arm. */
     val totalWeight: Double,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is KnnArmResult &&
+        contexts.size == other.contexts.size && contexts.indices.all {
+            contexts[it].contentEquals(
+                other.contexts[it],
+            )
+        } &&
+        rewards.contentEquals(other.rewards) &&
+        weights.contentEquals(other.weights) &&
+        totalWeight == other.totalWeight
+
+    override fun hashCode(): Int {
+        var h = contexts.fold(0) { acc, a -> 31 * acc + a.contentHashCode() }
+        h = 31 * h + rewards.contentHashCode()
+        h = 31 * h + weights.contentHashCode()
+        h = 31 * h + totalWeight.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "KnnArmResult(" +
+        "contexts=List(${contexts.size}), " +
+        "rewards=${rewards.preview()}, " +
+        "weights=${weights.preview()}, " +
+        "totalWeight=$totalWeight)"
+}
 
 /**
  * Non-parametric contextual bandit: each arm keeps a bounded FIFO history of

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/ArrayPreview.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/ArrayPreview.kt
@@ -1,0 +1,17 @@
+package com.eignex.kumulant.core
+
+/**
+ * Rendering helpers for the array-backed fields of [Result] types.
+ *
+ * Results are routinely logged, and some of them carry large arrays: a HyperLogLog register
+ * bank is `2^precision` entries, a Count-Min sketch is `depth * width`. Dumping those in
+ * full turns one log line into thousands, so these render the contents only when the array
+ * is small enough to be worth reading and fall back to a type-and-length summary otherwise.
+ */
+private const val PREVIEW_LIMIT = 16
+
+internal fun DoubleArray.preview(): String = if (size <= PREVIEW_LIMIT) contentToString() else "DoubleArray(size=$size)"
+
+internal fun IntArray.preview(): String = if (size <= PREVIEW_LIMIT) contentToString() else "IntArray(size=$size)"
+
+internal fun LongArray.preview(): String = if (size <= PREVIEW_LIMIT) contentToString() else "LongArray(size=$size)"

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Results.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Results.kt
@@ -13,6 +13,8 @@ interface Result
  * fields (`Center`, `Scale`, `Low`, `High`) via the transparent unwrap performed by
  * those AST nodes.
  */
+@Serializable
+@SerialName("IndexedResult")
 data class IndexedResult(
     /** The per-coordinate primary snapshot. */
     val inner: Result,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.stream.StreamLong
@@ -23,7 +24,27 @@ import kotlin.math.pow
 @Serializable
 @SerialName("HyperLogLogResult")
 data class HyperLogLogResult(val estimate: Double, val precision: Int, val registers: IntArray, val totalSeen: Long) :
-    Result
+    Result {
+    override fun equals(other: Any?): Boolean = other is HyperLogLogResult &&
+        estimate == other.estimate &&
+        precision == other.precision &&
+        registers.contentEquals(other.registers) &&
+        totalSeen == other.totalSeen
+
+    override fun hashCode(): Int {
+        var h = estimate.hashCode()
+        h = 31 * h + precision.hashCode()
+        h = 31 * h + registers.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "HyperLogLogResult(" +
+        "estimate=$estimate, " +
+        "precision=$precision, " +
+        "registers=${registers.preview()}, " +
+        "totalSeen=$totalSeen)"
+}
 
 /**
  * HyperLogLog cardinality estimator with a small-range linear-counting fallback.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.stream.StreamLong
@@ -31,7 +32,30 @@ data class LinearCountingResult(
     val words: LongArray,
     /** Total observations the sketch has absorbed. */
     val totalSeen: Long,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is LinearCountingResult &&
+        estimate == other.estimate &&
+        bits == other.bits &&
+        unsetBits == other.unsetBits &&
+        words.contentEquals(other.words) &&
+        totalSeen == other.totalSeen
+
+    override fun hashCode(): Int {
+        var h = estimate.hashCode()
+        h = 31 * h + bits.hashCode()
+        h = 31 * h + unsetBits.hashCode()
+        h = 31 * h + words.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "LinearCountingResult(" +
+        "estimate=$estimate, " +
+        "bits=$bits, " +
+        "unsetBits=$unsetBits, " +
+        "words=${words.preview()}, " +
+        "totalSeen=$totalSeen)"
+}
 
 /**
  * Linear-counting cardinality estimator over a fixed [bits]-bit bitset.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.pow
@@ -33,7 +34,36 @@ data class SketchResult(
     val positiveBins: Map<Int, Double>,
     /** Negative-side bin counts keyed by signed log-bucket index. */
     val negativeBins: Map<Int, Double>,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is SketchResult &&
+        probabilities.contentEquals(other.probabilities) &&
+        quantiles.contentEquals(other.quantiles) &&
+        gamma == other.gamma &&
+        totalWeights == other.totalWeights &&
+        zeroCount == other.zeroCount &&
+        positiveBins == other.positiveBins &&
+        negativeBins == other.negativeBins
+
+    override fun hashCode(): Int {
+        var h = probabilities.contentHashCode()
+        h = 31 * h + quantiles.contentHashCode()
+        h = 31 * h + gamma.hashCode()
+        h = 31 * h + totalWeights.hashCode()
+        h = 31 * h + zeroCount.hashCode()
+        h = 31 * h + positiveBins.hashCode()
+        h = 31 * h + negativeBins.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "SketchResult(" +
+        "probabilities=${probabilities.preview()}, " +
+        "quantiles=${quantiles.preview()}, " +
+        "gamma=$gamma, " +
+        "totalWeights=$totalWeights, " +
+        "zeroCount=$zeroCount, " +
+        "positiveBins=$positiveBins, " +
+        "negativeBins=$negativeBins)"
+}
 
 /** Histogram as parallel `[lowerBounds, upperBounds)` bucket arrays with [weights]. */
 @Serializable
@@ -45,7 +75,24 @@ data class SparseHistogramResult(
     val upperBounds: DoubleArray,
     /** Observed weight per bucket; parallel to [lowerBounds] / [upperBounds]. */
     val weights: DoubleArray,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is SparseHistogramResult &&
+        lowerBounds.contentEquals(other.lowerBounds) &&
+        upperBounds.contentEquals(other.upperBounds) &&
+        weights.contentEquals(other.weights)
+
+    override fun hashCode(): Int {
+        var h = lowerBounds.contentHashCode()
+        h = 31 * h + upperBounds.contentHashCode()
+        h = 31 * h + weights.contentHashCode()
+        return h
+    }
+
+    override fun toString(): String = "SparseHistogramResult(" +
+        "lowerBounds=${lowerBounds.preview()}, " +
+        "upperBounds=${upperBounds.preview()}, " +
+        "weights=${weights.preview()})"
+}
 
 /** Project a [SketchResult] into a [SparseHistogramResult] by expanding its bin indices to bucket boundaries. */
 fun SketchResult.toSparseHistogram(): SparseHistogramResult {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.quantile
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
 import com.eignex.kumulant.stream.monotonicMode
@@ -32,7 +33,30 @@ data class ReservoirResult(
     val totalSeen: Long,
     /** Cumulative observation weight folded in. */
     val totalWeight: Double,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is ReservoirResult &&
+        values.contentEquals(other.values) &&
+        keys.contentEquals(other.keys) &&
+        capacity == other.capacity &&
+        totalSeen == other.totalSeen &&
+        totalWeight == other.totalWeight
+
+    override fun hashCode(): Int {
+        var h = values.contentHashCode()
+        h = 31 * h + keys.contentHashCode()
+        h = 31 * h + capacity.hashCode()
+        h = 31 * h + totalSeen.hashCode()
+        h = 31 * h + totalWeight.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "ReservoirResult(" +
+        "values=${values.preview()}, " +
+        "keys=${keys.preview()}, " +
+        "capacity=$capacity, " +
+        "totalSeen=$totalSeen, " +
+        "totalWeight=$totalWeight)"
+}
 
 /** Linear-interpolated quantile at [probability] from a reservoir sample (treats sample as unweighted). */
 fun ReservoirResult.quantile(probability: Double): Double {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.quantile
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import com.eignex.kumulant.stream.spinHint
@@ -33,7 +34,33 @@ data class TDigestResult(
     val totalWeight: Double,
     /** T-digest compression parameter; lower = more centroids, tighter quantiles. */
     val compression: Double,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is TDigestResult &&
+        probabilities.contentEquals(other.probabilities) &&
+        quantiles.contentEquals(other.quantiles) &&
+        means.contentEquals(other.means) &&
+        weights.contentEquals(other.weights) &&
+        totalWeight == other.totalWeight &&
+        compression == other.compression
+
+    override fun hashCode(): Int {
+        var h = probabilities.contentHashCode()
+        h = 31 * h + quantiles.contentHashCode()
+        h = 31 * h + means.contentHashCode()
+        h = 31 * h + weights.contentHashCode()
+        h = 31 * h + totalWeight.hashCode()
+        h = 31 * h + compression.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "TDigestResult(" +
+        "probabilities=${probabilities.preview()}, " +
+        "quantiles=${quantiles.preview()}, " +
+        "means=${means.preview()}, " +
+        "weights=${weights.preview()}, " +
+        "totalWeight=$totalWeight, " +
+        "compression=$compression)"
+}
 
 /** Convert centroids to a sparse histogram with bins centered on each centroid. */
 fun TDigestResult.toSparseHistogram(): SparseHistogramResult {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
 import com.eignex.kumulant.math.LongHasher
@@ -31,7 +32,26 @@ data class BloomFilterResult(
     val totalSeen: Long,
     /** Reference to the [LongHasher] that produced the bitset; resolved by [contains]. */
     val hasher: HasherRef = HasherRef.SplitMix64,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is BloomFilterResult &&
+        bits == other.bits &&
+        hashes == other.hashes &&
+        words.contentEquals(other.words) &&
+        totalSeen == other.totalSeen &&
+        hasher == other.hasher
+
+    override fun hashCode(): Int {
+        var h = bits.hashCode()
+        h = 31 * h + hashes.hashCode()
+        h = 31 * h + words.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        h = 31 * h + hasher.hashCode()
+        return h
+    }
+
+    override fun toString(): String =
+        "BloomFilterResult(bits=$bits, hashes=$hashes, words=${words.preview()}, totalSeen=$totalSeen, hasher=$hasher)"
+}
 
 /**
  * True iff every bit set during an `update(value)` is still set in `words`. Re-derives the

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
 import com.eignex.kumulant.math.LongHasher
@@ -31,7 +32,33 @@ data class CountMinSketchResult(
     val totalSeen: Long,
     /** Reference to the [LongHasher] that produced the counters; resolved by [estimate]. */
     val hasher: HasherRef = HasherRef.SplitMix64,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is CountMinSketchResult &&
+        depth == other.depth &&
+        width == other.width &&
+        seed == other.seed &&
+        counters.contentEquals(other.counters) &&
+        totalSeen == other.totalSeen &&
+        hasher == other.hasher
+
+    override fun hashCode(): Int {
+        var h = depth.hashCode()
+        h = 31 * h + width.hashCode()
+        h = 31 * h + seed.hashCode()
+        h = 31 * h + counters.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        h = 31 * h + hasher.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "CountMinSketchResult(" +
+        "depth=$depth, " +
+        "width=$width, " +
+        "seed=$seed, " +
+        "counters=${counters.preview()}, " +
+        "totalSeen=$totalSeen, " +
+        "hasher=$hasher)"
+}
 
 /**
  * Estimated weighted count of [value] - the minimum across rows. Re-derives the per-row

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
 import com.eignex.kumulant.math.splitmix64
@@ -29,7 +30,24 @@ data class MinHashResult(
     val signatures: LongArray,
     /** Number of `update(value)` calls absorbed; informational. */
     val totalSeen: Long,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is MinHashResult &&
+        numHashes == other.numHashes &&
+        seed == other.seed &&
+        signatures.contentEquals(other.signatures) &&
+        totalSeen == other.totalSeen
+
+    override fun hashCode(): Int {
+        var h = numHashes.hashCode()
+        h = 31 * h + seed.hashCode()
+        h = 31 * h + signatures.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        return h
+    }
+
+    override fun toString(): String =
+        "MinHashResult(numHashes=$numHashes, seed=$seed, signatures=${signatures.preview()}, totalSeen=$totalSeen)"
+}
 
 /**
  * Estimated Jaccard similarity between the two underlying sets - the fraction of slots

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.welfordLock
 import kotlinx.serialization.SerialName
@@ -23,7 +24,30 @@ data class HeavyHittersResult(
     val counts: LongArray,
     val errors: LongArray,
     val totalSeen: Long,
-) : Result
+) : Result {
+    override fun equals(other: Any?): Boolean = other is HeavyHittersResult &&
+        capacity == other.capacity &&
+        keys.contentEquals(other.keys) &&
+        counts.contentEquals(other.counts) &&
+        errors.contentEquals(other.errors) &&
+        totalSeen == other.totalSeen
+
+    override fun hashCode(): Int {
+        var h = capacity.hashCode()
+        h = 31 * h + keys.contentHashCode()
+        h = 31 * h + counts.contentHashCode()
+        h = 31 * h + errors.contentHashCode()
+        h = 31 * h + totalSeen.hashCode()
+        return h
+    }
+
+    override fun toString(): String = "HeavyHittersResult(" +
+        "capacity=$capacity, " +
+        "keys=${keys.preview()}, " +
+        "counts=${counts.preview()}, " +
+        "errors=${errors.preview()}, " +
+        "totalSeen=$totalSeen)"
+}
 
 /**
  * Heavy-hitters tracker; keeps the [capacity] most-frequent keys with

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/IndexedResultSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/IndexedResultSerializationTest.kt
@@ -1,0 +1,63 @@
+package com.eignex.kumulant.core
+
+import com.eignex.kumulant.stat.summary.WeightedMeanResult
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [IndexedResult] was the only result type in the library without `@Serializable` and
+ * `@SerialName`, so it had no generated serializer and no stable wire name while every
+ * sibling had both.
+ *
+ * Note what this does and does not establish. The annotations give it a serializer and a
+ * stable discriminator, which is what this test pins. Encoding it still requires the caller
+ * to supply a [SerializersModule] covering its `inner` field, because that field is typed as
+ * the open [Result] interface and so resolves polymorphically. This test registers the one
+ * subclass it needs; the library does not currently ship a module covering the whole result
+ * catalogue.
+ */
+class IndexedResultSerializationTest {
+
+    private val json = Json {
+        serializersModule = SerializersModule {
+            polymorphic(Result::class) {
+                subclass(WeightedMeanResult::class)
+                subclass(IndexedResult::class)
+            }
+        }
+    }
+
+    @Test
+    fun `IndexedResult round trips through JSON`() {
+        val original = IndexedResult(WeightedMeanResult(totalWeights = 4.0, mean = 2.5), index = 3)
+        val wire = json.encodeToString(original)
+        assertEquals(original, json.decodeFromString<IndexedResult>(wire))
+    }
+
+    @Test
+    fun `IndexedResult carries its declared wire name`() {
+        // Encoded through an explicit PolymorphicSerializer rather than `encodeToString<Result>`.
+        // The reified form resolves on JVM and JS but throws on Kotlin/Native, where a
+        // serializer for a non-@Serializable open interface cannot be looked up from the type
+        // alone. Anything shipping results by their interface type needs the explicit form to
+        // behave the same on every target.
+        val wire = json.encodeToString(
+            PolymorphicSerializer(Result::class),
+            IndexedResult(WeightedMeanResult(1.0, 1.0), 0),
+        )
+        assertTrue(wire.contains("IndexedResult"), "expected the declared @SerialName in $wire")
+    }
+
+    @Test
+    fun `a nested IndexedResult survives the round trip`() {
+        val nested = IndexedResult(IndexedResult(WeightedMeanResult(2.0, 8.0), index = 1), index = 0)
+        val wire = json.encodeToString(nested)
+        assertEquals(nested, json.decodeFromString<IndexedResult>(wire))
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ResultEqualityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ResultEqualityTest.kt
@@ -1,0 +1,99 @@
+package com.eignex.kumulant.core
+
+import com.eignex.kumulant.bandit.contextual.Exp4State
+import com.eignex.kumulant.stat.cardinality.HyperLogLogResult
+import com.eignex.kumulant.stat.cardinality.LinearCountingResult
+import com.eignex.kumulant.stat.quantile.ReservoirResult
+import com.eignex.kumulant.stat.quantile.SketchResult
+import com.eignex.kumulant.stat.quantile.SparseHistogramResult
+import com.eignex.kumulant.stat.quantile.TDigestResult
+import com.eignex.kumulant.stat.sketch.BloomFilterResult
+import com.eignex.kumulant.stat.sketch.CountMinSketchResult
+import com.eignex.kumulant.stat.sketch.HeavyHittersResult
+import com.eignex.kumulant.stat.sketch.MinHashResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Structural equality for the array-bearing result types.
+ *
+ * A Kotlin `data class` derives `equals` from its components, and array components compare
+ * by reference, so two structurally identical snapshots of these types used to be unequal.
+ * That contradicts the documented promise that results are structurally comparable, and it
+ * quietly made any `assertEquals` over them unable to pass.
+ */
+class ResultEqualityTest {
+
+    private fun sketch(quantiles: DoubleArray) = SketchResult(
+        probabilities = doubleArrayOf(0.5, 0.9),
+        quantiles = quantiles,
+        gamma = 1.02,
+        totalWeights = 10.0,
+        zeroCount = 0.0,
+        positiveBins = mapOf(1 to 4.0),
+        negativeBins = emptyMap(),
+    )
+
+    @Test
+    fun `identical snapshots compare equal and hash alike`() {
+        val pairs: List<Pair<Result, Result>> = listOf(
+            Exp4State(doubleArrayOf(1.0, 2.0)) to Exp4State(doubleArrayOf(1.0, 2.0)),
+            HyperLogLogResult(1.5, 4, intArrayOf(1, 2, 3), 9L) to
+                HyperLogLogResult(1.5, 4, intArrayOf(1, 2, 3), 9L),
+            LinearCountingResult(2.0, 64, 60L, longArrayOf(7L), 4L) to
+                LinearCountingResult(2.0, 64, 60L, longArrayOf(7L), 4L),
+            sketch(doubleArrayOf(1.0, 9.0)) to sketch(doubleArrayOf(1.0, 9.0)),
+            SparseHistogramResult(doubleArrayOf(0.0), doubleArrayOf(1.0), doubleArrayOf(3.0)) to
+                SparseHistogramResult(doubleArrayOf(0.0), doubleArrayOf(1.0), doubleArrayOf(3.0)),
+            ReservoirResult(doubleArrayOf(1.0), doubleArrayOf(0.5), 8, 3L, 3.0) to
+                ReservoirResult(doubleArrayOf(1.0), doubleArrayOf(0.5), 8, 3L, 3.0),
+            TDigestResult(doubleArrayOf(0.5), doubleArrayOf(2.0), doubleArrayOf(2.0), doubleArrayOf(1.0), 1.0, 100.0) to
+                TDigestResult(
+                    doubleArrayOf(0.5),
+                    doubleArrayOf(2.0),
+                    doubleArrayOf(2.0),
+                    doubleArrayOf(1.0),
+                    1.0,
+                    100.0,
+                ),
+            BloomFilterResult(64, 3, longArrayOf(5L), 2L) to BloomFilterResult(64, 3, longArrayOf(5L), 2L),
+            CountMinSketchResult(2, 4, 11L, longArrayOf(1L, 2L), 3L) to
+                CountMinSketchResult(2, 4, 11L, longArrayOf(1L, 2L), 3L),
+            MinHashResult(2, 7L, longArrayOf(9L, 8L), 5L) to MinHashResult(2, 7L, longArrayOf(9L, 8L), 5L),
+            HeavyHittersResult(4, longArrayOf(1L), longArrayOf(2L), longArrayOf(0L), 2L) to
+                HeavyHittersResult(4, longArrayOf(1L), longArrayOf(2L), longArrayOf(0L), 2L),
+        )
+        for ((a, b) in pairs) {
+            assertTrue(a !== b, "${a::class.simpleName}: test built the same instance twice")
+            assertEquals(a, b, "${a::class.simpleName} should compare structurally equal")
+            assertEquals(a.hashCode(), b.hashCode(), "${a::class.simpleName} hashCode should agree")
+        }
+    }
+
+    @Test
+    fun `a difference inside an array makes snapshots unequal`() {
+        assertNotEquals(sketch(doubleArrayOf(1.0, 9.0)), sketch(doubleArrayOf(1.0, 9.5)))
+        assertNotEquals(
+            HyperLogLogResult(1.5, 4, intArrayOf(1, 2, 3), 9L),
+            HyperLogLogResult(1.5, 4, intArrayOf(1, 2, 4), 9L),
+        )
+        assertNotEquals(
+            MinHashResult(2, 7L, longArrayOf(9L, 8L), 5L),
+            MinHashResult(2, 7L, longArrayOf(9L, 7L), 5L),
+        )
+    }
+
+    @Test
+    fun `toString reports array contents when small and a summary when large`() {
+        val small = HyperLogLogResult(1.0, 2, intArrayOf(1, 2), 2L).toString()
+        assertTrue(small.contains("registers=[1, 2]"), "small arrays should be rendered: $small")
+
+        // A real HLL register bank is 2^precision entries; dumping it would flood a log line.
+        val large = HyperLogLogResult(1.0, 14, IntArray(16_384), 99L).toString()
+        assertTrue(large.contains("registers=IntArray(size=16384)"), "large arrays should be summarised: $large")
+        assertFalse(large.length > 200, "summarised toString should stay short, was ${large.length} chars")
+    }
+}


### PR DESCRIPTION
Two defects, no redesign.

IndexedResult in core/Results.kt was the only result type in the library without @Serializable and @SerialName, while every sibling had both. It now has them, so it gets a generated serializer and a stable wire name. Worth being precise about what that buys: encoding it still requires the caller to supply a SerializersModule covering its inner field, because that field is typed as the open Result interface and resolves polymorphically. The test supplies one locally and says so, rather than implying the library ships one.

Twelve result types that hold arrays were data classes, so equals and hashCode were derived from their components, and array components compare by reference. Two structurally identical snapshots were therefore unequal, which contradicts the promise in module.md that results are structurally comparable, and it meant any assertEquals over these types could only ever fail. Six result types already overrode, so this was drift rather than a decision. Affected: Exp4State, KnnArmResult, HyperLogLogResult, LinearCountingResult, SketchResult, SparseHistogramResult, ReservoirResult, TDigestResult, BloomFilterResult, CountMinSketchResult, MinHashResult, HeavyHittersResult.

toString is included, since these are exactly the objects people log, but it summarises large arrays instead of dumping them. A HyperLogLog register bank is 2^precision entries, so contentToString would put sixteen thousand numbers into a single log line. Arrays of sixteen or fewer render in full, larger ones render as IntArray(size=16384). There is a test pinning both halves.

I expected fallout from adding equals, on the theory that assertions previously passing on reference comparison might start failing on a real discrepancy. There was none; the suite is unchanged.

One finding worth carrying forward. The IndexedResult test initially passed jvmTest and jsNodeTest and failed only linuxX64Test: Json.encodeToString<Result>(value) resolves on JVM and JS but throws on Kotlin/Native, because a serializer for a non-@Serializable open interface cannot be looked up from the reified type alone. The explicit PolymorphicSerializer(Result::class) form works everywhere and is what the test now uses. Since GroupResult.results is a Map<String, Result> and thirteen targets are published, any code or documentation example using the reified form is silently JVM and JS only.

Not addressed here, and not merely cosmetic: there is still no shipped SerializersModule covering the result catalogue, so the advertised path of shipping snapshots between processes does not work out of the box.

Verified with jvmTest, jsNodeTest, linuxX64Test, lintDocs, checkKdoc and detektMainJvm.