### PR TITLE
Bound DDSketch memory, cut Adwin and TDigest allocation, and measure the rest

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -196,7 +196,11 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
 
         is CounterRate -> CounterRateStat(concurrency, treatDecreaseAsReset)
 
-        is DDSketch -> DDSketchStat(relativeError, probabilities.toDoubleArray(), concurrency)
+        is DDSketch -> DDSketchStat(
+            relativeError = relativeError,
+            probabilities = probabilities.toDoubleArray(),
+            concurrency = concurrency,
+        )
 
         is FrugalQuantile -> FrugalQuantileStat(q, stepSize, initialEstimate, concurrency)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
@@ -110,10 +110,21 @@ class AdwinStat(
         }
     }
 
-    private fun bucketsOldestToNewest(): List<Bucket> {
-        val out = ArrayList<Bucket>()
-        for (k in rows.indices.reversed()) for (b in rows[k]) out.add(b)
-        return out
+    // Scratch buffer for the oldest-to-newest bucket walk, reused across updates. This used
+    // to allocate a fresh ArrayList plus backing array on every call, and the call happens at
+    // least once per observation, which made it the single largest allocator on the update
+    // path (measured at 277 B/op before this change).
+    private val orderedScratch: MutableList<Bucket> = ArrayList()
+
+    private fun bucketsOldestToNewest(): MutableList<Bucket> {
+        orderedScratch.clear()
+        // Indexed access rather than a for-in loop: kotlin.collections.ArrayDeque is a
+        // MutableList, so this avoids allocating an iterator per row per call.
+        for (k in rows.indices.reversed()) {
+            val row = rows[k]
+            for (i in 0 until row.size) orderedScratch.add(row[i])
+        }
+        return orderedScratch
     }
 
     private fun detectAndShrink(): Boolean {
@@ -123,6 +134,10 @@ class AdwinStat(
         val n = totalN.toDouble()
         val mean = totalSum / n
         val variance = max(0.0, totalSumSquares / n - mean * mean)
+        // Loop-invariant: depends only on deltaPrime, which is fixed for this call. It was
+        // previously recomputed for every candidate cut, so a wide window paid one `ln` per
+        // bucket for no reason.
+        val logTerm = ln(2.0 / deltaPrime)
         var n0 = 0L
         var sum0 = 0.0
         for (i in 0 until ordered.size - 1) {
@@ -134,7 +149,6 @@ class AdwinStat(
             val mean0 = sum0 / n0.toDouble()
             val mean1 = (totalSum - sum0) / n1.toDouble()
             val m = 1.0 / (1.0 / n0.toDouble() + 1.0 / n1.toDouble())
-            val logTerm = ln(2.0 / deltaPrime)
             val epsCut = sqrt(2.0 / m * variance * logTerm) + (2.0 / (3.0 * m)) * logTerm
             if (abs(mean0 - mean1) > epsCut) {
                 dropOldest(i + 1)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -21,10 +21,15 @@ import kotlin.math.pow
  * when the value range is unbounded; over [TDigestStat] when relative-error
  * guarantees are required.
  *
- * **Memory:** O(log(max/min) / log(1+[relativeError])) bins; typically a few
- * hundred to a few thousand bins for sub-percent error on real-world ranges.
+ * **Memory:** bounded by the indexable range, at
+ * `log([maxIndexableValue] / [minIndexableValue]) / log(1 + [relativeError])` bins;
+ * roughly 2400 bins at the defaults. Values outside the range fold into the edge
+ * bins and still count toward every rank, so the bound holds whatever the input.
+ * Narrow the range if you know your data's span and want fewer bins at a tighter
+ * [relativeError].
  *
  * **Update:** O(1) per observation; one `log`/bin-assignment + striped atomic add.
+ * `NaN` is dropped, since it has no rank to bin.
  *
  * **Concurrency:** Striped atomic adds on independent bins. Lock-free and
  * exact under every [Concurrency] level; increments commute, bin assignment
@@ -42,6 +47,16 @@ class DDSketchStat(
         0.99,
         0.999,
     ),
+    /**
+     * Smallest magnitude given its own bin. Anything smaller (but non-zero) folds into the
+     * bottom bin, so it still counts toward the rank but stops driving bin allocation.
+     */
+    val minIndexableValue: Double = 1e-9,
+    /**
+     * Largest magnitude given its own bin. Anything larger folds into the top bin, on the
+     * same terms as [minIndexableValue].
+     */
+    val maxIndexableValue: Double = 1e12,
     override val concurrency: Concurrency = Concurrency.None,
 ) : SeriesStat<SketchResult> {
 
@@ -49,10 +64,26 @@ class DDSketchStat(
         require(relativeError > 0.0 && relativeError < 1.0) {
             "Relative error must be strictly between 0.0 and 1.0; got $relativeError"
         }
+        require(minIndexableValue > 0.0) { "minIndexableValue must be positive; got $minIndexableValue" }
+        require(maxIndexableValue > minIndexableValue) {
+            "maxIndexableValue must exceed minIndexableValue; got $maxIndexableValue and $minIndexableValue"
+        }
     }
 
     private val gamma: Double = (1.0 + relativeError) / (1.0 - relativeError)
     private val multiplier: Double = 1.0 / ln(gamma)
+
+    // Bin indices are clamped to the band spanned by the indexable range. Without this the
+    // index is unbounded: the bin array spans min..max observed index and allocates a cell
+    // per index in between, so a single denormal next to a single huge value forces an
+    // enormous array. Measured before this bound, from exactly two observations: 2.4 MiB at
+    // the default relativeError, 28 MiB at 0.001, and 220 MiB at 1e-4. Far enough out the
+    // index also overflows Int and the resize is skipped, silently dropping the bins that
+    // had already accumulated.
+    private val minIndex: Int = ceil(ln(minIndexableValue) * multiplier).toInt()
+    private val maxIndex: Int = ceil(ln(maxIndexableValue) * multiplier).toInt()
+
+    private fun indexOf(magnitude: Double): Int = ceil(ln(magnitude) * multiplier).toInt().coerceIn(minIndex, maxIndex)
 
     private val mode = concurrency.additiveMode()
     private val zeroCount = mode.newDouble(0.0)
@@ -62,13 +93,15 @@ class DDSketchStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0) return
+        // NaN has no rank, so it cannot go in a bin. Previously it fell through the sign
+        // comparisons into the zero bucket and was silently counted as an observation of
+        // zero, which shifts every quantile. LinearHistogramStat already drops it.
+        if (value.isNaN()) return
 
         if (value > 0.0) {
-            val index = ceil(ln(value) * multiplier).toInt()
-            positiveBins.add(index, weight)
+            positiveBins.add(indexOf(value), weight)
         } else if (value < 0.0) {
-            val index = ceil(ln(-value) * multiplier).toInt()
-            negativeBins.add(index, weight)
+            negativeBins.add(indexOf(-value), weight)
         } else {
             zeroCount.add(weight)
         }
@@ -77,6 +110,8 @@ class DDSketchStat(
     override fun create(concurrency: Concurrency?) = DDSketchStat(
         relativeError,
         probabilities,
+        minIndexableValue,
+        maxIndexableValue,
         concurrency ?: this.concurrency,
     )
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -214,6 +214,53 @@ class TDigestStat(
         }
     }
 
+    // Scratch buffers for the buffer-ordering sort, reused across compressions. Only ever
+    // touched under compressLock, so no synchronisation of their own is needed.
+    private var sortIdx: IntArray = IntArray(0)
+    private var sortTmp: IntArray = IntArray(0)
+
+    /**
+     * Indices `0 until bufLen` ordered by `bufVal`, without boxing.
+     *
+     * This replaced `(0 until bufLen).sortedBy { bufVal[it] }`, which materialised a
+     * `List<Integer>` of `bufLen` boxed indices plus an ArrayList and ran a comparator sort.
+     * At the default compression the buffer holds 500 entries, so every flush allocated
+     * roughly 8 KiB of boxes; amortised over the updates that filled it, TDigest measured
+     * 82 B/op on the update path.
+     *
+     * Bottom-up merge sort keyed on `bufVal`. Stable, `O(n log n)`, and allocation-free after
+     * the first call, which matters because an insertion sort would be `O(n^2)` over a
+     * 500-entry buffer and cost more than the boxing it replaces.
+     */
+    private fun sortedBufferIndices(bufVal: DoubleArray, bufLen: Int): IntArray {
+        if (sortIdx.size < bufLen) {
+            sortIdx = IntArray(bufLen)
+            sortTmp = IntArray(bufLen)
+        }
+        val idx = sortIdx
+        for (i in 0 until bufLen) idx[i] = i
+        var width = 1
+        while (width < bufLen) {
+            var lo = 0
+            while (lo < bufLen) {
+                val mid = minOf(lo + width, bufLen)
+                val hi = minOf(lo + 2 * width, bufLen)
+                var a = lo
+                var b = mid
+                var k = lo
+                while (a < mid && b < hi) {
+                    sortTmp[k++] = if (bufVal[idx[a]] <= bufVal[idx[b]]) idx[a++] else idx[b++]
+                }
+                while (a < mid) sortTmp[k++] = idx[a++]
+                while (b < hi) sortTmp[k++] = idx[b++]
+                lo += 2 * width
+            }
+            sortTmp.copyInto(idx, 0, 0, bufLen)
+            width *= 2
+        }
+        return idx
+    }
+
     /** Merge the snapshot into [means]/[weights] under the k1 difference rule. */
     private fun compressInto(bufVal: DoubleArray, bufW: DoubleArray, bufLen: Int) {
         if (bufLen == 0 && means.isEmpty()) return
@@ -225,7 +272,7 @@ class TDigestStat(
         var i = 0
         var j = 0
         var c = 0
-        val bufIdx = (0 until bufLen).sortedBy { bufVal[it] }
+        val bufIdx = sortedBufferIndices(bufVal, bufLen)
         while (i < means.size && j < bufLen) {
             val bv = bufVal[bufIdx[j]]
             if (means[i] <= bv) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchNaNTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchNaNTest.kt
@@ -1,0 +1,27 @@
+package com.eignex.kumulant.stat.quantile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * NaN has no rank, so it cannot be binned. It used to fall through the sign comparisons in
+ * `update` into the zero bucket and be counted as an observation of zero, which drags every
+ * quantile toward zero. [LinearHistogramStat] already dropped it; this makes DDSketch agree.
+ */
+class DDSketchNaNTest {
+
+    @Test
+    fun `NaN is dropped rather than counted as zero`() {
+        val sketch = DDSketchStat(relativeError = 0.01, probabilities = doubleArrayOf(0.5))
+        sketch.update(Double.NaN)
+        val empty = sketch.read()
+        assertEquals(0.0, empty.totalWeights, 0.0, "NaN should not register as an observation")
+        assertEquals(0.0, empty.zeroCount, 0.0, "NaN should not land in the zero bucket")
+
+        listOf(10.0, 20.0, 30.0).forEach { sketch.update(it) }
+        sketch.update(Double.NaN)
+        val r = sketch.read()
+        assertEquals(3.0, r.totalWeights, 0.0, "NaN should leave the observation count alone")
+        assertEquals(0.0, r.zeroCount, 0.0)
+    }
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DDSketchMemoryBoundTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DDSketchMemoryBoundTest.kt
@@ -1,0 +1,68 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.stat.quantile.DDSketchStat
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The bounded-memory claim, enforced.
+ *
+ * DDSketch assigns a bin per distinct log-bucket index and its bin array spans the whole
+ * range between the smallest and largest index seen, allocating a cell for every index in
+ * between. With an unbounded index, two observations at opposite ends of the Double range
+ * were enough to force an enormous array. Measured before [DDSketchStat.minIndexableValue]
+ * and [DDSketchStat.maxIndexableValue] existed, from exactly two updates:
+ *
+ * | relativeError | heap growth |
+ * |---------------|-------------|
+ * | 0.01          | 2472 KiB    |
+ * | 0.001         | 28195 KiB   |
+ * | 0.0001        | 220521 KiB  |
+ *
+ * Beyond that, at a tight enough error target the index saturates `Int`, `maxIndex` overflows
+ * negative, the resize is skipped and previously accumulated bins are silently dropped.
+ */
+class DDSketchMemoryBoundTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun heapGrowth(body: () -> Unit): Long {
+        val id = Thread.currentThread().threadId()
+        val before = bean.getThreadAllocatedBytes(id)
+        body()
+        return bean.getThreadAllocatedBytes(id) - before
+    }
+
+    @Test
+    fun `extreme values do not blow up the bin array`() {
+        val limits = mapOf(0.01 to 512L * 1024, 0.001 to 4L * 1024 * 1024)
+        for ((relativeError, limit) in limits) {
+            val sketch = DDSketchStat(relativeError = relativeError)
+            sketch.update(1.0)
+            val grown = heapGrowth {
+                sketch.update(Double.MIN_VALUE)
+                sketch.update(Double.MAX_VALUE)
+            }
+            assertTrue(
+                grown <= limit,
+                "relativeError=$relativeError grew the heap by ${grown / 1024} KiB on two " +
+                    "extreme observations, expected at most ${limit / 1024} KiB",
+            )
+        }
+    }
+
+    @Test
+    fun `out-of-range values still count toward the rank`() {
+        val sketch = DDSketchStat(relativeError = 0.01, probabilities = doubleArrayOf(0.5))
+        sketch.update(Double.MIN_VALUE)
+        sketch.update(1.0)
+        sketch.update(Double.MAX_VALUE)
+        val r = sketch.read()
+        // Folding into the edge bins must not lose the observation: the total still sees all
+        // three, so quantile ranks stay correct even where the value is clamped.
+        assertTrue(r.totalWeights == 3.0, "expected all three observations counted, got ${r.totalWeights}")
+        assertTrue(r.quantiles[0] > 0.0 && r.quantiles[0].isFinite(), "p50 was ${r.quantiles[0]}")
+    }
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
@@ -1,0 +1,130 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stat.change.AdwinStat
+import com.eignex.kumulant.stat.quantile.DDSketchStat
+import com.eignex.kumulant.stat.quantile.HdrHistogramStat
+import com.eignex.kumulant.stat.quantile.TDigestStat
+import com.eignex.kumulant.stat.summary.MeanStat
+import com.eignex.kumulant.stat.summary.MomentsStat
+import com.eignex.kumulant.stat.summary.SumStat
+import com.eignex.kumulant.stat.summary.VarianceStat
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Allocation on the update path, measured rather than assumed.
+ *
+ * kotlinx-benchmark 0.4.13 does not expose JMH's `gc` profiler - its `advanced` options are
+ * limited to fork and bridge settings - so per-operation allocation is invisible to the
+ * benchmark suite. This measures it directly through the HotSpot thread allocation counter,
+ * which is exact for a single-threaded loop and cheap enough to run as an ordinary test.
+ *
+ * Thresholds are ceilings meant to catch a regression, not exact figures. Measured values at
+ * the time of writing are in each assertion's message.
+ */
+class UpdateAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    /**
+     * Loop body taking a primitive `Int`.
+     *
+     * A Kotlin `(Int) -> Unit` compiles to `Function1<Integer, Unit>`, so every call boxes the
+     * index and the harness allocates 16 B per iteration, swamping what is being measured. A
+     * `fun interface` over a primitive parameter compiles to `(I)V` and allocates nothing.
+     */
+    private fun interface IntBody {
+        fun run(i: Int)
+    }
+
+    /**
+     * Best-of-five bytes per iteration.
+     *
+     * Warmup matters more than it looks: at 20k iterations the JIT has not settled and even a
+     * genuinely allocation-free stat reports several bytes per op. Taking the minimum of
+     * several passes after a 50k warmup removes that noise.
+     */
+    private fun bytesPerOp(iterations: Int, body: IntBody): Double {
+        repeat(50_000) { body.run(it) }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            for (i in 0 until iterations) body.run(i)
+            val after = bean.getThreadAllocatedBytes(id)
+            val per = (after - before).toDouble() / iterations
+            if (per < best) best = per
+        }
+        return best
+    }
+
+    private fun assertUpdateAllocation(name: String, limit: Double, stat: SeriesStat<*>, span: Int = 97) {
+        val perOp = bytesPerOp(200_000) { i -> stat.update(1.0 + (i % span), 0L, 1.0) }
+        assertTrue(perOp <= limit, "$name allocated $perOp B/update, expected at most $limit")
+    }
+
+    @Test
+    fun `summary stats allocate nothing per update`() {
+        assertUpdateAllocation("SumStat", 0.0, SumStat(Concurrency.None))
+        assertUpdateAllocation("MeanStat", 0.0, MeanStat(Concurrency.None))
+        assertUpdateAllocation("VarianceStat", 0.0, VarianceStat(Concurrency.None))
+        assertUpdateAllocation("MomentsStat", 0.0, MomentsStat(Concurrency.None))
+    }
+
+    /**
+     * The cost of the lock, pinned as it actually behaves.
+     *
+     * `update` bodies are written `lock.withLock { ... }`, and `withLock` is a non-inline
+     * interface method, so each call constructs a capturing lambda. Whether that lambda costs
+     * anything depends on the call site:
+     *
+     * - Under [Concurrency.None] the lock is `NoopMutex` and the measured cost is zero.
+     * - Under [Concurrency.Strict] it is 32 B/update **once more than one `Mutex`
+     *   implementation is live in the process**. Measured in isolation this test reports zero,
+     *   because the call site stays monomorphic and the JIT scalar-replaces the lambda; measured
+     *   in a full-suite run, where both `NoopMutex` and `PlatformMutex` have been used, escape
+     *   analysis gives up and the allocation is real. A real application looks like the latter.
+     *
+     * Removing it needs an `enter`/`exit` split so no lambda is constructed at all, which
+     * touches every platform's `PlatformMutex` plus every `update` body. Not done here; this
+     * pins the current cost so the eventual fix has a baseline and a regression cannot creep in.
+     * Kotlin/Native has no comparable escape analysis and cannot be measured with this counter,
+     * so the cost there is likely unconditional.
+     */
+    @Test
+    fun `the lock allocation on the update path stays at its known cost`() {
+        assertUpdateAllocation("MeanStat[None]", 0.0, MeanStat(Concurrency.None))
+        assertUpdateAllocation("MeanStat[Strict]", 48.0, MeanStat(Concurrency.Strict))
+        assertUpdateAllocation("MomentsStat[Strict]", 48.0, MomentsStat(Concurrency.Strict))
+    }
+
+    @Test
+    fun `sketches allocate nothing per update`() {
+        assertUpdateAllocation("DDSketchStat", 0.0, DDSketchStat(concurrency = Concurrency.None), span = 9973)
+        assertUpdateAllocation("HdrHistogramStat", 0.0, HdrHistogramStat(concurrency = Concurrency.None))
+    }
+
+    /**
+     * Ceilings for the two stats that allocate by design, as tripwires against a large
+     * regression rather than as precise figures.
+     *
+     * These are deliberately loose. Unlike the zero-allocation assertions above, which are
+     * exact because zero is zero, an amortised figure moves with the JIT state left behind by
+     * whatever ran before it: TDigest measures ~55 B/op when this class runs alone and ~86
+     * B/op in a full-suite run. The ceilings sit above the noisier of the two.
+     */
+    @Test
+    fun `the amortised allocators stay under their ceiling`() {
+        // AdwinStat allocates one Bucket per observation by design, and its bucket-walk scratch
+        // buffer grows with the window. Measured 277 B/op before the scratch buffer was made
+        // reusable, 75 B/op after.
+        assertUpdateAllocation("AdwinStat", 160.0, AdwinStat(concurrency = Concurrency.None))
+        // TDigestStat allocates the merged centroid arrays once per compression epoch, amortised
+        // over the buffer. Measured 82 B/op before the index sort stopped boxing, 55 B/op after.
+        assertUpdateAllocation("TDigestStat", 130.0, TDigestStat(concurrency = Concurrency.None), span = 9973)
+    }
+}


### PR DESCRIPTION
Measurement first, and the measurements changed what was worth fixing.

kotlinx-benchmark 0.4.13 does not expose JMH's gc profiler, so per-operation allocation was invisible to the benchmark suite. Rather than add a report nobody reads, this measures allocation directly through the HotSpot thread allocation counter in an ordinary jvmTest, which is exact for a single-threaded loop and becomes a permanent guard.

Two false starts worth recording, because both produced confident wrong numbers. The first harness took a (Int) -> Unit loop body, which compiles to Function1<Integer, Unit> and boxes the index, so the harness itself allocated 16 B per iteration and swamped everything. The second used 20k warmup iterations, which is not enough for the JIT to settle and reported several bytes per op for stats that allocate nothing. The final harness uses a fun interface over a primitive Int, a 50k warmup, and best-of-five.

Measured results on the update path:

| stat | before | after |
|---|---|---|
| AdwinStat | 277 B/op | 75 B/op |
| TDigestStat | 82 B/op | 54 B/op |
| Sum, Mean, Variance, Moments | 0 B/op | 0 B/op |
| DDSketch, HdrHistogram | 0 B/op | 0 B/op |

DDSketch memory was the real bug. Bin indices were unbounded, and the bin array spans the whole range between the smallest and largest index seen, allocating a cell for every index in between. Two observations at opposite ends of the Double range were enough to force an enormous array. Measured from exactly two updates: 2472 KiB at the default relativeError, 28 MiB at 0.001, and 220 MiB at 1e-4. Far enough out the index also overflows Int, maxIndex goes negative, the resize is skipped and the bins accumulated so far are silently dropped. There are now minIndexableValue and maxIndexableValue parameters, defaulting to 1e-9 and 1e12, and values outside the range fold into the edge bins so they still count toward every rank. The same two updates now cost 93 KiB, 730 KiB and 8.3 MiB.

DDSketch also silently counted NaN as an observation of zero: it fell through both sign comparisons into the zero bucket, dragging every quantile toward zero. LinearHistogramStat already dropped it; DDSketch now agrees.

AdwinStat allocated a fresh ArrayList plus backing array on every call to its oldest-to-newest bucket walk, and that call happens at least once per observation. It now reuses a scratch buffer and iterates by index rather than allocating a per-row iterator. The loop-invariant ln(2/deltaPrime) also moved out of the cut scan, where it was recomputed once per candidate cut.

TDigestStat sorted its buffer with (0 until bufLen).sortedBy { bufVal[it] }, materialising a List<Integer> of boxed indices plus an ArrayList and a comparator sort, roughly 8 KiB of boxes per flush at the default compression. It now uses an allocation-free bottom-up merge sort over a reusable primitive index array. Merge sort rather than insertion sort because the buffer holds 500 entries at the default compression, where an O(n^2) sort would cost more than the boxing it replaced.

On the finding I got wrong twice, in both directions. The review's headline item was that Mutex.withLock allocates roughly 40 B/update across 28 stats because it is a non-inline interface method taking a lambda. Measured in isolation it is 0, and I reported that it did not hold. Measured in a full-suite run it is 32 B/update under Concurrency.Strict. The difference is the mechanism the review actually predicted: in isolation the call site stays monomorphic and the JIT scalar-replaces the lambda, but once both NoopMutex and PlatformMutex are live the site is polymorphic and escape analysis gives up. A production process looks like the second case, so 32 B/update is the true figure and the review was right. Fixing it needs an enter/exit split so no lambda is constructed, which touches four platform PlatformMutex implementations plus every update body and the return@withLock labels inside them. Too wide for this PR, so the test pins the current cost at a ceiling of 48 B/update with the reasoning written down, and the eventual fix has a baseline.

Left alone deliberately: read() allocates 12 to 16 KiB per call on HdrHistogram and DDSketch, which is the result arrays and is per read rather than per update. Adwin still allocates one Bucket per observation and TDigest still allocates merged centroid arrays per compression epoch; removing those means converting Bucket to parallel arrays, a redesign rather than a tidy-up. Ceilings pin both so they cannot regress silently.

Verified with jvmTest, jsNodeTest, linuxX64Test, lintDocs, checkKdoc, detektMainJvm and detektTestJvm.