### PR TITLE
Correct the README examples and document what an empty read reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ reference.
 
 ```kotlin
 dependencies {
-    implementation("com.eignex:kumulant:0.3.0")
+    implementation("com.eignex:kumulant:0.3.3")
 }
 ```
 
@@ -94,13 +94,18 @@ which.
 
 You can wrap a stat to change how it sees its input. Time-windowing,
 weighting, filtering, and pre-update transforms all stack on top of
-any stat. See the `operation` package overview on the Dokka site for
-the full adapter surface.
+any stat. Composition happens on the *spec*, then you materialize the
+result into a live accumulator. See the `schema.ops` package overview
+on the Dokka site for the full adapter surface.
 
 ```kotlin
-val recentMean = MeanStat().windowed(1.minutes, slices = 10)
+val recentMean = Mean.windowed(durationMillis = 60_000, slices = 10).materialize()
 val positiveMean = Mean.filter(X gt 0.0).materialize()
 ```
+
+Composing on the spec rather than on a live stat is what lets the same
+composition travel over the wire, since the spec is data and the
+adapters that implement it are an internal detail.
 
 ## Sending stats over the wire
 
@@ -119,10 +124,21 @@ object Telemetry : StatSchema(concurrency = Concurrency.Strict) {
     val uniqueUsers by discrete(HyperLogLog(precision = 14))
 }
 
-val group = StatGroup(Telemetry)
-group.update(value = 12.7)
-val p99 = group.read()[Telemetry.latencyP99]
+val latencies = StatGroup(Telemetry)
+latencies.update(value = 12.7)
+val p99 = latencies.read()[Telemetry.latencyP99]
+
+// A schema can mix modalities, and each one is driven by its own group,
+// because a scalar observation and a discrete key are not the same input.
+val users = DiscreteStatGroup(Telemetry)
+users.update(value = userIdHash)
+val distinctUsers = users.read()[Telemetry.uniqueUsers]
 ```
+
+`StatGroup` covers the `series` entries, `DiscreteStatGroup` the
+`discrete` ones, and `PairedStatGroup` / `VectorStatGroup` the
+remaining modalities. Reading a key from the group that does not own it
+throws, so pick the group that matches the entry.
 
 ## Bandits
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
@@ -89,6 +89,36 @@ inside a [com.eignex.kumulant.schema.runtime.StatSchema] with the desired
 `concurrency`; the schema propagates the choice to every registered stat
 at delegate registration.
 
+## Reading an empty accumulator
+
+`read()` on a stat that has seen no observations is always legal and never
+throws, but what it reports is per-family rather than uniform. The four
+conventions in use, all observed rather than intended:
+
+| Family | Empty read reports |
+|--------|--------------------|
+| Sum, Count, BernoulliSum | `0.0`, the additive identity |
+| Mean, Variance, Moments | `0.0` for every field |
+| Min, Max | `+Infinity` / `-Infinity`, the comparison identities |
+| HdrHistogram, LinearHistogram, Reservoir | empty arrays |
+| Auc | `NaN` |
+| DDSketch, TDigest | `0.0` for every requested quantile |
+
+The last row is the one to watch. A p99 of `0.0` from an empty sketch is
+indistinguishable from a p99 of `0.0` computed over real zero-valued data,
+and on a latency dashboard it reads as healthy rather than as absent. Until
+that is unified, gate on the observation count before trusting a quantile:
+
+```kotlin
+val r = sketch.read()
+val p99 = if (r.totalWeights > 0.0) r.quantiles.last() else null
+```
+
+Every result carries the count needed for that check, whether as
+`totalWeights`, `totalSeen`, or a per-bin weight array, so the guard is
+always available. The `0.0`-versus-`NaN` divergence is a known
+inconsistency, not a deliberate per-family design.
+
 ## Lifecycle
 
 @sample com.eignex.kumulant.samples.basicMeanLifecycle

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
@@ -28,8 +28,8 @@ data class RateResult(val startTimestampNanos: Long, val totalValue: Double, val
  * first update.
  *
  * For time-decaying rates that weight recent observations more heavily, see
- * [DecayingRateStat]. Use [withValue][com.eignex.kumulant.operation.withValue]
- * to count each update as 1.
+ * [DecayingRateStat]. Use [withValue][com.eignex.kumulant.schema.ops.withValue] on
+ * the [Rate][com.eignex.kumulant.schema.spec.Rate] spec to count each update as 1.
  *
  * **Use cases:** lifetime throughput (requests/sec since start, total bytes
  * divided by uptime). Pair with `withValue(1.0)` for an event-rate counter.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
@@ -33,8 +33,10 @@ data class WeightedMeanResult(
  * Chan's parallel algorithm.
  *
  * **Use cases:** central-tendency monitoring on any scalar quantity. Compose
- * with [com.eignex.kumulant.operation.withValue] / `withWeight` to derive
- * other means (event rate, conditional mean, etc.).
+ * with [withValue][com.eignex.kumulant.schema.ops.withValue] /
+ * [withWeight][com.eignex.kumulant.schema.ops.withWeight] on the [Mean]
+ * [spec][com.eignex.kumulant.schema.spec.Mean] to derive other means (event rate,
+ * conditional mean, etc.), then `materialize()` the composed spec.
  *
  * **Memory:** O(1); two doubles plus a lock.
  *

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ReadmeExamplesTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ReadmeExamplesTest.kt
@@ -1,0 +1,64 @@
+package com.eignex.kumulant.schema
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.schema.expr.*
+import com.eignex.kumulant.schema.ops.*
+import com.eignex.kumulant.schema.runtime.*
+import com.eignex.kumulant.schema.spec.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The README's composition and schema examples, compiled and executed.
+ *
+ * These were both wrong before. The composition example called `MeanStat().windowed(...)`,
+ * but every `windowed` overload on a live stat is `internal`, so the snippet did not compile
+ * for a consumer at all. The schema example built a single `StatGroup` from a schema that
+ * mixes `series` and `discrete` entries, but `StatGroup` binds only the series specs, so the
+ * `discrete` entry was silently never updated and reading it threw.
+ *
+ * Keeping them here as a test is the only thing that stops that recurring: a README snippet
+ * nothing compiles is indistinguishable from a correct one until someone tries it.
+ */
+class ReadmeExamplesTest {
+
+    private object Telemetry : StatSchema(concurrency = Concurrency.Strict) {
+        val latencyMean by series(Mean)
+        val latencyP99 by series(DDSketch(probabilities = listOf(0.99)))
+        val errorRate by series(Rate)
+        val uniqueUsers by discrete(HyperLogLog(precision = 14))
+    }
+
+    @Test
+    fun `composing on a spec then materializing works`() {
+        val recentMean = Mean.windowed(durationMillis = 60_000, slices = 10).materialize()
+        val positiveMean = Mean.filter(X gt 0.0).materialize()
+
+        for (x in listOf(-5.0, 10.0, 20.0)) {
+            recentMean.update(x)
+            positiveMean.update(x)
+        }
+
+        // The filter drops the negative observation; the window keeps all three.
+        assertEquals(15.0, positiveMean.read().mean, 1e-9)
+        assertEquals(2.0, positiveMean.read().totalWeights, 1e-9)
+        assertEquals(3.0, recentMean.read().totalWeights, 1e-9)
+    }
+
+    @Test
+    fun `each modality in a mixed schema is driven by its own group`() {
+        val latencies = StatGroup(Telemetry)
+        latencies.update(value = 12.7)
+        latencies.update(value = 31.4)
+        val p99 = latencies.read()[Telemetry.latencyP99]
+        assertTrue(p99.quantiles.isNotEmpty(), "expected the sketch to report a p99")
+        assertEquals(2.0, latencies.read()[Telemetry.latencyMean].totalWeights, 1e-9)
+
+        val users = DiscreteStatGroup(Telemetry)
+        users.update(value = 0x9E3779B97F4A7C15uL.toLong())
+        users.update(value = 0x243F6A8885A308D3uL.toLong())
+        val distinct = users.read()[Telemetry.uniqueUsers]
+        assertTrue(distinct.estimate > 0.0, "expected a non-zero cardinality estimate")
+    }
+}


### PR DESCRIPTION
Both README code examples were wrong, in ways a reader could not have detected.

The composition example was `MeanStat().windowed(1.minutes, slices = 10)`. Every `windowed` overload on a live stat is internal, and the whole `operation` package has no public declarations, so that line did not compile for a consumer at all. It also pointed at an `operation` package overview on the Dokka site that does not exist, since that package has no package.md and is not in the Dokka includes. Composition is genuinely available, just on the spec rather than on a live stat: `Mean.windowed(durationMillis = 60_000, slices = 10).materialize()`, from the public `schema.ops` package, which does have a package.md and is included. The example now uses that form and says why it is the spec that composes, which is what lets the same composition travel over the wire.

The schema example built one `StatGroup` from a schema mixing `series` and `discrete` entries. `StatGroup` binds only the series specs, so `uniqueUsers` was never updated and reading it threw. The example now shows one group per modality, with a note that `StatGroup`, `DiscreteStatGroup`, `PairedStatGroup` and `VectorStatGroup` each cover their own entries.

Both examples are now a compiled test, ReadmeExamplesTest, that drives them and asserts the results. A README snippet nothing compiles is indistinguishable from a correct one until someone tries it, which is how both of these survived.

Also fixed: the install snippet pinned 0.3.0 while the current tag is v0.3.3, and two public KDoc blocks linked `com.eignex.kumulant.operation.withValue`, which is internal and therefore a dead link for any reader. Both now point at the public `schema.ops` equivalents.

Documented rather than changed: reading a stat that has seen no observations. There are four different conventions in the library, none previously written down. Sum and Count report 0.0, Mean and Variance report 0.0 for every field, Min and Max report the infinities, the array-backed histograms report empty arrays, Auc reports NaN, and DDSketch and TDigest report 0.0 for every requested quantile. The last one matters: a p99 of 0.0 from an empty sketch is indistinguishable from a p99 of 0.0 over real zero-valued data, and on a latency dashboard it reads as healthy rather than absent. Auc already returns NaN for the same situation, so the library disagrees with itself. core/package.md now carries the full table, flags that row explicitly, and shows the count-guard to use meanwhile. Unifying it is a semantic decision that will change published behaviour and break tests pinning the current values, so it is left for its own change rather than smuggled into a docs PR.

Verified with jvmTest, jsNodeTest, linuxX64Test, lintDocs, checkKdoc, detektMainJvm and detektTestJvm.