### PR TITLE
Pin negative-weight semantics per stat family (re-targeted onto main)

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -36,6 +36,27 @@ import com.eignex.kumulant.stream.currentTimeNanos
  * Checks beyond that are the caller's responsibility. Stats validate only where
  * the alternative is corrupted state, not to police inputs.
  *
+ * How that resolves per family, surveyed across the catalogue rather than assumed:
+ *
+ * - **Additive** (sums, counts, rates, decayed sums): subtraction, exactly as you
+ *   would expect. Nothing to guard.
+ * - **Welford** (mean, variance, moments): a downdate that inverts the update
+ *   exactly. The one rejected case is a downdate that would take the accumulated
+ *   weight to zero or below, since every step divides by the new total and the
+ *   accumulator would be left permanently non-finite.
+ * - **EWMA and decay**: a downdate. Over-subtracting drives the accumulated weight
+ *   negative, which is reported rather than hidden and recovers as soon as positive
+ *   weight arrives. [DecayingMeanStat][com.eignex.kumulant.stat.decay.DecayingMeanStat]
+ *   reports `NaN` while the decayed weight is negative, since there is no meaningful
+ *   mean of a negative amount of evidence; that is a sentinel, not a wedged state.
+ * - **Counting** (histograms, threshold buckets): the bin is a signed accumulation
+ *   rather than a population count, so subtraction can take a bin below zero.
+ *   Guarding it would break the legitimate case of retracting an earlier observation.
+ * - **Monotone sketches** (HyperLogLog, Bloom, MinHash): no inverse exists, since
+ *   these only ever set bits or take maxima. They ignore non-positive weights.
+ *
+ * `NegativeWeightSemanticsTest` pins each of these.
+ *
  * @param R The result type returned by [read]; always a [Result] subtype.
  *
  * @sample com.eignex.kumulant.samples.basicMeanLifecycle

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/NegativeWeightSemanticsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/NegativeWeightSemanticsTest.kt
@@ -1,0 +1,107 @@
+package com.eignex.kumulant.core
+
+import com.eignex.kumulant.stat.decay.DecayingMeanStat
+import com.eignex.kumulant.stat.decay.DecayingSumStat
+import com.eignex.kumulant.stat.decay.EwmaMeanStat
+import com.eignex.kumulant.stat.quantile.ThresholdBucketStat
+import com.eignex.kumulant.stat.summary.MeanStat
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * What a negative weight means, per family.
+ *
+ * The contract is that zero is a no-op and a negative weight does whatever is standard for
+ * the specific statistic, throwing only where the alternative is a corrupted accumulator.
+ * These tests pin the behaviour that was measured across the catalogue rather than assumed:
+ * every family surveyed treats a negative weight as a downdate, stays finite, and recovers
+ * when weight is added back. No family needed a new guard beyond the Welford summary stats,
+ * where an exhausted total is genuinely unrecoverable.
+ */
+class NegativeWeightSemanticsTest {
+
+    @Test
+    fun `additive stats subtract`() {
+        val sum = SumStat()
+        listOf(10.0, 20.0, 30.0).forEach { sum.update(it) }
+        sum.update(5.0, weight = -1.0)
+        assertEquals(55.0, sum.read().sum, 1e-9)
+    }
+
+    @Test
+    fun `a decaying sum subtracts and round-trips`() {
+        val decaying = DecayingSumStat(30.seconds)
+        listOf(10.0, 20.0).forEach { decaying.update(it, 0L, 1.0) }
+        val before = decaying.read(0L).sum
+        decaying.update(7.0, 0L, 1.0)
+        decaying.update(7.0, 0L, -1.0)
+        assertEquals(before, decaying.read(0L).sum, 1e-9)
+    }
+
+    @Test
+    fun `an EWMA downdate restores the prior state`() {
+        val ewma = EwmaMeanStat(alpha = 0.3)
+        listOf(10.0, 20.0, 30.0).forEach { ewma.update(it, 0L, 1.0) }
+        val before = ewma.read(0L)
+
+        repeat(6) { ewma.update(5.0, 0L, -1.0) }
+        // Over-subtracting drives the accumulated weight negative. The reported mean goes with
+        // it rather than becoming non-finite, and nothing is wedged.
+        val over = ewma.read(0L)
+        assertTrue(over.totalWeights < 0.0, "expected a negative accumulated weight, got $over")
+        assertTrue(over.mean.isFinite(), "mean should stay finite, was ${over.mean}")
+
+        repeat(6) { ewma.update(5.0, 0L, 1.0) }
+        val after = ewma.read(0L)
+        assertEquals(before.totalWeights, after.totalWeights, 1e-9)
+        assertEquals(before.mean, after.mean, 1e-9)
+    }
+
+    @Test
+    fun `a decaying mean reports NaN on negative effective weight and recovers`() {
+        val decaying = DecayingMeanStat(30.seconds)
+        listOf(10.0, 20.0, 30.0).forEach { decaying.update(it, 0L, 1.0) }
+        repeat(6) { decaying.update(5.0, 0L, -1.0) }
+
+        // This NaN is deliberate, not corruption: `read` has an explicit branch for a negative
+        // decayed weight, because there is no meaningful mean of a negative amount of evidence.
+        // It is a sentinel rather than a wedged state, which the recovery below establishes.
+        val over = decaying.read(0L)
+        assertTrue(over.totalWeights < 0.0, "expected a negative decayed weight, got $over")
+        assertTrue(over.mean.isNaN(), "expected the NaN sentinel, got ${over.mean}")
+
+        repeat(6) { decaying.update(5.0, 0L, 1.0) }
+        val after = decaying.read(0L)
+        assertTrue(after.mean.isFinite(), "mean should recover once weight is positive again")
+        assertEquals(20.0, after.mean, 1e-6)
+    }
+
+    @Test
+    fun `a bucket count can go negative so callers must not read it as a population`() {
+        val buckets = ThresholdBucketStat(doubleArrayOf(5.0, 15.0, 25.0))
+        buckets.update(1.0, weight = -1.0)
+        // Documented consequence of subtraction on a counting stat: the bucket is a signed
+        // accumulation, not a population count, so it can go below zero. Guarding it would
+        // break the legitimate case of retracting an observation that was counted earlier.
+        assertEquals(-1.0, buckets.read().counts[0], 1e-9)
+        buckets.update(1.0, weight = 1.0)
+        assertEquals(0.0, buckets.read().counts[0], 1e-9)
+    }
+
+    @Test
+    fun `Welford stats reject only the downdate that cannot be recovered`() {
+        val mean = MeanStat()
+        mean.update(10.0, weight = 2.0)
+        // A downdate inside the accumulated weight is fine.
+        mean.update(10.0, weight = -1.0)
+        assertEquals(1.0, mean.read().totalWeights, 1e-9)
+        // Exhausting it is not: every Welford step divides by the new total, so a zero or
+        // negative total leaves a permanently non-finite accumulator.
+        assertFailsWith<IllegalArgumentException> { mean.update(10.0, weight = -1.0) }
+        assertTrue(mean.read().mean.isFinite())
+    }
+}


### PR DESCRIPTION
Re-opens the content of #28, which merged into the wrong branch.

#28 was stacked on #23 with base fix/weighted-moments. #23 had already merged into main several hours earlier, so when #28 merged it went into that now-stale branch and its content never reached main. Stacking it was my mistake: once the base PR is merged, a stacked PR has to be re-targeted at main before it lands, and I did not flag that.

This is a clean cherry-pick of the single commit 8a03af9 onto current main. Nothing else from the old branch comes with it, which matters: feat/negative-weight-semantics branches off the pre-#24 tree, so a PR from it into main today would have reverted #24, #25 and #27 by deleting ConcurrentReadInvariantsTest, ResultEqualityTest, ReadmeExamplesTest and ArrayPreview.kt.

Content is unchanged from #28. No guards added and no behaviour changed: a test suite pinning what a negative weight means per family, and a table on the Stat contract documenting it. Additive stats subtract. Welford stats downdate exactly and reject only the downdate that exhausts the accumulated weight. EWMA and decay stats downdate and recover when weight is added back. Counting stats treat a bin as a signed accumulation so it can go below zero. Monotone sketches have no inverse and already ignore non-positive weights.

Re-verified against current main rather than against the old base, since the surrounding code has moved under it.