### PR TITLE
Take locks without allocating via an inline enter and exit split

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.schema.spec.ResampleAggregator
 import com.eignex.kumulant.stream.additiveMode
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlin.math.max
 import kotlin.math.min
@@ -49,17 +50,17 @@ internal class ResampleByTimeStat<R : Result>(
     private val maximum = streamMode.newDouble(Double.NEGATIVE_INFINITY)
     private val bucketEndTimestamp = streamMode.newLong(0L)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val newBucket = timestampNanos.floorDiv(bucketNanos)
         val cur = currentBucket.load()
         if (cur == NO_BUCKET) {
             currentBucket.store(newBucket)
             seed(value, timestampNanos)
-            return@withLock
+            return@guarded
         }
         if (newBucket == cur) {
             accumulate(value, timestampNanos)
-            return@withLock
+            return@guarded
         }
         // Bucket changed: flush the closed bucket and seed the new one.
         flushLocked()
@@ -98,7 +99,7 @@ internal class ResampleByTimeStat<R : Result>(
         delegate.update(value, bucketEndTimestamp.load(), weight = 1.0)
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         delegate.reset()
         currentBucket.store(NO_BUCKET)
         count.store(0L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -12,6 +12,7 @@ import com.eignex.kumulant.stream.PlatformMutex
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.additiveMode
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -220,8 +221,8 @@ class HalfSpaceTreesStat(
         if (n >= windowSize) rotateWindow()
     }
 
-    private fun rotateWindow() = swapLock.withLock {
-        if (windowCounter.load() < windowSize) return@withLock
+    private fun rotateWindow() = swapLock.guarded {
+        if (windowCounter.load() < windowSize) return@guarded
         windowCounter.store(0L)
         for (i in 0 until numTrees * numLeaves) {
             val latest = latestMass.load(i)
@@ -267,7 +268,7 @@ class HalfSpaceTreesStat(
         totalWeightsCell.add(values.totalWeights)
     }
 
-    override fun reset() = swapLock.withLock {
+    override fun reset() = swapLock.guarded {
         for (i in 0 until numTrees * numLeaves) {
             referenceMass.store(i, 0.0)
             latestMass.store(i, 0.0)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.change
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -84,7 +85,7 @@ class AdwinStat(
     private var changesDetected: Long = 0L
     private var lastUpdateRaisedAlarm: Boolean = false
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         rows[0].addLast(Bucket(n = 1L, sum = value, sumSquares = value * value))
         totalN += 1L
         totalSum += value
@@ -174,12 +175,12 @@ class AdwinStat(
         while (rows.size > 1 && rows.last().isEmpty()) rows.removeAt(rows.size - 1)
     }
 
-    override fun merge(values: AdwinResult) = lock.withLock {
+    override fun merge(values: AdwinResult) = lock.guarded {
         // No exact structural merge for the exponential histogram; carry over the change counter.
         changesDetected += values.changesDetected
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         rows.clear()
         rows.add(ArrayDeque())
         totalN = 0L
@@ -189,7 +190,7 @@ class AdwinStat(
         lastUpdateRaisedAlarm = false
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         val n = totalN
         val mean = if (n > 0L) totalSum / n.toDouble() else 0.0
         val variance = if (n > 0L) max(0.0, totalSumSquares / n.toDouble() - mean * mean) else 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.change
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -87,7 +88,7 @@ class PageHinkleyStat(
     private val minPos = streamMode.newDouble(0.0)
     private val maxNeg = streamMode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val n = count.load() + 1L
         count.store(n)
         val prevMean = mean.load()
@@ -102,12 +103,12 @@ class PageHinkleyStat(
         maxNeg.store(max(maxNeg.load(), cn))
     }
 
-    override fun merge(values: PageHinkleyResult) = lock.withLock {
+    override fun merge(values: PageHinkleyResult) = lock.guarded {
         // Approximate merge: weighted-average mean, then average the cumulative-drift cells.
         val localCount = count.load()
         val incomingCount = values.count
         val combinedCount = localCount + incomingCount
-        if (combinedCount == 0L) return@withLock
+        if (combinedCount == 0L) return@guarded
         val combinedMean =
             (mean.load() * localCount + values.mean * incomingCount) / combinedCount.toDouble()
         count.store(combinedCount)
@@ -118,7 +119,7 @@ class PageHinkleyStat(
         maxNeg.store(max(maxNeg.load(), values.maxNegative))
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         count.store(0L)
         mean.store(0.0)
         cumPos.store(0.0)
@@ -127,7 +128,7 @@ class PageHinkleyStat(
         maxNeg.store(0.0)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         val cp = cumPos.load()
         val cn = cumNeg.load()
         val mp = minPos.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stream.currentTimeNanos
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -86,8 +87,8 @@ class DecayingVarianceStat(
         landmarkNanos.store(t)
     }
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight <= 0.0) return@withLock
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight <= 0.0) return@guarded
         advanceTo(timestampNanos)
         val priorW = totalWeights.load()
         val nextW = priorW + weight
@@ -99,7 +100,7 @@ class DecayingVarianceStat(
         m2.add(weight * delta * (value - newMean))
     }
 
-    override fun read(timestampNanos: Long): DecayingVarianceResult = lock.withLock {
+    override fun read(timestampNanos: Long): DecayingVarianceResult = lock.guarded {
         val landmark = landmarkNanos.load()
         val priorW = totalWeights.load()
         val priorM2 = m2.load()
@@ -117,8 +118,8 @@ class DecayingVarianceStat(
         DecayingVarianceResult(mean.load(), variance, w, timestampNanos)
     }
 
-    override fun merge(values: DecayingVarianceResult) = lock.withLock {
-        if (values.totalWeights <= 0.0) return@withLock
+    override fun merge(values: DecayingVarianceResult) = lock.guarded {
+        if (values.totalWeights <= 0.0) return@guarded
         val target = maxOf(landmarkNanos.load(), values.timestampNanos)
         advanceTo(target)
         val remoteDecay = exp(-alpha * (target - values.timestampNanos).toDouble())
@@ -126,7 +127,7 @@ class DecayingVarianceStat(
         val remoteM2 = values.variance * remoteW
         val w1 = totalWeights.load()
         val nextW = w1 + remoteW
-        if (nextW == 0.0) return@withLock
+        if (nextW == 0.0) return@guarded
         val priorMean = mean.load()
         val delta = values.mean - priorMean
         mean.store(priorMean + delta * remoteW / nextW)
@@ -134,7 +135,7 @@ class DecayingVarianceStat(
         m2.add(remoteM2 + delta * delta * w1 * remoteW / nextW)
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         landmarkNanos.store(currentTimeNanos())
         totalWeights.store(0.0)
         mean.store(0.0)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.decay
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 
@@ -56,13 +57,13 @@ class EwmaMeanStat(
             return if (correction == 0.0) Double.NaN else biased / correction
         }
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val a = weighting.correction(weight)
         biasedMean.add(a * (value - biasedMean.load()))
         totalWeights.add(weight)
     }
 
-    override fun merge(values: WeightedMeanResult) = lock.withLock {
+    override fun merge(values: WeightedMeanResult) = lock.guarded {
         val localMean = this.mean
         val localWeight = totalWeights.load()
         val localEffectiveWeight = weighting.correction(localWeight)
@@ -72,7 +73,7 @@ class EwmaMeanStat(
         val remoteEffectiveWeight = weighting.correction(remoteWeight)
 
         val totalEffectiveWeight = localEffectiveWeight + remoteEffectiveWeight
-        if (totalEffectiveWeight == 0.0) return@withLock
+        if (totalEffectiveWeight == 0.0) return@guarded
 
         val mergedMean =
             (localMean * localEffectiveWeight + remoteMean * remoteEffectiveWeight) / totalEffectiveWeight
@@ -90,7 +91,7 @@ class EwmaMeanStat(
         totalWeights.store(0.0)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         WeightedMeanResult(totalWeights.load(), mean)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.decay
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 
@@ -59,7 +60,7 @@ class EwmaVarianceStat(
             return if (correction == 0.0) 0.0 else biasedVar / correction
         }
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val a = weighting.correction(weight)
 
         val currentRawMean = biasedMean.load()
@@ -73,16 +74,16 @@ class EwmaVarianceStat(
         totalWeights.add(weight)
     }
 
-    override fun merge(values: WeightedVarianceResult) = lock.withLock {
+    override fun merge(values: WeightedVarianceResult) = lock.guarded {
         val remoteWeightRaw = values.totalWeights
-        if (remoteWeightRaw <= 0.0) return@withLock
+        if (remoteWeightRaw <= 0.0) return@guarded
 
         val localWeightRaw = totalWeights.load()
         val w1 = weighting.correction(localWeightRaw)
         val w2 = weighting.correction(remoteWeightRaw)
         val wSum = w1 + w2
 
-        if (wSum == 0.0) return@withLock
+        if (wSum == 0.0) return@guarded
 
         val localMean = this.mean
         val localVar = this.variance
@@ -107,7 +108,7 @@ class EwmaVarianceStat(
         totalWeights.store(0.0)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         WeightedVarianceResult(
             totalWeights.load(),
             mean,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.event
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
@@ -57,7 +58,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
     private val maxExcursion = mode.newDouble(0.0)
     private val lastValue = mode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         lastValue.store(value)
         val seen = initialized.addAndGet(1L)
         if (seen == 1L) {
@@ -65,7 +66,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
             peakTs.store(timestampNanos)
             trough.store(value)
             troughTs.store(timestampNanos)
-            return@withLock
+            return@guarded
         }
         if (value > peak.load()) {
             peak.store(value)
@@ -80,7 +81,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
         }
     }
 
-    override fun merge(values: ExcursionResult) = lock.withLock {
+    override fun merge(values: ExcursionResult) = lock.guarded {
         val seen = initialized.addAndGet(1L)
         if (seen == 1L) {
             peak.store(values.peak)
@@ -89,7 +90,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
             troughTs.store(values.troughTimestampNanos)
             maxExcursion.store(values.maxExcursion)
             lastValue.store(values.peak - values.currentRecovery)
-            return@withLock
+            return@guarded
         }
         if (values.peak > peak.load()) {
             peak.store(values.peak)
@@ -102,7 +103,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
         if (values.maxExcursion > maxExcursion.load()) maxExcursion.store(values.maxExcursion)
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         initialized.store(0L)
         peak.store(Double.NEGATIVE_INFINITY)
         peakTs.store(0L)
@@ -112,7 +113,7 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
         lastValue.store(0.0)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         if (initialized.load() == 0L) {
             ExcursionResult(0.0, 0L, 0.0, 0L, 0.0, 0.0)
         } else {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/SojournStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/SojournStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.event
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
@@ -74,18 +75,18 @@ class SojournStat(
         return idx
     }
 
-    override fun update(value: Long, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Long, timestampNanos: Long, weight: Double) = lock.guarded {
         val newIdx = indexOfState(value)
         val curIdx = currentStateIndex.load()
         if (curIdx == NO_STATE) {
             currentStateIndex.store(newIdx.toLong())
             enterTimestamp.store(timestampNanos)
             transitions.store(newIdx, transitions.load(newIdx) + 1L)
-            return@withLock
+            return@guarded
         }
         if (curIdx.toInt() == newIdx) {
             // No transition; dwell extends silently.
-            return@withLock
+            return@guarded
         }
         val priorEnter = enterTimestamp.load()
         val elapsed = (timestampNanos - priorEnter).coerceAtLeast(0L)
@@ -95,13 +96,13 @@ class SojournStat(
         transitions.store(newIdx, transitions.load(newIdx) + 1L)
     }
 
-    override fun merge(values: SojournResult) = lock.withLock {
+    override fun merge(values: SojournResult) = lock.guarded {
         require(values.states == states) { "merge state alphabet ${values.states} != $states" }
         for (i in states.indices) {
             totalNanos.store(i, totalNanos.load(i) + values.totalNanosByState[i])
             transitions.store(i, transitions.load(i) + values.transitionsByState[i])
         }
-        if (!values.hasState) return@withLock
+        if (!values.hasState) return@guarded
         val incomingEnter = values.currentStateEnterTimestampNanos
         val localEnter = enterTimestamp.load()
         if (currentStateIndex.load() == NO_STATE || incomingEnter > localEnter) {
@@ -110,7 +111,7 @@ class SojournStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in states.indices) {
             totalNanos.store(i, 0L)
             transitions.store(i, 0L)
@@ -119,7 +120,7 @@ class SojournStat(
         enterTimestamp.store(0L)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         val curIdx = currentStateIndex.load()
         val has = curIdx != NO_STATE
         SojournResult(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/HoltStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/HoltStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.decay.DecayWeighting
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -106,11 +107,11 @@ class HoltStat(
     private val level = mode.newDouble(0.0)
     private val trend = mode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         if (initialized.addAndGet(1L) == 1L) {
             level.store(value)
             trend.store(0.0)
-            return@withLock
+            return@guarded
         }
         val a = alphaWeighting.correction(weight)
         val b = betaWeighting.correction(weight)
@@ -122,7 +123,7 @@ class HoltStat(
         trend.store(newTrend)
     }
 
-    override fun merge(values: HoltResult) = lock.withLock {
+    override fun merge(values: HoltResult) = lock.guarded {
         // No principled stat-level merge of two independent Holt traces; take the other's snapshot
         // as the new state once we have anything to merge into. Useful for windowed-slot folds.
         if (initialized.addAndGet(1L) == 1L) {
@@ -134,13 +135,13 @@ class HoltStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         initialized.store(0L)
         level.store(0.0)
         trend.store(0.0)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         HoltResult(level.load(), trend.load(), phi)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.decay.DecayWeighting
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -154,7 +155,7 @@ class SeasonalSmoothingStat(
     private val seasons = streamMode.newDoubleArray(period) { seasonInit.load() }
     private val slot = streamMode.newLong(0L)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val seen = initialized.addAndGet(1L)
         val currentSlot = (slot.load() % period).toInt()
         if (seen == 1L) {
@@ -162,7 +163,7 @@ class SeasonalSmoothingStat(
             trend.store(0.0)
             // Leave seasons at their identity (0 additive, 1 multiplicative) and advance the slot.
             slot.store((currentSlot + 1).toLong() % period)
-            return@withLock
+            return@guarded
         }
         val a = alphaWeighting.correction(weight)
         val b = betaWeighting.correction(weight)
@@ -191,7 +192,7 @@ class SeasonalSmoothingStat(
         slot.store((currentSlot + 1).toLong() % period)
     }
 
-    override fun merge(values: SeasonalSmoothingResult) = lock.withLock {
+    override fun merge(values: SeasonalSmoothingResult) = lock.guarded {
         require(values.seasons.size == period) { "merge seasons size ${values.seasons.size} != period $period" }
         if (initialized.addAndGet(1L) == 1L) {
             level.store(values.level)
@@ -207,7 +208,7 @@ class SeasonalSmoothingStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         initialized.store(0L)
         level.store(0.0)
         trend.store(0.0)
@@ -216,7 +217,7 @@ class SeasonalSmoothingStat(
         for (i in 0 until period) seasons.store(i, identity)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         SeasonalSmoothingResult(
             level = level.load(),
             trend = trend.load(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 
@@ -52,8 +53,8 @@ class FrugalQuantileStat(
     private val lock = concurrency.welfordLock()
     private val quantile = mode.newDouble(initialEstimate)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight <= 0.0) return@withLock
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight <= 0.0) return@guarded
 
         val m = quantile.load()
         val delta = if (value > m) {
@@ -76,7 +77,7 @@ class FrugalQuantileStat(
         concurrency ?: this.concurrency,
     )
 
-    override fun merge(values: QuantileResult) = lock.withLock {
+    override fun merge(values: QuantileResult) = lock.guarded {
         val current = quantile.load()
         quantile.store((current + values.quantile) / 2.0)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.welfordLock
 import kotlinx.serialization.SerialName
@@ -181,7 +182,7 @@ class ReservoirHistogramStat(
     private val totalWeightCell = mode.newDouble(0.0)
 
     private fun drawKey(weight: Double): Double {
-        val u = rngLock.withLock { random.nextDouble() }
+        val u = rngLock.guarded { random.nextDouble() }
         return if (weight == 1.0) u else u.pow(1.0 / weight)
     }
 
@@ -211,7 +212,7 @@ class ReservoirHistogramStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0 || value.isNaN()) return
-        outerLock.withLock {
+        outerLock.guarded {
             val key = drawKey(weight)
             admit(value, key)
             totalSeenCell.add(1L)
@@ -229,7 +230,7 @@ class ReservoirHistogramStat(
         require(values.values.size == values.keys.size) {
             "ReservoirResult values/keys size mismatch"
         }
-        outerLock.withLock {
+        outerLock.guarded {
             for (i in values.values.indices) {
                 admit(values.values[i], values.keys[i])
             }
@@ -239,7 +240,7 @@ class ReservoirHistogramStat(
     }
 
     override fun reset() {
-        outerLock.withLock {
+        outerLock.guarded {
             for (i in 0 until capacity) {
                 sampleKeys.store(i, emptyKey)
                 sampleValues.store(i, 0.0)
@@ -249,7 +250,7 @@ class ReservoirHistogramStat(
         }
     }
 
-    override fun read(timestampNanos: Long): ReservoirResult = outerLock.withLock {
+    override fun read(timestampNanos: Long): ReservoirResult = outerLock.guarded {
         // Snapshot under outerLock (strict) or best-effort (relaxed). Filter
         // out unfilled slots by sentinel key.
         var filled = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.preview
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import com.eignex.kumulant.stream.spinHint
@@ -344,7 +345,7 @@ class TDigestStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight <= 0.0 || value.isNaN()) return
-        outerLock.withLock {
+        outerLock.guarded {
             while (true) {
                 val claimed = bufferIndex.addAndGet(1L)
                 val idx = (claimed - 1L).toInt()
@@ -354,12 +355,12 @@ class TDigestStat(
                     totalWeightCell.add(weight)
                     commitIndex.add(1L)
                     if (claimed == bufferCapLong) {
-                        compressLock.withLock { drainLocked() }
+                        compressLock.guarded { drainLocked() }
                     }
-                    return@withLock
+                    return@guarded
                 }
                 // Overflow: a concurrent compress is needed before our claim can land.
-                compressLock.withLock { drainLocked() }
+                compressLock.guarded { drainLocked() }
                 // Loop and retry against the next epoch.
             }
         }
@@ -375,8 +376,8 @@ class TDigestStat(
         require(abs(compression - values.compression) < 1e-9) {
             "Cannot merge TDigests with different compression"
         }
-        outerLock.withLock {
-            compressLock.withLock {
+        outerLock.guarded {
+            compressLock.guarded {
                 // Drain any buffered points first so they appear in the centroid array.
                 drainLocked()
                 // Feed the incoming centroids through the same compress path.
@@ -399,8 +400,8 @@ class TDigestStat(
     }
 
     override fun reset() {
-        outerLock.withLock {
-            compressLock.withLock {
+        outerLock.guarded {
+            compressLock.guarded {
                 bufferIndex.store(0L)
                 commitIndex.store(0L)
                 totalWeightCell.store(0.0)
@@ -410,14 +411,14 @@ class TDigestStat(
         }
     }
 
-    override fun read(timestampNanos: Long): TDigestResult = outerLock.withLock {
-        compressLock.withLock {
+    override fun read(timestampNanos: Long): TDigestResult = outerLock.guarded {
+        compressLock.guarded {
             drainLocked()
 
             val total = totalWeightCell.load()
             val computed = DoubleArray(probabilities.size)
             if (means.isEmpty() || total <= 0.0) {
-                return@withLock TDigestResult(
+                return@guarded TDigestResult(
                     probabilities,
                     computed,
                     means.copyOf(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stream.additiveMode
 import com.eignex.kumulant.stream.firstWriterMode
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import com.eignex.kumulant.stream.welfordMode
 
@@ -53,14 +54,14 @@ class CounterRateStat(
     private val lastCounter = mode.newDouble(Double.NaN)
     private val lastTimestampNanos = mode.newLong(Long.MIN_VALUE)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         val previousCounter = lastCounter.load()
         val previousTimestamp = lastTimestampNanos.load()
 
         if (previousCounter.isNaN()) {
             lastCounter.store(value)
             lastTimestampNanos.store(timestampNanos)
-            return@withLock
+            return@guarded
         }
 
         when {
@@ -101,7 +102,7 @@ class CounterRateStat(
     override fun create(concurrency: Concurrency?) =
         CounterRateStat(concurrency ?: this.concurrency, treatDecreaseAsReset)
 
-    override fun read(timestampNanos: Long): RateResult = lock.withLock {
+    override fun read(timestampNanos: Long): RateResult = lock.guarded {
         val start = if (startTimestampNanos.load() == Long.MIN_VALUE) {
             timestampNanos
         } else {
@@ -114,8 +115,8 @@ class CounterRateStat(
         )
     }
 
-    override fun merge(values: RateResult) = lock.withLock {
-        if (values.totalValue == 0.0) return@withLock
+    override fun merge(values: RateResult) = lock.guarded {
+        if (values.totalValue == 0.0) return@guarded
 
         totalDelta.add(values.totalValue)
 
@@ -125,7 +126,7 @@ class CounterRateStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         totalDelta.store(0.0)
         lastCounter.store(Double.NaN)
         lastTimestampNanos.store(Long.MIN_VALUE)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -152,11 +153,11 @@ class GaussianNaiveBayesStat(
     private val classWeightCell: StreamDoubleArray = mode.newDoubleArray(numClasses)
     private val totalWeightCell: StreamDouble = mode.newDouble(0.0)
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0) return@withLock
+        if (weight <= 0.0) return@guarded
         val c = y.toInt()
-        if (c !in 0 until numClasses) return@withLock
+        if (c !in 0 until numClasses) return@guarded
         val priorW = classWeightCell.load(c)
         val newW = priorW + weight
         classWeightCell.store(c, newW)
@@ -171,7 +172,7 @@ class GaussianNaiveBayesStat(
         }
     }
 
-    override fun read(timestampNanos: Long): GaussianNaiveBayesResult = lock.withLock {
+    override fun read(timestampNanos: Long): GaussianNaiveBayesResult = lock.guarded {
         val meansFlat = DoubleArray(numClasses * featureSize) { meanCell.load(it) }
         val varsFlat = DoubleArray(numClasses * featureSize) { idx ->
             val c = idx / featureSize
@@ -202,7 +203,7 @@ class GaussianNaiveBayesStat(
         require(values.featureSize == featureSize && values.numClasses == numClasses) {
             "merge: shape mismatch (${values.numClasses}x${values.featureSize}) vs (${numClasses}x$featureSize)"
         }
-        lock.withLock {
+        lock.guarded {
             for (c in 0 until numClasses) {
                 val w1 = classWeightCell.load(c)
                 val w2 = values.classWeights[c]
@@ -226,7 +227,7 @@ class GaussianNaiveBayesStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in 0 until numClasses * featureSize) {
             meanCell.store(i, 0.0)
             m2Cell.store(i, 0.0)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -12,6 +12,7 @@ import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.getValue
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -148,11 +149,11 @@ class SoftmaxRegressionStat(
     /** Live view of the accumulated weighted cross-entropy. */
     val crossEntropy: Double by crossEntropyCell
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0) return@withLock
+        if (weight <= 0.0) return@guarded
         val c = y.toInt()
-        if (c !in 0 until numClasses) return@withLock
+        if (c !in 0 until numClasses) return@guarded
         stepCell.addAndGet(1L)
 
         // Softmax over current logits.
@@ -169,7 +170,7 @@ class SoftmaxRegressionStat(
             etas[k] = exp(etas[k] - maxEta)
             z += etas[k]
         }
-        if (z <= 0.0) return@withLock
+        if (z <= 0.0) return@guarded
         val invZ = 1.0 / z
         // Probabilities live in etas[] now.
         for (k in 0 until numClasses) etas[k] *= invZ
@@ -192,7 +193,7 @@ class SoftmaxRegressionStat(
         totalWeightsCell.add(weight)
     }
 
-    override fun read(timestampNanos: Long): SoftmaxRegressionResult = lock.withLock {
+    override fun read(timestampNanos: Long): SoftmaxRegressionResult = lock.guarded {
         val w = DoubleArray(numClasses * featureSize) { weightsCell.load(it) }
         val b = DoubleArray(numClasses) { biasCell.load(it) }
         SoftmaxRegressionResult(
@@ -210,7 +211,7 @@ class SoftmaxRegressionStat(
         require(values.featureSize == featureSize && values.numClasses == numClasses) {
             "merge: shape mismatch (${values.numClasses}x${values.featureSize}) vs (${numClasses}x$featureSize)"
         }
-        lock.withLock {
+        lock.guarded {
             val w1 = totalWeightsCell.load()
             val w2 = values.totalWeights
             val wNew = w1 + w2
@@ -230,7 +231,7 @@ class SoftmaxRegressionStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in 0 until numClasses * featureSize) weightsCell.store(i, 0.0)
         for (k in 0 until numClasses) biasCell.store(k, 0.0)
         totalWeightsCell.store(0.0)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -18,6 +18,7 @@ import com.eignex.koblas.scale
 import com.eignex.koblas.solveSpd
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
 import kotlin.math.sqrt
@@ -125,9 +126,9 @@ class BayesianRegressionStat(
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0) return@withLock
+        if (weight <= 0.0) return@guarded
         step++
 
         val etaPred = bias + (x dot weights)
@@ -145,7 +146,7 @@ class BayesianRegressionStat(
         val wc = weight * curvature
         val z = matVec(covariance, x)
         val denom = sqrt(1.0 + wc * (x dot z))
-        if (denom == 0.0) return@withLock
+        if (denom == 0.0) return@guarded
         scale(z, sqrt(wc) / denom)
 
         // Downdate the Cholesky factor; repair on instability.
@@ -174,7 +175,7 @@ class BayesianRegressionStat(
         totalWeights += weight
     }
 
-    override fun read(timestampNanos: Long): CovarianceRegressionResult = lock.withLock {
+    override fun read(timestampNanos: Long): CovarianceRegressionResult = lock.guarded {
         CovarianceRegressionResult(
             weights = DenseVector.of(weights.toDoubleArray()),
             bias = bias,
@@ -211,7 +212,7 @@ class BayesianRegressionStat(
         require(values.featureSize == featureSize) {
             "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
         }
-        lock.withLock {
+        lock.guarded {
             val n = featureSize
 
             val hSelf = invertSpd(covarianceL)
@@ -264,7 +265,7 @@ class BayesianRegressionStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in 0 until featureSize) weights[i] = initialWeights[i]
         for (k in covariance.data.indices) {
             covariance.data[k] = initialCovariance.data[k]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.schema.expr.ScalarExpr
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 
 /**
@@ -80,9 +81,9 @@ class DiagonalRegressionStat(
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0) return@withLock
+        if (weight <= 0.0) return@guarded
         step++
         val eta = learningRate.eval(step.toDouble())
 
@@ -122,7 +123,7 @@ class DiagonalRegressionStat(
         totalWeights += weight
     }
 
-    override fun read(timestampNanos: Long): DiagonalRegressionResult = lock.withLock {
+    override fun read(timestampNanos: Long): DiagonalRegressionResult = lock.guarded {
         DiagonalRegressionResult(
             weights = DenseVector.of(weights),
             bias = bias,
@@ -144,7 +145,7 @@ class DiagonalRegressionStat(
         require(values.featureSize == featureSize) {
             "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
         }
-        lock.withLock {
+        lock.guarded {
             val otherWeights = values.weights.toDoubleArray()
             val otherPrecision = values.precision.toDoubleArray()
             for (i in 0 until featureSize) {
@@ -167,7 +168,7 @@ class DiagonalRegressionStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in 0 until featureSize) {
             weights[i] = 0.0
             precision[i] = priorPrecision

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -12,6 +12,7 @@ import com.eignex.kumulant.stat.regression.Optimizer
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.getValue
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 
@@ -123,9 +124,9 @@ class StochasticRegressionStat(
         else -> 0.0
     }
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0) return@withLock
+        if (weight <= 0.0) return@guarded
         stepCell.addAndGet(1L)
 
         var dot = 0.0
@@ -207,7 +208,7 @@ class StochasticRegressionStat(
         }
     }
 
-    override fun read(timestampNanos: Long): StochasticRegressionResult = lock.withLock {
+    override fun read(timestampNanos: Long): StochasticRegressionResult = lock.guarded {
         val materialised = DoubleArray(featureSize) { effectiveWeight(it) }
         when (penalty) {
             Penalty.None -> {}
@@ -243,7 +244,7 @@ class StochasticRegressionStat(
         require(values.featureSize == featureSize) {
             "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
         }
-        lock.withLock {
+        lock.guarded {
             val w1 = totalWeightsCell.load()
             val w2 = values.totalWeights
             val wNew = w1 + w2
@@ -263,7 +264,7 @@ class StochasticRegressionStat(
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         for (i in 0 until featureSize) {
             weightsCell.store(i, 0.0)
             l1LastApplied?.store(i, 0.0)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.VarianceResult
 import com.eignex.kumulant.stream.getValue
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -114,8 +115,8 @@ class UnivariateRegressionStat(
     /** Live view of the running mean of `y`. */
     val meanY: Double by my
 
-    override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight <= 0.0) return@withLock
+    override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight <= 0.0) return@guarded
 
         val nextW = w.addAndGet(weight)
         val oldW = nextW - weight
@@ -132,9 +133,9 @@ class UnivariateRegressionStat(
         sxy.add(dx * dy * factor)
     }
 
-    override fun merge(values: UnivariateRegressionResult) = lock.withLock {
+    override fun merge(values: UnivariateRegressionResult) = lock.guarded {
         val w2 = values.totalWeights
-        if (w2 <= 0.0) return@withLock
+        if (w2 <= 0.0) return@guarded
 
         val w1 = w.load()
         val nextW = w1 + w2
@@ -156,7 +157,7 @@ class UnivariateRegressionStat(
         w.add(w2)
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         w.store(0.0)
         mx.store(0.0)
         my.store(0.0)
@@ -165,7 +166,7 @@ class UnivariateRegressionStat(
         sxy.store(0.0)
     }
 
-    override fun read(timestampNanos: Long): UnivariateRegressionResult = lock.withLock {
+    override fun read(timestampNanos: Long): UnivariateRegressionResult = lock.guarded {
         val totalW = w.load()
         val meanX = mx.load()
         val meanY = my.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
+import com.eignex.kumulant.stream.guarded
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -74,7 +75,7 @@ class ClassificationTree(
 
     /** Reset to a single fresh leaf. */
     fun reset() {
-        splitLock.withLock {
+        splitLock.guarded {
             nbrNodes.store(1)
             root = newLeaf(depth = 0)
         }
@@ -85,7 +86,7 @@ class ClassificationTree(
 
     /** Structurally merge [other] into this tree; [other] is consumed. */
     fun merge(other: ClassificationTree) {
-        splitLock.withLock {
+        splitLock.guarded {
             root = mergeNodes(root, other.root)
             nbrNodes.store(countNodes(root))
         }
@@ -93,7 +94,7 @@ class ClassificationTree(
 
     /** Snapshot merge: same rules as [merge] but the other side is an immutable result. */
     fun mergeSnapshot(other: TreeClassificationNodeResult) {
-        splitLock.withLock {
+        splitLock.guarded {
             root = mergeNodeWithResult(root, other)
             nbrNodes.store(countNodes(root))
         }
@@ -261,21 +262,21 @@ class ClassificationTree(
         val ticks = leaf.observationsSinceLastCheck.addAndFetch(1L)
         if (ticks < config.splitPeriod) return leaf
 
-        return splitLock.withLock {
-            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@withLock leaf
+        return splitLock.guarded {
+            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@guarded leaf
             leaf.observationsSinceLastCheck.store(0L)
 
             val total = leaf.arm.read(0L)
-            if (total.totalWeights < config.minSamplesSplit) return@withLock leaf
+            if (total.totalWeights < config.minSamplesSplit) return@guarded leaf
             val pos = leaf.pos.map { it.read(0L) }
             val neg = leaf.neg.map { it.read(0L) }
             val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@withLock leaf
+            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@guarded leaf
 
             val eps = hoeffdingBound(config.delta, total.totalWeights, depth, config.deltaDecay)
             val passesHoeffding = ranked.top1 - ranked.top2 > eps
             val passesTau = eps < config.tau
-            if (!passesHoeffding && !passesTau) return@withLock leaf
+            if (!passesHoeffding && !passesTau) return@guarded leaf
 
             nbrNodes.addAndFetch(2)
             ClassificationSplitNode(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
+import com.eignex.kumulant.stream.guarded
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -86,7 +87,7 @@ class RegressionTree<Row>(
 
     /** Reset to a single fresh leaf. */
     fun reset() {
-        splitLock.withLock {
+        splitLock.guarded {
             nbrNodes.store(1)
             root = newLeaf(depth = 0)
         }
@@ -113,7 +114,7 @@ class RegressionTree<Row>(
      * structures don't align.
      */
     fun merge(other: RegressionTree<Row>) {
-        splitLock.withLock {
+        splitLock.guarded {
             root = mergeNodes(root, other.root)
             nbrNodes.store(countNodes(root))
         }
@@ -239,23 +240,23 @@ class RegressionTree<Row>(
         val ticks = leaf.observationsSinceLastCheck.addAndFetch(1L)
         if (ticks < config.splitPeriod) return leaf
 
-        return splitLock.withLock {
+        return splitLock.guarded {
             // Double-check inside the lock: another thread may have already audited
             // (and reset the counter) or replaced this leaf.
-            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@withLock leaf
+            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@guarded leaf
             leaf.observationsSinceLastCheck.store(0L)
 
             val total = leaf.arm.read(0L)
-            if (total.totalWeights < config.minSamplesSplit) return@withLock leaf
+            if (total.totalWeights < config.minSamplesSplit) return@guarded leaf
             val pos = leaf.pos.map { it.read(0L) }
             val neg = leaf.neg.map { it.read(0L) }
             val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@withLock leaf
+            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@guarded leaf
 
             val eps = hoeffdingBound(config.delta, total.totalWeights, depth, config.deltaDecay)
             val passesHoeffding = ranked.top1 - ranked.top2 > eps
             val passesTau = eps < config.tau
-            if (!passesHoeffding && !passesTau) return@withLock leaf
+            if (!passesHoeffding && !passesTau) return@guarded leaf
 
             // Stash the pre-split aggregate as the new split's carryover so it shows up
             // in subtree aggregates without burdening the hot path. New leaves start

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -5,6 +5,7 @@ package com.eignex.kumulant.stat.regression.tree
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
+import com.eignex.kumulant.stream.guarded
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -102,7 +103,7 @@ fun RegressionNode<VectorView>.snapshot(): TreeNodeResult = when (this) {
  * only, for the same reason [snapshot] is.
  */
 fun RegressionTree<VectorView>.mergeSnapshot(other: TreeNodeResult) {
-    splitLock.withLock {
+    splitLock.guarded {
         root = mergeNodeWithResult(root, other)
         nbrNodes.store(countNodes(root))
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.welfordLock
 import kotlinx.serialization.SerialName
@@ -190,7 +191,7 @@ class SpaceSavingStat(
             admitMisraGries(value, w, 0L)
             totalSeenCell.add(1L)
         } else {
-            outerLock.withLock {
+            outerLock.guarded {
                 admitClassic(value, w, 0L)
                 totalSeenCell.add(1L)
             }
@@ -207,7 +208,7 @@ class SpaceSavingStat(
             }
             totalSeenCell.add(values.totalSeen)
         } else {
-            outerLock.withLock {
+            outerLock.guarded {
                 for (i in values.keys.indices) {
                     admitClassic(values.keys[i], values.counts[i], values.errors[i])
                 }
@@ -217,7 +218,7 @@ class SpaceSavingStat(
     }
 
     override fun reset() {
-        outerLock.withLock {
+        outerLock.guarded {
             for (i in 0 until capacity) {
                 keys.store(i, 0L)
                 counts.store(i, 0L)
@@ -227,7 +228,7 @@ class SpaceSavingStat(
         }
     }
 
-    override fun read(timestampNanos: Long): HeavyHittersResult = outerLock.withLock {
+    override fun read(timestampNanos: Long): HeavyHittersResult = outerLock.guarded {
         // Filter active slots (count > 0). Snapshot per-slot; under Relaxed a brief
         // torn pair window is possible.
         var active = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.summary
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
@@ -40,26 +41,26 @@ class ArgMaxStat(override val concurrency: Concurrency = Concurrency.None) : Ser
     private val value = mode.newDouble(Double.NEGATIVE_INFINITY)
     private val at = mode.newLong(0L)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         if (value > this.value.load()) {
             this.value.store(value)
             at.store(timestampNanos)
         }
     }
 
-    override fun merge(values: ArgMaxResult) = lock.withLock {
+    override fun merge(values: ArgMaxResult) = lock.guarded {
         if (values.max > value.load()) {
             value.store(values.max)
             at.store(values.atTimestampNanos)
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         value.store(Double.NEGATIVE_INFINITY)
         at.store(0L)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         ArgMaxResult(value.load(), at.load())
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/ArgMinStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.summary
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
@@ -40,26 +41,26 @@ class ArgMinStat(override val concurrency: Concurrency = Concurrency.None) : Ser
     private val value = mode.newDouble(Double.POSITIVE_INFINITY)
     private val at = mode.newLong(0L)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
         if (value < this.value.load()) {
             this.value.store(value)
             at.store(timestampNanos)
         }
     }
 
-    override fun merge(values: ArgMinResult) = lock.withLock {
+    override fun merge(values: ArgMinResult) = lock.guarded {
         if (values.min < value.load()) {
             value.store(values.min)
             at.store(values.atTimestampNanos)
         }
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         value.store(Double.POSITIVE_INFINITY)
         at.store(0L)
     }
 
-    override fun read(timestampNanos: Long) = lock.withLock {
+    override fun read(timestampNanos: Long) = lock.guarded {
         ArgMinResult(value.load(), at.load())
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireLiveWeight
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -63,26 +64,26 @@ class MeanStat(override val concurrency: Concurrency = Concurrency.None) : Serie
     private val totalWeights = mode.newDouble(0.0)
     private val mean = mode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight == 0.0) return@withLock
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight == 0.0) return@guarded
         requireLiveWeight(totalWeights.load(), weight)
         val nextW = totalWeights.addAndGet(weight)
         val delta = value - mean.load()
         mean.add(delta * (weight / nextW))
     }
 
-    override fun read(timestampNanos: Long): WeightedMeanResult = lock.withLock {
+    override fun read(timestampNanos: Long): WeightedMeanResult = lock.guarded {
         WeightedMeanResult(totalWeights.load(), mean.load())
     }
 
-    override fun merge(values: WeightedMeanResult) = lock.withLock {
-        if (values.totalWeights <= 0.0) return@withLock
+    override fun merge(values: WeightedMeanResult) = lock.guarded {
+        if (values.totalWeights <= 0.0) return@guarded
         val nextW = totalWeights.addAndGet(values.totalWeights)
         val delta = values.mean - mean.load()
         mean.add(delta * (values.totalWeights / nextW))
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         totalWeights.store(0.0)
         mean.store(0.0)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MomentsStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MomentsStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.HasShapeMoments
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireLiveWeight
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -64,8 +65,8 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
     private val m3 = mode.newDouble(0.0)
     private val m4 = mode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight == 0.0) return@withLock
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight == 0.0) return@guarded
         val oldW = totalWeights.load()
         requireLiveWeight(oldW, weight)
         val nextW = totalWeights.addAndGet(weight)
@@ -95,8 +96,8 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
         mean.add(deltaW)
     }
 
-    override fun merge(values: MomentsResult) = lock.withLock {
-        if (values.totalWeights <= 0.0) return@withLock
+    override fun merge(values: MomentsResult) = lock.guarded {
+        if (values.totalWeights <= 0.0) return@guarded
         val w1 = totalWeights.load()
         val w2 = values.totalWeights
         val nextW = totalWeights.addAndGet(w2)
@@ -128,7 +129,7 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
         mean.add(delta * (w2 / nextW))
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         totalWeights.store(0.0)
         mean.store(0.0)
         m2.store(0.0)
@@ -136,7 +137,7 @@ class MomentsStat(override val concurrency: Concurrency = Concurrency.None) : Se
         m4.store(0.0)
     }
 
-    override fun read(timestampNanos: Long): MomentsResult = lock.withLock {
+    override fun read(timestampNanos: Long): MomentsResult = lock.guarded {
         MomentsResult(totalWeights.load(), mean.load(), m2.load(), m3.load(), m4.load())
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stream.casMax
 import com.eignex.kumulant.stream.casMin
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
@@ -71,8 +72,8 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         casMin(minCell, value)
         casMax(maxCell, value)
-        lock.withLock {
-            if (weight == 0.0) return@withLock
+        lock.guarded {
+            if (weight == 0.0) return@guarded
             val priorW = totalWeights.load()
             val nextW = totalWeights.addAndGet(weight)
             val delta = value - mean.load()
@@ -85,8 +86,8 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
     override fun merge(values: SummaryResult) {
         casMin(minCell, values.min)
         casMax(maxCell, values.max)
-        lock.withLock {
-            if (values.totalWeights <= 0.0) return@withLock
+        lock.guarded {
+            if (values.totalWeights <= 0.0) return@guarded
             val w1 = totalWeights.load()
             val w2 = values.totalWeights
             val nextW = totalWeights.addAndGet(w2)
@@ -104,7 +105,7 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
         maxCell.store(Double.NEGATIVE_INFINITY)
     }
 
-    override fun read(timestampNanos: Long): SummaryResult = lock.withLock {
+    override fun read(timestampNanos: Long): SummaryResult = lock.guarded {
         val w = totalWeights.load()
         val variance = if (w > 0.0) sst.load() / w else 0.0
         val lo = minCell.load().let { if (it == Double.POSITIVE_INFINITY) 0.0 else it }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/VarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/VarianceStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.HasSampleVariance
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireLiveWeight
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
@@ -69,8 +70,8 @@ class VarianceStat(override val concurrency: Concurrency = Concurrency.None) : S
     private val mean = mode.newDouble(0.0)
     private val sst = mode.newDouble(0.0)
 
-    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.withLock {
-        if (weight == 0.0) return@withLock
+    override fun update(value: Double, timestampNanos: Long, weight: Double) = lock.guarded {
+        if (weight == 0.0) return@guarded
         val priorW = totalWeights.load()
         requireLiveWeight(priorW, weight)
         val nextW = totalWeights.addAndGet(weight)
@@ -80,8 +81,8 @@ class VarianceStat(override val concurrency: Concurrency = Concurrency.None) : S
         sst.add(priorW * delta * r)
     }
 
-    override fun merge(values: WeightedVarianceResult) = lock.withLock {
-        if (values.totalWeights <= 0.0) return@withLock
+    override fun merge(values: WeightedVarianceResult) = lock.guarded {
+        if (values.totalWeights <= 0.0) return@guarded
         val w1 = totalWeights.load()
         val w2 = values.totalWeights
         val nextW = totalWeights.addAndGet(w2)
@@ -90,13 +91,13 @@ class VarianceStat(override val concurrency: Concurrency = Concurrency.None) : S
         sst.add(values.variance * w2 + (delta * delta) * (w1 * w2 / nextW))
     }
 
-    override fun reset() = lock.withLock {
+    override fun reset() = lock.guarded {
         totalWeights.store(0.0)
         mean.store(0.0)
         sst.store(0.0)
     }
 
-    override fun read(timestampNanos: Long): WeightedVarianceResult = lock.withLock {
+    override fun read(timestampNanos: Long): WeightedVarianceResult = lock.guarded {
         val w = totalWeights.load()
         val m = mean.load()
         val s = sst.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
@@ -41,4 +41,47 @@ internal object NoopMutex : Mutex {
  */
 internal expect class PlatformMutex() : Mutex {
     override fun <R> withLock(block: () -> R): R
+
+    /**
+     * Acquire the lock. Pair with [exit] in a `finally`; prefer [guarded], which does that
+     * for you. Exists so a hot update path can take the lock without constructing a lambda.
+     */
+    fun enter()
+
+    /** Release the lock acquired by [enter]. */
+    fun exit()
+}
+
+/**
+ * Run [block] holding this lock, without allocating.
+ *
+ * [Mutex.withLock] is a non-inline interface method taking a function, so every call
+ * constructs a capturing lambda. On JVM the JIT scalar-replaces that lambda only while the
+ * call site stays monomorphic; once a process has used both [NoopMutex] and [PlatformMutex]
+ * the site is polymorphic, escape analysis gives up, and the allocation is real. It measured
+ * 32 B per update under [com.eignex.kumulant.core.Concurrency.Strict] in a full-suite run
+ * against 0 B when measured alone, and a production process looks like the former. Kotlin
+ * platforms without escape analysis pay it unconditionally.
+ *
+ * Being `inline`, this constructs nothing at all: the branch resolves to a direct
+ * `enter`/`try`/`finally`/`exit` around the inlined body, and to the bare body under
+ * [NoopMutex]. The `finally` preserves the release-on-throw behaviour `withLock` gave for
+ * free, which several stats rely on for their `require` checks.
+ */
+internal inline fun <R> Mutex.guarded(block: () -> R): R {
+    if (this === NoopMutex) return block()
+    // Only [NoopMutex] and [PlatformMutex] exist in this module, and every internal lock comes
+    // from `welfordLock` / `serializedLock` / `Concurrency.lock`, so this always holds. It
+    // cannot fall back to `withLock` for an exotic implementation, because passing an inline
+    // parameter to a non-inline function is not allowed - which is the whole reason the
+    // allocation exists in the first place.
+    check(this is PlatformMutex) {
+        "guarded expects a lock from Concurrency.lock(); got ${this::class.simpleName}"
+    }
+    enter()
+    try {
+        return block()
+    } finally {
+        exit()
+    }
 }

--- a/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.jvm.kt
+++ b/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.jvm.kt
@@ -9,4 +9,8 @@ internal actual class PlatformMutex actual constructor() : Mutex {
     @Suppress("UnusedPrivateProperty") // detekt misses the kotlin.concurrent.withLock extension call
     private val lock = ReentrantLock()
     actual override fun <R> withLock(block: () -> R): R = lock.withLock(block)
+
+    actual fun enter() = lock.lock()
+
+    actual fun exit() = lock.unlock()
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/GuardedLockReleaseTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/GuardedLockReleaseTest.kt
@@ -1,0 +1,67 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stat.summary.MeanStat
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The lock must be released when the guarded body throws.
+ *
+ * `Mutex.withLock` gave this for free. The `enter`/`exit` split that replaced it on the hot
+ * path relies on an explicit `finally`, so a mistake there would not show up as a wrong
+ * answer: it would leave the mutex held and deadlock the next writer. Several stats throw
+ * from inside the guarded body - the weight guards in the Welford family, the dimension
+ * checks in the vector family - so this is a reachable path, not a hypothetical.
+ */
+class GuardedLockReleaseTest {
+
+    @Test
+    fun `a throw inside the guarded body leaves the lock usable on the same thread`() {
+        val mean = MeanStat(Concurrency.Strict)
+        mean.update(10.0, weight = 1.0)
+        // Exhausting the accumulated weight throws from inside the guarded body.
+        assertFailsWith<IllegalArgumentException> { mean.update(10.0, weight = -1.0) }
+        // If the lock had leaked, a ReentrantLock would let the owning thread back in and this
+        // would pass regardless; the cross-thread case below is the real check.
+        mean.update(30.0, weight = 1.0)
+        assertEquals(2.0, mean.read().totalWeights, 1e-9)
+        assertEquals(20.0, mean.read().mean, 1e-9)
+    }
+
+    @Test
+    fun `a throw inside the guarded body does not wedge other threads`() {
+        val mean = MeanStat(Concurrency.Strict)
+        mean.update(10.0, weight = 1.0)
+        assertFailsWith<IllegalArgumentException> { mean.update(10.0, weight = -1.0) }
+
+        // A ReentrantLock is held by the thread that took it, so a leaked lock only becomes
+        // visible from a different thread. Without the finally, this times out.
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit { mean.update(30.0, weight = 1.0) }
+            future.get(5, TimeUnit.SECONDS)
+        } finally {
+            pool.shutdownNow()
+        }
+        assertEquals(2.0, mean.read().totalWeights, 1e-9)
+    }
+
+    @Test
+    fun `reads still complete after a failed update`() {
+        val mean = MeanStat(Concurrency.Strict)
+        mean.update(5.0, weight = 1.0)
+        assertFailsWith<IllegalArgumentException> { mean.update(5.0, weight = -2.0) }
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit<Double> { mean.read().mean }
+            assertTrue(future.get(5, TimeUnit.SECONDS).isFinite())
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
@@ -76,30 +76,25 @@ class UpdateAllocationTest {
     }
 
     /**
-     * The cost of the lock, pinned as it actually behaves.
+     * Taking a lock must not allocate.
      *
-     * `update` bodies are written `lock.withLock { ... }`, and `withLock` is a non-inline
-     * interface method, so each call constructs a capturing lambda. Whether that lambda costs
-     * anything depends on the call site:
+     * `update` bodies used to be written `lock.withLock { ... }`. `withLock` is a non-inline
+     * interface method taking a function, so each call constructed a capturing lambda. The JIT
+     * scalar-replaced it only while the call site stayed monomorphic: measured alone this test
+     * reported 0 B/update under [Concurrency.Strict], but in a full-suite run, where both
+     * `NoopMutex` and `PlatformMutex` have been used, escape analysis gave up and it was
+     * 32 B/update. A production process looks like the second case.
      *
-     * - Under [Concurrency.None] the lock is `NoopMutex` and the measured cost is zero.
-     * - Under [Concurrency.Strict] it is 32 B/update **once more than one `Mutex`
-     *   implementation is live in the process**. Measured in isolation this test reports zero,
-     *   because the call site stays monomorphic and the JIT scalar-replaces the lambda; measured
-     *   in a full-suite run, where both `NoopMutex` and `PlatformMutex` have been used, escape
-     *   analysis gives up and the allocation is real. A real application looks like the latter.
-     *
-     * Removing it needs an `enter`/`exit` split so no lambda is constructed at all, which
-     * touches every platform's `PlatformMutex` plus every `update` body. Not done here; this
-     * pins the current cost so the eventual fix has a baseline and a regression cannot creep in.
-     * Kotlin/Native has no comparable escape analysis and cannot be measured with this counter,
-     * so the cost there is likely unconditional.
+     * The bodies now use the inlining `guarded`, which expands to a direct
+     * `enter`/`try`/`finally`/`exit` and constructs nothing, so these are exact zeroes in both
+     * contexts rather than only in isolation. Kotlin platforms without escape analysis, which
+     * this counter cannot measure, benefit unconditionally.
      */
     @Test
-    fun `the lock allocation on the update path stays at its known cost`() {
+    fun `taking a lock does not allocate on the update path`() {
         assertUpdateAllocation("MeanStat[None]", 0.0, MeanStat(Concurrency.None))
-        assertUpdateAllocation("MeanStat[Strict]", 48.0, MeanStat(Concurrency.Strict))
-        assertUpdateAllocation("MomentsStat[Strict]", 48.0, MomentsStat(Concurrency.Strict))
+        assertUpdateAllocation("MeanStat[Strict]", 0.0, MeanStat(Concurrency.Strict))
+        assertUpdateAllocation("MomentsStat[Strict]", 0.0, MomentsStat(Concurrency.Strict))
     }
 
     @Test
@@ -112,19 +107,22 @@ class UpdateAllocationTest {
      * Ceilings for the two stats that allocate by design, as tripwires against a large
      * regression rather than as precise figures.
      *
-     * These are deliberately loose. Unlike the zero-allocation assertions above, which are
-     * exact because zero is zero, an amortised figure moves with the JIT state left behind by
-     * whatever ran before it: TDigest measures ~55 B/op when this class runs alone and ~86
-     * B/op in a full-suite run. The ceilings sit above the noisier of the two.
+     * These have headroom but are no longer loose. They used to need a wide margin because the
+     * figures moved with the JIT state left behind by preceding tests - TDigest measured ~55
+     * B/op alone and ~86 B/op in a full-suite run. That gap was the lock lambda, and with
+     * `guarded` inlining it away both stats now report the same number under every
+     * [Concurrency] level in either context, so the remaining allocation is purely structural:
+     * one Bucket per observation for Adwin, the merged centroid arrays per compression epoch
+     * for TDigest.
      */
     @Test
     fun `the amortised allocators stay under their ceiling`() {
         // AdwinStat allocates one Bucket per observation by design, and its bucket-walk scratch
         // buffer grows with the window. Measured 277 B/op before the scratch buffer was made
-        // reusable, 75 B/op after.
-        assertUpdateAllocation("AdwinStat", 160.0, AdwinStat(concurrency = Concurrency.None))
+        // reusable, 75 B/op after, and the same under Strict now that the lock does not allocate.
+        assertUpdateAllocation("AdwinStat", 110.0, AdwinStat(concurrency = Concurrency.None))
         // TDigestStat allocates the merged centroid arrays once per compression epoch, amortised
-        // over the buffer. Measured 82 B/op before the index sort stopped boxing, 55 B/op after.
-        assertUpdateAllocation("TDigestStat", 130.0, TDigestStat(concurrency = Concurrency.None), span = 9973)
+        // over the buffer. Measured 82 B/op before the index sort stopped boxing, 54 B/op after.
+        assertUpdateAllocation("TDigestStat", 80.0, TDigestStat(concurrency = Concurrency.None), span = 9973)
     }
 }

--- a/kumulant/src/mingwMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.mingw.kt
+++ b/kumulant/src/mingwMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.mingw.kt
@@ -35,4 +35,12 @@ internal actual class PlatformMutex actual constructor() : Mutex {
             LeaveCriticalSection(cs.ptr)
         }
     }
+
+    actual fun enter() {
+        EnterCriticalSection(cs.ptr)
+    }
+
+    actual fun exit() {
+        LeaveCriticalSection(cs.ptr)
+    }
 }

--- a/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
+++ b/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
@@ -35,4 +35,12 @@ internal actual class PlatformMutex actual constructor() : Mutex {
             pthread_mutex_unlock(mutex.ptr)
         }
     }
+
+    actual fun enter() {
+        pthread_mutex_lock(mutex.ptr)
+    }
+
+    actual fun exit() {
+        pthread_mutex_unlock(mutex.ptr)
+    }
 }

--- a/kumulant/src/webMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.web.kt
+++ b/kumulant/src/webMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.web.kt
@@ -4,4 +4,10 @@ package com.eignex.kumulant.stream
 
 internal actual class PlatformMutex actual constructor() : Mutex {
     actual override fun <R> withLock(block: () -> R): R = block()
+
+    // JS and current Kotlin/Wasm are single-threaded with no shared heap, so there is
+    // nothing to acquire. See the note on Mutex for why that is safe today.
+    actual fun enter() = Unit
+
+    actual fun exit() = Unit
 }


### PR DESCRIPTION
Removes the per-update lock allocation measured in #26, which pinned it at a ceiling rather than fixing it.

Every stat wrote its update body as `lock.withLock { ... }`. `withLock` is a non-inline interface method taking a function, so each call constructed a capturing lambda. The JIT scalar-replaced that lambda only while the call site stayed monomorphic. Measured in isolation the cost was 0 B/update under Concurrency.Strict; measured in a full-suite run, where both NoopMutex and PlatformMutex have been used and the site is polymorphic, it was 32 B/update. A production process looks like the second case, which is why the isolated measurement was the misleading one.

PlatformMutex gains an internal enter/exit pair on all four platforms, and an internal inline `guarded` extension replaces withLock at the 117 internal call sites across 32 files. Being inline, it constructs nothing: it expands to the bare body under NoopMutex and to a direct enter/try/finally/exit around the inlined body otherwise. The public Mutex interface is unchanged, since interface members are public and adding enter/exit there would have widened the API for a purely internal optimisation.

Results, measured in a full-suite run rather than in isolation:

| path | before | after |
|---|---|---|
| MeanStat, MomentsStat under Strict | 32 B/op | 0 B/op |
| AdwinStat under None / Strict | 75 / ~107 B/op | 74.56 B/op both |
| TDigestStat under None / Strict | 54 / ~86 B/op | 54.24 B/op both |

The Adwin and TDigest rows are worth noting: they now report the same figure under every Concurrency level and in either measurement context. The gap between their isolated and full-suite numbers in #26 was this lambda, which also means the loose ceilings that PR needed can be tightened, from 160 to 110 and from 130 to 80. What remains is structural: one Bucket per observation for Adwin, the merged centroid arrays per compression epoch for TDigest.

The risk in this change is not a wrong answer, it is a leaked lock. withLock released on throw for free; enter/exit relies on an explicit finally, and a mistake there would leave the mutex held and deadlock the next writer rather than fail a computation. Several stats do throw from inside the guarded body, including the weight guards added in #23, so it is a reachable path. GuardedLockReleaseTest covers it, including the cross-thread case, which is the one that actually matters: a ReentrantLock readmits the thread that owns it, so a leak is invisible from the same thread and only shows up when another thread tries to acquire.

One deliberate sharp edge. `guarded` cannot fall back to withLock for a Mutex implementation from outside this module, because passing an inline parameter to a non-inline function is not allowed, and that restriction is the very reason the allocation existed. It therefore asserts that the receiver is one of the two implementations in this module. That always holds, since every internal lock comes from welfordLock, serializedLock or Concurrency.lock, and no stat accepts a caller-supplied Mutex. The check makes the assumption explicit rather than letting it become a ClassCastException.

Verified with jvmTest, jsNodeTest, jsBrowserTest, wasmJsNodeTest, wasmWasiNodeTest, linuxX64Test, lintDocs, checkKdoc, checkNativeSafeTestNames, detektMainJvm and detektTestJvm. mingwX64 was also cross-compiled, since its CRITICAL_SECTION enter/exit is new code that no target reachable from this machine executes.