### PR TITLE
Report NaN rather than zero quantiles on an empty sketch

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -70,6 +70,28 @@ interface HasMinMax : Result {
 }
 
 /**
+ * Result trait for snapshots that know how much evidence they are built from.
+ *
+ * Exists so a caller can ask "did this stat see anything?" without knowing which field
+ * carries the answer. The count is spelled `totalWeights` on most results, `totalSeen` on the
+ * sketches and `totalWeight` on a few others, so before this trait the emptiness check was
+ * per-stat knowledge.
+ *
+ * The distinction matters because several results report a numerically plausible value on an
+ * empty stream. A quantile sketch with no observations reports `NaN` per quantile precisely so
+ * that absence is distinguishable, but a mean reports `0.0`, which is not. Gate on [isEmpty]
+ * before trusting any field of a snapshot that might have arrived before the first
+ * observation did.
+ */
+interface HasObservationCount : Result {
+    /** Cumulative weight of observations folded into this result. */
+    val totalWeights: Double
+
+    /** True when no observation has been folded in, so every other field is a placeholder. */
+    val isEmpty: Boolean get() = !(totalWeights > 0.0)
+}
+
+/**
  * Result trait for accumulators that expose variance-family quantities. Derived
  * properties [variance] / [stdDev] / [sampleVariance] / [sampleStdDev] all fall
  * out of [sst] (sum of squared deviations) and [totalWeights] without storing
@@ -85,10 +107,7 @@ interface HasMinMax : Result {
  * from an underlying distribution; use [variance] / [stdDev] when treating
  * the observations as the complete population.
  */
-interface HasSampleVariance : Result {
-    /** Cumulative weight of observations folded into this result. */
-    val totalWeights: Double
-
+interface HasSampleVariance : HasObservationCount {
     /** Sum of squared deviations from the running mean: `Sum (x - mean)^2 * weight`. */
     val sst: Double get() = variance * totalWeights
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
@@ -92,32 +92,40 @@ at delegate registration.
 ## Reading an empty accumulator
 
 `read()` on a stat that has seen no observations is always legal and never
-throws, but what it reports is per-family rather than uniform. The four
-conventions in use, all observed rather than intended:
+throws. What it reports depends on whether the statistic has a meaningful
+identity element:
 
 | Family | Empty read reports |
 |--------|--------------------|
 | Sum, Count, BernoulliSum | `0.0`, the additive identity |
-| Mean, Variance, Moments | `0.0` for every field |
 | Min, Max | `+Infinity` / `-Infinity`, the comparison identities |
 | HdrHistogram, LinearHistogram, Reservoir | empty arrays |
+| DDSketch, TDigest, Mad | `NaN` per quantile |
 | Auc | `NaN` |
-| DDSketch, TDigest | `0.0` for every requested quantile |
+| Mean, Variance, Moments | `0.0` for every field |
 
-The last row is the one to watch. A p99 of `0.0` from an empty sketch is
-indistinguishable from a p99 of `0.0` computed over real zero-valued data,
-and on a latency dashboard it reads as healthy rather than as absent. Until
-that is unified, gate on the observation count before trusting a quantile:
+Where an identity exists, it is reported: a sum of nothing is genuinely zero,
+and the infinities are the correct starting points for a min/max fold and are
+already distinguishable from real data. Where none exists, the result is `NaN`
+rather than a plausible-looking number. An empty quantile sketch has no p99,
+and reporting `0.0` claimed one; on a latency dashboard that read as excellent
+rather than as absent.
+
+Mean, Variance and Moments still report `0.0` on an empty stream. That has the
+same ambiguity as the quantile case did and is a candidate for the same
+treatment, but changing it is a wider break than the sketches were.
+
+Rather than knowing which field carries the count, gate on
+[com.eignex.kumulant.core.HasObservationCount.isEmpty]:
 
 ```kotlin
 val r = sketch.read()
-val p99 = if (r.totalWeights > 0.0) r.quantiles.last() else null
+if (!r.isEmpty) report(r.quantiles.last())
 ```
 
-Every result carries the count needed for that check, whether as
-`totalWeights`, `totalSeen`, or a per-bin weight array, so the guard is
-always available. The `0.0`-versus-`NaN` divergence is a known
-inconsistency, not a deliberate per-family design.
+The count is spelled `totalWeights` on most results, `totalSeen` on the
+sketches and `totalWeight` on a few others; `HasObservationCount` normalises
+that, so `isEmpty` is the same check everywhere it is implemented.
 
 ## Lifecycle
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.anomaly
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -23,8 +23,8 @@ data class GaussianScoreResult(
     /** Running variance. */
     val variance: Double,
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
-) : Result {
+    override val totalWeights: Double,
+) : HasObservationCount {
 
     /** Sample standard deviation. */
     val stdDev: Double get() = sqrt(variance)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -4,7 +4,7 @@ package com.eignex.kumulant.stat.anomaly
 
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
@@ -50,14 +50,14 @@ data class HalfSpaceTreesResult(
     /** Depth of each tree; each tree has `2^height` leaves. */
     val height: Int,
     /** Cumulative observation weight folded into the reference window. */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Flat `numTrees * (2^height - 1)` array of per-internal-node feature indices. */
     val featureIndices: IntArray,
     /** Flat `numTrees * (2^height - 1)` array of per-internal-node split thresholds. */
     val thresholds: DoubleArray,
     /** Flat `numTrees * 2^height` array of per-leaf masses summed over the reference window. */
     val referenceMass: DoubleArray,
-) : Result {
+) : HasObservationCount {
 
     private val numInternal: Int get() = (1 shl height) - 1
     private val numLeaves: Int get() = 1 shl height

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.anomaly
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.quantile.DDSketchStat
 import kotlinx.serialization.SerialName
@@ -20,8 +20,8 @@ data class QuantileFilterResult(
     /** Estimated quantile of the input stream at [probability]. */
     val threshold: Double,
     /** Cumulative observation weight folded into the underlying sketch. */
-    val totalWeights: Double,
-) : Result {
+    override val totalWeights: Double,
+) : HasObservationCount {
 
     /** `1.0` when [x] strictly exceeds [threshold], `0.0` otherwise. */
     fun score(x: Double): Double = if (x > threshold) 1.0 else 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.calibration
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
-import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -26,8 +26,8 @@ data class IsotonicCalibratorResult(
     /** Monotone-non-decreasing calibrated probability per bin. */
     val probabilities: DoubleArray,
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
-) : Result {
+    override val totalWeights: Double,
+) : HasObservationCount {
 
     init {
         require(numBins > 0) { "numBins must be > 0; got $numBins" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
@@ -2,8 +2,8 @@ package com.eignex.kumulant.stat.calibration
 
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
@@ -28,8 +28,8 @@ data class PlattCalibratorResult(
     /** Sigmoid intercept. */
     val intercept: Double,
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
-) : Result {
+    override val totalWeights: Double,
+) : HasObservationCount {
 
     /** Calibrated probability for raw score [x] via `sigmoid(slope * x + intercept)`. */
     fun calibrate(x: Double): Double {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.cardinality
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
@@ -24,7 +24,9 @@ import kotlin.math.pow
 @Serializable
 @SerialName("HyperLogLogResult")
 data class HyperLogLogResult(val estimate: Double, val precision: Int, val registers: IntArray, val totalSeen: Long) :
-    Result {
+    HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is HyperLogLogResult &&
         estimate == other.estimate &&
         precision == other.precision &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.cardinality
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
@@ -32,7 +32,9 @@ data class LinearCountingResult(
     val words: LongArray,
     /** Total observations the sketch has absorbed. */
     val totalSeen: Long,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is LinearCountingResult &&
         estimate == other.estimate &&
         bits == other.bits &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.decay
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -14,10 +14,10 @@ data class DecayingMeanResult(
     /** Time-decayed weighted running mean. */
     val mean: Double,
     /** Effective weight of observations still contributing (decays with time). */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Wall-clock timestamp (nanoseconds) at which the snapshot was taken. */
     val timestampNanos: Long,
-) : Result
+) : HasObservationCount
 
 /**
  * Exponentially decaying weighted mean: `Sum(v_i*w_i*decay) / Sum(w_i*decay)`.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.decay
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stream.currentTimeNanos
 import com.eignex.kumulant.stream.guarded
@@ -22,10 +22,10 @@ data class DecayingVarianceResult(
     /** Time-decayed weighted running variance. */
     val variance: Double,
     /** Effective weight of observations still contributing (decays with time). */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Wall-clock timestamp (nanoseconds) at which the snapshot was taken. */
     val timestampNanos: Long,
-) : Result {
+) : HasObservationCount {
     /** Square root of [variance]. */
     val stdDev: Double get() = sqrt(variance)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -156,6 +156,12 @@ class DDSketchStat(
         for (w in posSnap.values) total += w
 
         if (total <= 0.0) {
+            // NaN per quantile rather than 0.0. A zero-filled array is indistinguishable from a
+            // sketch that genuinely observed zeros, so an untouched sketch used to render as a
+            // p99 of 0.0 - which reads as excellent latency rather than as no data. AucStat
+            // already returned NaN in the same situation. Callers who want to branch rather
+            // than propagate NaN can check [SketchResult.isEmpty].
+            computedQuantiles.fill(Double.NaN)
             return SketchResult(
                 probabilities = probabilities,
                 quantiles = computedQuantiles,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.quantile
 
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
@@ -32,14 +33,14 @@ data class SketchResult(
      * independently: merge folds in the bins and the zero bucket and recomputes this, so a
      * hand-built result whose total disagrees with its bins contributes only its bins.
      */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Weight observed at the zero bin. */
     val zeroCount: Double,
     /** Positive-side bin counts keyed by signed log-bucket index. */
     val positiveBins: Map<Int, Double>,
     /** Negative-side bin counts keyed by signed log-bucket index. */
     val negativeBins: Map<Int, Double>,
-) : Result {
+) : HasObservationCount {
     override fun equals(other: Any?): Boolean = other is SketchResult &&
         probabilities.contentEquals(other.probabilities) &&
         quantiles.contentEquals(other.quantiles) &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.NoopMutex
@@ -34,7 +34,9 @@ data class ReservoirResult(
     val totalSeen: Long,
     /** Cumulative observation weight folded in. */
     val totalWeight: Double,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalWeight
     override fun equals(other: Any?): Boolean = other is ReservoirResult &&
         values.contentEquals(other.values) &&
         keys.contentEquals(other.keys) &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.guarded
@@ -35,7 +35,9 @@ data class TDigestResult(
     val totalWeight: Double,
     /** T-digest compression parameter; lower = more centroids, tighter quantiles. */
     val compression: Double,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalWeight
     override fun equals(other: Any?): Boolean = other is TDigestResult &&
         probabilities.contentEquals(other.probabilities) &&
         quantiles.contentEquals(other.quantiles) &&
@@ -418,6 +420,11 @@ class TDigestStat(
             val total = totalWeightCell.load()
             val computed = DoubleArray(probabilities.size)
             if (means.isEmpty() || total <= 0.0) {
+                // NaN per quantile rather than 0.0, matching DDSketchStat and AucStat. A
+                // zero-filled array cannot be told apart from a digest that genuinely observed
+                // zeros, so an untouched digest reported a p99 of 0.0 and read as healthy.
+                // [TDigestResult.isEmpty] is the check for callers who would rather branch.
+                computed.fill(Double.NaN)
                 return@guarded TDigestResult(
                     probabilities,
                     computed,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/CovarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/CovarianceStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.operation.mapResult
 import com.eignex.kumulant.stat.regression.glm.Penalty
 import com.eignex.kumulant.stat.regression.glm.UnivariateRegressionResult
@@ -17,7 +17,7 @@ import kotlin.math.sqrt
 @SerialName("CovarianceResult")
 data class CovarianceResult(
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Weighted running mean of `x`. */
     val meanX: Double,
     /** Weighted running mean of `y`. */
@@ -28,7 +28,7 @@ data class CovarianceResult(
     val sxx: Double,
     /** Sum of squared deviations in y: `Sum (y - meanY)^2 * w`. */
     val syy: Double,
-) : Result {
+) : HasObservationCount {
     /** Sample covariance `sxy / totalWeights`. */
     val covariance: Double get() = if (totalWeights > 0.0) sxy / totalWeights else 0.0
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -4,8 +4,8 @@ import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.guarded
@@ -42,10 +42,10 @@ data class GaussianNaiveBayesResult(
     /** Cumulative observation weight per class; length [numClasses]. */
     val classWeights: DenseVector,
     /** Total cumulative observation weight across all classes. */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Lower bound applied to per-class variances at predict time. */
     val varianceFloor: Double,
-) : Result {
+) : HasObservationCount {
 
     init {
         require(means.rows == numClasses && means.cols == featureSize) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -5,8 +5,8 @@ import com.eignex.koblas.DenseVector
 import com.eignex.koblas.VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stream.StreamDouble
@@ -38,12 +38,12 @@ data class SoftmaxRegressionResult(
     /** Per-class intercept; length [numClasses]. */
     val biases: DenseVector,
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Number of `update` calls absorbed. */
     val step: Long,
     /** Accumulated weighted negative log-likelihood (cross-entropy) over the stream. */
     val crossEntropy: Double,
-) : Result {
+) : HasObservationCount {
     init {
         require(weights.rows == numClasses && weights.cols == featureSize) {
             "weights must be ${numClasses}x$featureSize; got ${weights.rows}x${weights.cols}"

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.sketch
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
@@ -32,7 +32,9 @@ data class BloomFilterResult(
     val totalSeen: Long,
     /** Reference to the [LongHasher] that produced the bitset; resolved by [contains]. */
     val hasher: HasherRef = HasherRef.SplitMix64,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is BloomFilterResult &&
         bits == other.bits &&
         hashes == other.hashes &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.sketch
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
@@ -32,7 +32,9 @@ data class CountMinSketchResult(
     val totalSeen: Long,
     /** Reference to the [LongHasher] that produced the counters; resolved by [estimate]. */
     val hasher: HasherRef = HasherRef.SplitMix64,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is CountMinSketchResult &&
         depth == other.depth &&
         width == other.width &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.sketch
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
@@ -30,7 +30,9 @@ data class MinHashResult(
     val signatures: LongArray,
     /** Number of `update(value)` calls absorbed; informational. */
     val totalSeen: Long,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is MinHashResult &&
         numHashes == other.numHashes &&
         seed == other.seed &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.sketch
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
@@ -25,7 +25,9 @@ data class HeavyHittersResult(
     val counts: LongArray,
     val errors: LongArray,
     val totalSeen: Long,
-) : Result {
+) : HasObservationCount {
+
+    override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is HeavyHittersResult &&
         capacity == other.capacity &&
         keys.contentEquals(other.keys) &&

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/MeanStat.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.summary
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireLiveWeight
@@ -23,10 +24,10 @@ data class MeanResult(
 @SerialName("WeightedMeanResult")
 data class WeightedMeanResult(
     /** Cumulative observation weight folded in. */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Weighted running mean. */
     val mean: Double,
-) : Result
+) : HasObservationCount
 
 /**
  * Weighted arithmetic mean via Welford-style online update.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/PairedSumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/PairedSumStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -17,12 +17,12 @@ import kotlinx.serialization.Serializable
 @SerialName("PairedSumResult")
 data class PairedSumResult(
     /** Cumulative observation weight (`Sum w_i`). */
-    val totalWeights: Double,
+    override val totalWeights: Double,
     /** Weighted `x` sum (`Sum w_i * x_i`). */
     val sumX: Double,
     /** Weighted `y` sum (`Sum w_i * y_i`). */
     val sumY: Double,
-) : Result
+) : HasObservationCount
 
 /**
  * Weighted paired sum `(Sum w_i*x_i, Sum w_i*y_i)` with accumulated weight.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/EmptyReadSemanticsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/EmptyReadSemanticsTest.kt
@@ -1,0 +1,90 @@
+package com.eignex.kumulant.core
+
+import com.eignex.kumulant.stat.quantile.DDSketchStat
+import com.eignex.kumulant.stat.quantile.HdrHistogramStat
+import com.eignex.kumulant.stat.quantile.LinearHistogramStat
+import com.eignex.kumulant.stat.quantile.TDigestStat
+import com.eignex.kumulant.stat.score.AucStat
+import com.eignex.kumulant.stat.summary.CountStat
+import com.eignex.kumulant.stat.summary.MadStat
+import com.eignex.kumulant.stat.summary.MaxStat
+import com.eignex.kumulant.stat.summary.MeanStat
+import com.eignex.kumulant.stat.summary.MinStat
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What a stat reports before it has seen anything.
+ *
+ * The convention: report the identity element where the statistic has one, and `NaN` where it
+ * does not. The quantile family previously reported `0.0` per quantile on an empty sketch,
+ * which is indistinguishable from a sketch that observed real zeros - so an untouched service
+ * rendered a p99 of zero and read as healthy rather than as having no data. [AucStat] already
+ * used `NaN` for the same case, so the library disagreed with itself.
+ */
+class EmptyReadSemanticsTest {
+
+    @Test
+    fun `statistics with an identity element report it`() {
+        // A sum of nothing really is zero, and a count of nothing really is zero.
+        assertEquals(0.0, SumStat().read().sum)
+        assertEquals(0.0, CountStat().read().sum, "an empty count is genuinely zero")
+        // The infinities are the correct starting points for a fold and cannot be mistaken for
+        // observed data.
+        assertEquals(Double.POSITIVE_INFINITY, MinStat().read().min)
+        assertEquals(Double.NEGATIVE_INFINITY, MaxStat().read().max)
+    }
+
+    @Test
+    fun `array-backed histograms report no buckets`() {
+        assertEquals(0, HdrHistogramStat().read().weights.size)
+        assertEquals(0, LinearHistogramStat(0.0, 10.0, 4).read().weights.size)
+    }
+
+    @Test
+    fun `quantile estimators report NaN rather than a plausible zero`() {
+        val sketch = DDSketchStat(probabilities = doubleArrayOf(0.5, 0.99)).read()
+        assertTrue(sketch.quantiles.all { it.isNaN() }, "DDSketch reported ${sketch.quantiles.toList()}")
+
+        val digest = TDigestStat(probabilities = doubleArrayOf(0.5, 0.99)).read()
+        assertTrue(digest.quantiles.all { it.isNaN() }, "TDigest reported ${digest.quantiles.toList()}")
+
+        // MadStat is built on two TDigests, so it inherits the sentinel: an empty sample has no
+        // median, and reporting 0.0 claimed one.
+        val mad = MadStat().read()
+        assertTrue(mad.median.isNaN(), "Mad median was ${mad.median}")
+        assertTrue(mad.mad.isNaN(), "Mad mad was ${mad.mad}")
+
+        assertTrue(AucStat().read().auc.isNaN(), "Auc should already have been NaN")
+    }
+
+    @Test
+    fun `isEmpty is the same check whatever the count is called`() {
+        // totalWeights, totalSeen and totalWeight are three spellings of the same thing across
+        // the catalogue; HasObservationCount normalises them.
+        val empties: List<HasObservationCount> = listOf(
+            MeanStat().read(),
+            DDSketchStat().read(),
+            TDigestStat().read(),
+        )
+        for (r in empties) assertTrue(r.isEmpty, "${r::class.simpleName} should report isEmpty")
+
+        val populated: List<HasObservationCount> = listOf(
+            MeanStat().apply { update(1.0) }.read(),
+            DDSketchStat().apply { update(1.0) }.read(),
+            TDigestStat().apply { update(1.0) }.read(),
+        )
+        for (r in populated) assertTrue(!r.isEmpty, "${r::class.simpleName} should not report isEmpty")
+    }
+
+    @Test
+    fun `a populated quantile estimator reports finite quantiles again`() {
+        val sketch = DDSketchStat(probabilities = doubleArrayOf(0.5))
+        sketch.update(42.0)
+        assertTrue(sketch.read().quantiles[0].isFinite(), "the sentinel must not persist past the first observation")
+        sketch.reset()
+        assertTrue(sketch.read().quantiles[0].isNaN(), "reset returns the sketch to empty")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
@@ -9,12 +9,15 @@ import kotlin.test.assertTrue
 class DDSketchTest {
 
     @Test
-    fun `empty sketch returns zero quantiles`() {
+    fun `empty sketch returns NaN quantiles`() {
         val sketch = DDSketchStat(probabilities = doubleArrayOf(0.5, 0.9))
         val r = sketch.read()
-        assertEquals(0.0, r.quantiles[0])
-        assertEquals(0.0, r.quantiles[1])
+        // NaN, not 0.0: a zero-filled array is indistinguishable from a sketch that observed
+        // real zeros, so an untouched sketch used to report a p99 that read as healthy.
+        assertTrue(r.quantiles[0].isNaN(), "p50 was ${r.quantiles[0]}")
+        assertTrue(r.quantiles[1].isNaN(), "p90 was ${r.quantiles[1]}")
         assertEquals(0.0, r.totalWeights)
+        assertTrue(r.isEmpty)
     }
 
     @Test
@@ -113,7 +116,8 @@ class DDSketchTest {
         sketch.reset()
         val r = sketch.read()
         assertEquals(0.0, r.totalWeights)
-        assertEquals(0.0, r.quantiles[0])
+        assertTrue(r.quantiles[0].isNaN(), "a reset sketch is empty, so the quantile is NaN")
+        assertTrue(r.isEmpty)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/TDigestTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/TDigestTest.kt
@@ -9,12 +9,13 @@ import kotlin.test.assertTrue
 class TDigestTest {
 
     @Test
-    fun `empty digest returns zero quantiles`() {
+    fun `empty digest returns NaN quantiles`() {
         val td = TDigestStat(probabilities = doubleArrayOf(0.5, 0.9))
         val r = td.read()
-        assertEquals(0.0, r.quantiles[0])
-        assertEquals(0.0, r.quantiles[1])
+        assertTrue(r.quantiles[0].isNaN(), "p50 was ${r.quantiles[0]}")
+        assertTrue(r.quantiles[1].isNaN(), "p90 was ${r.quantiles[1]}")
         assertEquals(0.0, r.totalWeight)
+        assertTrue(r.isEmpty)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MadStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MadStatTest.kt
@@ -8,10 +8,12 @@ import kotlin.test.assertTrue
 class MadStatTest {
 
     @Test
-    fun `read before any update reports zero estimates`() {
+    fun `read before any update reports NaN estimates`() {
+        // MadStat is built on two TDigestStats, so it inherits their empty-read sentinel. An
+        // empty sample has no median, and reporting 0.0 claimed one.
         val r = MadStat().read()
-        assertEquals(0.0, r.median)
-        assertEquals(0.0, r.mad)
+        assertTrue(r.median.isNaN(), "median was ${r.median}")
+        assertTrue(r.mad.isNaN(), "mad was ${r.mad}")
     }
 
     @Test
@@ -47,15 +49,16 @@ class MadStatTest {
         val s = MadStat().apply { for (i in 0 until 100) update(i.toDouble()) }
         s.reset()
         val r = s.read()
-        assertEquals(0.0, r.median)
-        assertEquals(0.0, r.mad)
+        // A reset stat is empty again, and an empty sample has no median.
+        assertTrue(r.median.isNaN(), "median was ${r.median}")
+        assertTrue(r.mad.isNaN(), "mad was ${r.mad}")
     }
 
     @Test
     fun `create produces an independent stat`() {
         val tpl = MadStat().apply { for (i in 0 until 100) update(i.toDouble()) }
         val fresh = tpl.create()
-        assertEquals(0.0, fresh.read().median)
-        assertTrue(tpl.read().median != 0.0)
+        assertTrue(fresh.read().median.isNaN(), "a fresh stat has seen nothing, so it has no median")
+        assertTrue(tpl.read().median.isFinite(), "the populated template still reports a median")
     }
 }


### PR DESCRIPTION
Implements the recommendation from the empty-read survey documented in #27, which described the inconsistency without changing it.

The rule is now: report the identity element where the statistic has one, and NaN where it does not.

A sum of nothing genuinely is zero, and the infinities are the correct starting points for a min/max fold and cannot be mistaken for observed data, so those stay. An empty quantile sketch is different: it has no p99, and reporting 0.0 claimed one. That value is indistinguishable from a sketch which observed real zeros, so a service that had received no traffic rendered a p99 of zero and read as excellent rather than as absent. AucStat already returned NaN for exactly this case, so the library contradicted itself.

DDSketchStat and TDigestStat now fill the quantile array with NaN when the observation count is zero. MadStat is built on two TDigestStats and inherits the sentinel, which was not on my list but is the consistent outcome: an empty sample has no median either.

Mean, Variance and Moments still report 0.0. They have the same ambiguity, but changing them is a wider break than the sketches, and the argument is weaker, so that is left as a separate decision. The docs say so rather than implying the convention is complete.

Alongside it, HasObservationCount gives the emptiness check one name. The count was spelled totalWeights on most results, totalSeen on the sketches and totalWeight on a few others, so before this a caller had to know which field their particular stat used. The trait normalises that and supplies isEmpty; HasSampleVariance now extends it, which is source- and behaviour-compatible since it already declared totalWeights. Wired onto 21 result types, including the eight whose count had a different name.

Fallout was the six tests that pinned the old zeros: two in DDSketchTest, one in TDigestTest and three in MadStatTest. All updated to assert the sentinel and, where relevant, isEmpty. The MadStat ones are the interesting ones, since they show the change propagating through a composed stat rather than only at the sketch boundary.

Two incidental findings while writing the tests. CountStat delegates to SumStat and therefore returns SumResult, which means CountResult is dead code with no references anywhere. And a test named with a comma does not compile on Kotlin/Native, which is what checkNativeSafeTestNames exists to catch.

Note on merge order: this touches DDSketchStat and TDigestStat, as do #26 and #30. Merging #26 then #30 then this one is the cheapest order, and I will rebase this if the others land first.

Verified with jvmTest, jsNodeTest, wasmJsNodeTest, linuxX64Test, lintDocs, checkKdoc, checkNativeSafeTestNames, detektMainJvm and detektTestJvm.