### PR TITLE
feat: enable snapshot releases to Sonatype snapshots repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew --no-daemon publishToSonatypeSnapshots -PciVersion=${{ env.RELEASE_VERSION }}
+        run: ./gradlew --no-daemon publishAllPublicationsToSonatypeSnapshotsRepository -PciVersion=${{ env.RELEASE_VERSION }}
 
       - name: Detect pre-release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,22 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish to Maven Central (Portal)
+        if: ${{ !contains(env.RELEASE_VERSION, '-') }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USER }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew --no-daemon publishToMavenCentral -PciVersion=${{ env.RELEASE_VERSION }}
+
+      - name: Publish to Sonatype Snapshots
+        if: ${{ contains(env.RELEASE_VERSION, '-') }}
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew --no-daemon publishToSonatypeSnapshots -PciVersion=${{ env.RELEASE_VERSION }}
 
       - name: Detect pre-release
         run: |


### PR DESCRIPTION
## Summary
- Add conditional publishing logic to release workflow
- Publish final releases (v1.0.0) to Maven Central Portal
- Publish snapshot/pre-release versions (v1.0.0-SNAPSHOT, v1.0.0-RC1) to Sonatype snapshots (unlimited quota, no rate limits)

## Motivation
Allows testing and cross-repo dependencies on snapshots without consuming Maven Central release quota.