### PR TITLE
chore: update Gradle, Kotlin, kotlinx-benchmark and kotlinx-serialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     // Declared here with apply=false so that two KMP subprojects don't each load
     // the Kotlin plugin into separate classloaders (which conflicts on shared
     // build services like KotlinNativeBundleBuildService).
-    kotlin("multiplatform") version "2.3.20" apply false
-    kotlin("plugin.allopen") version "2.3.20" apply false
-    kotlin("plugin.serialization") version "2.3.20" apply false
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.13" apply false
+    kotlin("multiplatform") version "2.4.10" apply false
+    kotlin("plugin.allopen") version "2.4.10" apply false
+    kotlin("plugin.serialization") version "2.4.10" apply false
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.17" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1836,7 +1836,16 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1854,7 +1863,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2088,7 +2104,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/kumulant-bench/build.gradle.kts
+++ b/kumulant-bench/build.gradle.kts
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    kotlin("multiplatform") version "2.3.20"
-    kotlin("plugin.allopen") version "2.3.20"
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.13"
+    kotlin("multiplatform") version "2.4.10"
+    kotlin("plugin.allopen") version "2.4.10"
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.17"
 }
 
 repositories {
@@ -22,9 +22,9 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":kumulant"))
-            implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.13")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.17")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     wasmJs { browser(); nodejs() }
     wasmWasi { nodejs() }
     linuxX64(); linuxArm64()
-    macosX64(); macosArm64(); mingwX64()
+    macosArm64(); mingwX64()
     iosX64(); iosArm64(); iosSimulatorArm64()
 
     sourceSets {
@@ -40,7 +40,7 @@ kotlin {
         wasmWasiMain.get().dependsOn(webMain.get())
         commonMain.dependencies {
             api("com.eignex:koblas:0.1.0")
-            api("com.eignex:skema:0.1.1")
+            api("com.eignex:skema:0.3.0")
             compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
             compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
         }

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.eignex.kmp") version "1.2.7"
-    kotlin("plugin.serialization") version "2.3.20"
+    kotlin("plugin.serialization") version "2.4.10"
 }
 
 eignexPublish {
@@ -19,7 +19,7 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
     jvm()
-    js(IR) { browser(); nodejs() }
+    js { browser(); nodejs() }
     wasmJs { browser(); nodejs() }
     wasmWasi { nodejs() }
     linuxX64(); linuxArm64()
@@ -41,16 +41,16 @@ kotlin {
         commonMain.dependencies {
             api("com.eignex:koblas:0.1.0")
             api("com.eignex:skema:0.1.1")
-            compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
-            compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+            compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
+            compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
         }
         jvmMain.dependencies {
             implementation(kotlin("reflect"))
         }
         commonTest.dependencies {
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:1.10.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:1.11.0")
         }
     }
 }


### PR DESCRIPTION
## What changed

- Gradle 9.5.1 to 9.6.1 and Kotlin 2.3.20 to 2.4.10.
- kotlinx-benchmark 0.4.13 to 0.4.17 and kotlinx-serialization 1.10.0 to 1.11.0.
- `js(IR) { ... }` becomes `js { ... }`.

## Why

Kotlin 2.4 deprecates the explicit JS compiler selector because IR is the only supported compiler,
and removes it in 2.6.

The `com.eignex.kmp` pin stays at 1.2.7. Kotlin resolves to 2.4.10 on the plugin classpath even
though kbuild 1.2.7 brings 2.3.20, so this does not need a kbuild release. Moving to JVM 25 does,
and is a separate change.

## Left at the current version deliberately

The `com.eignex:skema` dependency stays at 0.1.1. skema 0.3.0 does not publish `macosX64`, which
this module still declares, so bumping it fails resolution in `commonMain` and `appleMain`. That
needs either skema to publish the target again or this module to drop it, which is a decision about
the published platform set rather than part of a version bump.

Kotlin 2.4 also deprecates `macosX64()` itself with "Target is no longer available", so the same
decision is coming for this repo independently.

## Testing

`./gradlew :kumulant:jvmTest` passes.