### PR TITLE
ci: bound the CI jobs with timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: Run tests and collect coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## What changed

- Every CI job declares `timeout-minutes: 45`.

## Why

Jobs were unbounded, so they fell back to the 6 hour job limit. A wedged Gradle daemon in kbuild
burned the full 6 hours twice before being killed, and produced no failure summary either time
because the daemon died mid-report. A bound turns that into a fast, readable failure.

45 leaves large headroom: the slowest job measured here is well under it.

## Testing

Each workflow is parsed and asserted to carry the setting on every job. No job logic changes.