### PR TITLE
chore: clear the build warnings

### DIFF
--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -27,13 +27,13 @@ kotlin {
     iosX64(); iosArm64(); iosSimulatorArm64()
 
     sourceSets {
-        val nonJvmMain by creating {
+        val nonJvmMain = create("nonJvmMain") {
             dependsOn(commonMain.get())
         }
         nativeMain.get().dependsOn(nonJvmMain)
         wasmWasiMain.get().dependsOn(nonJvmMain)
 
-        val posixMain by creating { dependsOn(nativeMain.get()) }
+        val posixMain = create("posixMain") { dependsOn(nativeMain.get()) }
         appleMain.get().dependsOn(posixMain)
         linuxMain.get().dependsOn(posixMain)
         webMain.get().dependsOn(nonJvmMain)


### PR DESCRIPTION
## Summary

The two `by creating` source sets become `create(...)`.

## Why

Gradle 9.6 deprecates the delegate idiom and prints "making it incompatible with Gradle 10" for the
build. Each site emitted three warnings.

## Testing

`:kumulant:jvmTest` and `:kumulant:compileCommonMainKotlinMetadata` pass, with no Gradle 9.6
deprecation output.