### PR TITLE
chore: take kbuild 1.2.8 and move CI to JDK 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       # Persists the Gradle home incl. the build and configuration caches across runs.
       - name: Set up Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: 25
           cache: gradle
 
       - name: Cache Kotlin/Native toolchain

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    id("com.eignex.kmp") version "1.2.7"
+    id("com.eignex.kmp") version "1.2.8"
     kotlin("plugin.serialization") version "2.4.10"
 }
 


### PR DESCRIPTION
## Summary

- `com.eignex.*` pins move from 1.2.7 to 1.2.8.
- CI moves to JDK 25 in both build.yml and release.yml.

## Why these are one commit

kbuild 1.2.8 publishes Java 25 bytecode and declares `"org.gradle.jvm.version": 25` in its Gradle
module metadata. Gradle reads that during dependency resolution, so a build whose Gradle runs on
JDK 21 cannot resolve the plugin at all:

    > Could not resolve com.eignex:kbuild:1.2.8.
       > Dependency requires at least JVM runtime version 25. This build uses a Java 21 JVM.

Splitting the change fails in either order. Bumping the pin alone breaks on a JDK 21 runner. Moving
CI to JDK 25 alone breaks too, because the 1.2.7 conventions request a toolchain of 21 that a
runner holding only JDK 25 cannot satisfy.

## What 1.2.8 brings

Gradle 9.6.1 to 9.7.0, Kotlin 2.3.20 to 2.4.10, Kover 0.9.9, detekt 2.0.0-alpha.5, JUnit 6.1.2,
`jvmToolchain(25)` across the kmp, jvm and cli conventions, and the plugin jvm target pinned rather
than inherited from whichever JDK CI happens to run.

## Testing

CI only. Once this lands the build needs JDK 25, which the machine used to prepare it does not have
and cannot auto-provision, so nothing here was built locally.

Local development needs a JDK 25 installed after this merges; no repo configures a toolchain
resolver.