### PR TITLE
chore: take kbuild 1.2.9

### DIFF
--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    id("com.eignex.kmp") version "1.2.9"
+    id("com.eignex.kmp") version "1.2.10"
     kotlin("plugin.serialization") version "2.4.10"
 }
 

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    id("com.eignex.kmp") version "1.2.8"
+    id("com.eignex.kmp") version "1.2.9"
     kotlin("plugin.serialization") version "2.4.10"
 }
 


### PR DESCRIPTION
## Summary

`com.eignex.*` pins move from 1.2.8 to 1.2.9.

## Why

1.2.9 carries detekt 2.0.0-alpha.6. alpha.5, which 1.2.8 shipped, reports constructor parameters as
undocumented when they are documented; koblas hit it on `LuDecomposition` and
`PivotedQrDecomposition`, whose parameters all carry `@property` or `@param` tags. Rewording,
unwrapping a continuation line and swapping `@property` for `@param` all left them flagged, and the
same files analyse clean under alpha.6.

Nothing else changed between 1.2.8 and 1.2.9.

## Testing

CI. kbuild 1.2.9 was verified before release with a dry run of the release workflow and with
`samples/smoke-test.sh`, which confirms the negative samples still fail with the rule ids they
assert, so alpha.6 has not changed what the rules detect.