### PR TITLE
chore: provision toolchains with the foojay resolver

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,4 +7,9 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Provisions the JDK the conventions ask for, so a machine without it does not need one installed.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 include(":kumulant", ":kumulant-bench")


### PR DESCRIPTION
## Summary

The foojay toolchain resolver is applied in settings, so Gradle can provision the JDK the
conventions ask for instead of requiring it to be installed already.

## Why

kbuild sets `jvmToolchain(25)`, so building needs a JDK 25 toolchain. Without a resolver a machine
that lacks one stops at:

    Cannot find a Java installation on your machine matching: {languageVersion=25, ...}.
    Toolchain download repositories have not been configured.

This only became worth doing with kbuild 1.2.10. Before it, the blocker was the Gradle **daemon**
JVM, which no resolver can provision; 1.2.10 emits Java 21 bytecode so the daemon floor is 21 again,
leaving the toolchain as the only requirement, and a toolchain can be downloaded.

It changes nothing where a JDK 25 is already present: Gradle prefers what it detects and only
downloads when nothing matches.

## Testing

Verified against the case it is meant to fix, a machine with no JDK 25 in scope. Running on JDK 22
with an empty `GRADLE_USER_HOME`, `jvmTest` passes and Temurin 25.0.1 is provisioned into that
home rather than found:

    <gradle-home>/jdks/eclipse_adoptium-25-amd64-linux.2  ->  Language Version: 25

## Trade-off

Builds gain the ability to download JDKs, which some locked-down environments disallow. The
alternative is every developer installing JDK 25 by hand.