### PR TITLE
refactor: drop private val from constructor params read only at construction

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -45,7 +45,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
     private val chooseTemplate: RegressionStat<out Result>? = null,
     private val updateJointTemplate: RegressionStat<out Result>? = null,
     private val updateMarginalTemplate: RegressionStat<out Result>? = null,
-    private val updateArmRewardTemplate: PairedStat<out Result>? = null,
+    updateArmRewardTemplate: PairedStat<out Result>? = null,
     private val nowNanos: () -> Long = { 0L },
 ) : ContextualBandit {
 
@@ -142,8 +142,8 @@ class TrackedContextualBandit<B : ContextualBandit>(
 class TrackedUnivariateBandit<B : UnivariateBandit>(
     /** Underlying bandit; exposed for `PerArmBandit` / `Scorable` access. */
     val inner: B,
-    private val chooseTemplate: SeriesStat<out Result>? = null,
-    private val updateArmRewardTemplate: PairedStat<out Result>? = null,
+    chooseTemplate: SeriesStat<out Result>? = null,
+    updateArmRewardTemplate: PairedStat<out Result>? = null,
     private val nowNanos: () -> Long = { 0L },
 ) : UnivariateBandit {
 


### PR DESCRIPTION
## Summary

Drops the `private val` modifier from constructor parameters that are only read while the object is
being built, leaving them as plain constructor parameters.

## Why

detekt 2.0.0-alpha.6 reports these through `UnusedPrivateProperty`. The message reads "Private
property `x` is unused", which is misleading, and it is why this looked like a false positive at
first: the name is referenced later in the file. The rule is right, though. Each of these is read
only from `init` or a property initializer, so storing it as a property keeps a field alive that
nothing reads afterwards. Removing the modifier keeps the parameter and drops the field.

detekt names this deliberately, from detekt/detekt#9491; the wording is being discussed in
detekt/detekt#9571.

The change is valid on the detekt version in use today; it does not need alpha.6 to land first.

## Testing

`detekt` and `jvmTest` pass, and the modules compile, verified against a kbuild built with detekt
alpha.6 so the rule was actually running.