### PR TITLE
ci: build every pull request, not only those based on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 # A newer push supersedes any in-flight run for the same ref.


### PR DESCRIPTION
## Summary

`build.yml` runs on every pull request rather than only those based on `main`.

## Why

The workflow already ran on pull requests, so this is not about turning CI on; it is about which
pull requests it covers. `pull_request: branches: [ main ]` means a stacked pull request — one branch
based on another, targeting that other branch — gets no checks at all and can merge unverified.

klause hit this and dropped the filter; the change here is the same, comment included, so the repos
agree. `push` stays restricted to `main`, so this adds no duplicate runs beyond the stacked case it
is meant to cover.

## Testing

The workflow parses, and its trigger now matches klause's byte for byte: `pull_request` present with
no base filter, `push` still `[ main ]`.
