### PR TITLE
chore: update koblas to 0.1.1-SNAPSHOT and migrate to its reshaped API

### DIFF
--- a/kumulant-bench/build.gradle.kts
+++ b/kumulant-bench/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    // The koblas snapshot arrives transitively through :kumulant.
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        mavenContent { snapshotsOnly() }
+    }
 }
 
 kotlin {

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -13,6 +13,14 @@ eignexPublish {
     githubRepo.set("Eignex/kumulant")
 }
 
+// koblas has no release carrying the reshaped API yet, so the dependency below is a
+// snapshot and needs the snapshot repository alongside the Central one kbuild adds.
+repositories {
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        mavenContent { snapshotsOnly() }
+    }
+}
+
 kotlin {
     applyDefaultHierarchyTemplate()
     compilerOptions {
@@ -39,7 +47,7 @@ kotlin {
         webMain.get().dependsOn(nonJvmMain)
         wasmWasiMain.get().dependsOn(webMain.get())
         commonMain.dependencies {
-            api("com.eignex:koblas:0.1.0")
+            api("com.eignex:koblas:0.1.1-SNAPSHOT")
             api("com.eignex:skema:0.3.0")
             compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
             compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -1,5 +1,5 @@
-// math convention: single-letter matrices L, M, etc.
-@file:Suppress("VariableNaming", "FunctionParameterNaming", "PropertyName")
+// math convention: the Cholesky factor is L, as everywhere it is written down.
+@file:Suppress("PropertyName")
 
 package com.eignex.kumulant.math
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -1,0 +1,82 @@
+// math convention: single-letter matrices L, M, etc.
+@file:Suppress("VariableNaming", "FunctionParameterNaming", "PropertyName")
+
+package com.eignex.kumulant.math
+
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorView
+import com.eignex.koblas.dense.trsv
+import com.eignex.koblas.forEachStored
+import com.eignex.koblas.norm2
+import kotlin.math.absoluteValue
+import kotlin.math.sqrt
+
+/**
+ * In-place Cholesky rank-1 downdate of a lower-triangular factor: modifies [this] so that the
+ * matrix `A = L·Lᵀ` it represents becomes `A - x·xᵀ`. Returns `0.0` on success, or a positive
+ * "norm" value when the downdate would leave the matrix outside the positive-definite cone; the
+ * caller then repairs via a fresh decomposition or takes a smaller step.
+ *
+ * koblas covers a defined BLAS/LAPACK subset and the rank-1 factor update is outside it, so it
+ * lives here, with the one caller that needs it: [com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat]
+ * tracks the posterior covariance factor across observations instead of refactorizing per update.
+ *
+ * Solve `L·s = x` by forward substitution; if `‖s‖ < 1` the downdate stays SPD. Then apply Givens
+ * rotations to the rows of L to absorb `s` without breaking triangularity. The rotation loop is
+ * carried in `xx` and stays scalar; the substitution goes through the backend's `trsv`.
+ */
+internal fun DenseMatrix.choleskyDowndateInPlace(x: VectorView): Double {
+    require(rows == cols) { "choleskyDowndateInPlace requires a square matrix; got ${rows}x$cols" }
+    require(rows == x.size) { "x size ${x.size} must match matrix dim $rows" }
+    if (rows == 0) return 0.0 // an empty downdate stays in the cone trivially
+    val n = rows
+    val L = data
+
+    // Scatter rather than index x: SparseVector.get is a linear scan, so a per-element read would
+    // be quadratic in its nonzeros.
+    val s = DoubleArray(n)
+    x.forEachStored { i, v -> s[i] = v }
+    trsv(this, s, lower = true)
+
+    val norm = norm2(DenseVector.wrap(s))
+    if (norm <= 0.0 || norm >= 1.0) return norm
+
+    val c = DoubleArray(n)
+    var alpha = sqrt(1.0 - norm * norm)
+    for (ii in 0 until n) {
+        val i = n - ii - 1
+        val scale = alpha + s[i].absoluteValue
+        val a = alpha / scale
+        val b = s[i] / scale
+        val nrm = sqrt(a * a + b * b)
+        c[i] = a / nrm
+        s[i] = b / nrm
+        alpha = scale * nrm
+    }
+    // Apply the rotations along the rows of L; entry (j, i) of the column-major backing is at
+    // `j + i * n`.
+    for (j in 0 until n) {
+        var xx = 0.0
+        for (i in j downTo 0) {
+            val idx = j + i * n
+            val t = c[i] * xx + s[i] * L[idx]
+            L[idx] = c[i] * L[idx] - s[i] * xx
+            xx = t
+        }
+    }
+    return 0.0
+}
+
+/**
+ * Zero the strict upper triangle of a Cholesky factor. koblas only promises the lower triangle of
+ * `CholeskyDecomposition.l`, leaving whatever the backend wrote above the diagonal, so a factor
+ * that gets stored in a snapshot is cleaned first: the snapshots are compared and serialised, and
+ * two mathematically equal posteriors have to agree entry for entry.
+ */
+internal fun DenseMatrix.zeroUpperTriangle(): DenseMatrix {
+    for (j in 1 until cols) {
+        for (i in 0 until minOf(j, rows)) this[i, j] = 0.0
+    }
+    return this
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/package.md
@@ -1,10 +1,21 @@
 # Package com.eignex.kumulant.math
 
-Distribution sampling and stream-hash functions consumed by the rest of
-the library. The vector / matrix primitives and BLAS-style linear algebra
-live in the separate [koblas](https://github.com/Eignex/koblas) library
-(`com.eignex.koblas`); this package holds only the sampling and hashing
-helpers.
+Distribution sampling, stream-hash functions, and the few numeric
+routines that sit outside koblas, consumed by the rest of the library.
+The vector / matrix primitives and BLAS-style linear algebra live in the
+separate [koblas](https://github.com/Eignex/koblas) library
+(`com.eignex.koblas`), which covers a defined BLAS/LAPACK subset; what
+falls outside that subset and only kumulant needs lives here.
+
+## Linear-algebra helpers
+
+- `choleskyDowndateInPlace`: rank-1 downdate of a lower-triangular
+  Cholesky factor, so
+  [BayesianRegressionStat][com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat]
+  can track the posterior covariance factor across observations instead
+  of refactorizing per update.
+- `zeroUpperTriangle`: clears the strict upper triangle of a factor,
+  which koblas leaves unspecified, before it is stored in a snapshot.
 
 ## Distribution sampling
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -158,16 +158,19 @@ class BayesianRegressionStat(
         if (denom == 0.0) return@guarded
         scale(z, sqrt(wc) / denom)
 
-        // Downdate the Cholesky factor; repair on instability.
+        // Downdate the Cholesky factor; repair on instability. The downdate leaves the factor
+        // untouched for any norm at or above one, so the repair has to trigger on the same
+        // condition: treating an exact 1.0 as success downdates the covariance below without its
+        // factor, and the two never agree again.
         var norm = covarianceL.choleskyDowndateInPlace(z)
-        if (norm > 1.0) {
+        if (norm >= 1.0) {
             for (i in 0 until featureSize) covariance[i, i] = covariance[i, i] + 1e-5
             val Lnew = covariance.cholesky(CholeskyPolicy.Regularize()).l
             for (i in 0 until featureSize) {
                 for (j in 0..i) covarianceL[i, j] = Lnew[i, j]
             }
             norm = covarianceL.choleskyDowndateInPlace(z)
-            while (norm > 1.0) {
+            while (norm >= 1.0) {
                 scale(z, 1.0 / (norm + 1e-5))
                 norm = covarianceL.choleskyDowndateInPlace(z)
             }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -7,17 +7,20 @@ import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.MatrixView
 import com.eignex.koblas.VectorView
-import com.eignex.koblas.addOuter
 import com.eignex.koblas.axpy
-import com.eignex.koblas.cholesky
-import com.eignex.koblas.choleskyDowndateInPlace
+import com.eignex.koblas.dense.CholeskyDecomposition
+import com.eignex.koblas.dense.CholeskyPolicy
+import com.eignex.koblas.dense.cholesky
+import com.eignex.koblas.dense.invert
+import com.eignex.koblas.dense.solve
 import com.eignex.koblas.dot
-import com.eignex.koblas.invertSpd
+import com.eignex.koblas.ger
 import com.eignex.koblas.matVec
 import com.eignex.koblas.scale
-import com.eignex.koblas.solveSpd
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.math.choleskyDowndateInPlace
+import com.eignex.kumulant.math.zeroUpperTriangle
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
@@ -102,10 +105,16 @@ class BayesianRegressionStat(
     private val initialCovariance: DenseMatrix = priorCovariance
         ?.let { DenseMatrix.of(it.toArray()) }
         ?: DenseMatrix.diagonal(featureSize, priorVariance)
-    private val initialCovarianceL: DenseMatrix = initialCovariance.cholesky(regularizeNonPD = false)
+    private val initialCovarianceL: DenseMatrix
 
     // Prior precision H_prior = Sigma_prior^-1, cached so merge() can subtract one prior factor.
-    private val priorPrecisionMatrix: DenseMatrix = invertSpd(initialCovarianceL)
+    private val priorPrecisionMatrix: DenseMatrix
+
+    init {
+        val chol = initialCovariance.cholesky(CholeskyPolicy.Strict)
+        initialCovarianceL = chol.l.zeroUpperTriangle()
+        priorPrecisionMatrix = chol.invert()
+    }
 
     // priorInfo = H_prior * mu_prior, the natural-form contribution from the prior.
     private val priorInfo: DoubleArray = DoubleArray(featureSize).also { out ->
@@ -144,7 +153,7 @@ class BayesianRegressionStat(
         //   S_new = S - (w_c * S x xT S) / (1 + w_c * xT S x)
         //         = S - z zT, where z = sqrt(w_c) * S x / sqrt(1 + w_c * xT S x).
         val wc = weight * curvature
-        val z = matVec(covariance, x)
+        val z = covariance.matVec(x)
         val denom = sqrt(1.0 + wc * (x dot z))
         if (denom == 0.0) return@guarded
         scale(z, sqrt(wc) / denom)
@@ -153,7 +162,7 @@ class BayesianRegressionStat(
         var norm = covarianceL.choleskyDowndateInPlace(z)
         if (norm > 1.0) {
             for (i in 0 until featureSize) covariance[i, i] = covariance[i, i] + 1e-5
-            val Lnew = covariance.cholesky()
+            val Lnew = covariance.cholesky(CholeskyPolicy.Regularize()).l
             for (i in 0 until featureSize) {
                 for (j in 0..i) covarianceL[i, j] = Lnew[i, j]
             }
@@ -165,10 +174,10 @@ class BayesianRegressionStat(
         }
 
         // Sum = Sum - z * zT  (rank-1 downdate of the covariance).
-        addOuter(covariance, -1.0, z, z)
+        ger(-1.0, z, z, covariance)
 
         // Posterior mean update: w += (weight * residual) * S_new * x.
-        axpy(weights, weight * residual, matVec(covariance, x))
+        axpy(weights, weight * residual, covariance.matVec(x))
 
         biasPrecision += wc
         bias += weight * residual / biasPrecision
@@ -215,11 +224,11 @@ class BayesianRegressionStat(
         lock.guarded {
             val n = featureSize
 
-            val hSelf = invertSpd(covarianceL)
-            val hOther = invertSpd(values.covarianceL)
+            val hSelf = CholeskyDecomposition(covarianceL).invert()
+            val hOther = CholeskyDecomposition(values.covarianceL).invert()
 
             // H_new = H_self + H_other - H_prior.
-            val hNew = DenseMatrix(n, n)
+            val hNew = DenseMatrix.zero(n, n)
             for (i in 0 until n) {
                 for (j in 0 until n) {
                     hNew[i, j] = hSelf[i, j] + hOther[i, j] - priorPrecisionMatrix[i, j]
@@ -237,10 +246,10 @@ class BayesianRegressionStat(
             }
 
             // Solve H_new * mu_new = b via chol(H_new); reuse the same factor for Sum_new.
-            val Lh = hNew.cholesky()
-            val muNew = solveSpd(Lh, b)
-            val sigmaNew = invertSpd(Lh)
-            val LsigmaNew = sigmaNew.cholesky()
+            val hChol = hNew.cholesky(CholeskyPolicy.Regularize())
+            val muNew = hChol.solve(b)
+            val sigmaNew = hChol.invert()
+            val LsigmaNew = sigmaNew.cholesky(CholeskyPolicy.Regularize()).l.zeroUpperTriangle()
 
             for (i in 0 until n) {
                 weights[i] = muNew[i]
@@ -329,7 +338,7 @@ class BayesianRegressionStat(
             for (i in 0 until n) muPop[i] /= wTotal
 
             // Sigma_pop = weighted mean of Sigma_i + weighted covariance of (mu_i - mu_pop).
-            val sigmaPop = DenseMatrix(n, n)
+            val sigmaPop = DenseMatrix.zero(n, n)
             for (s in snapshots.indices) {
                 val wi = weights[s] / wTotal
                 val cov = snapshots[s].covariance

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -215,10 +215,10 @@ class BayesianRegressionStat(
      *
      * For a non-zero prior mean the `H_prior * mu_prior` correction is subtracted
      * from the information vector as well, otherwise the merged posterior would
-     * count the prior shift twice. When `H_new` drifts outside SPD the Cholesky
-     * helper's diagonal clamp catches it and returns a regularised result rather
-     * than NaNs. Bias is merged the same way, treating the intercept as a scalar
-     * Gaussian with zero prior mean.
+     * count the prior shift twice. When `H_new` drifts outside SPD,
+     * `CholeskyPolicy.Regularize` clamps the offending pivot and factors a nearby
+     * matrix rather than returning NaNs. Bias is merged the same way, treating
+     * the intercept as a scalar Gaussian with zero prior mean.
      */
     override fun merge(values: CovarianceRegressionResult) {
         require(values.featureSize == featureSize) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -139,7 +139,7 @@ data object MultivariateGaussian : LinearPosterior<CovarianceRegressionResult> {
         exploration: Double,
     ): Double {
         val mean = snapshot.predict(x)
-        val sigmaX = matVec(snapshot.covariance, x)
+        val sigmaX = snapshot.covariance.matVec(x)
         val variance = x dot sigmaX
         return mean + sqrt(exploration * variance) * rng.nextNormal()
     }
@@ -166,7 +166,7 @@ data object LinUcb : LinearPosterior<CovarianceRegressionResult> {
         exploration: Double,
     ): Double {
         val mean = snapshot.predict(x)
-        val sigmaX = matVec(snapshot.covariance, x)
+        val sigmaX = snapshot.covariance.matVec(x)
         val variance = x dot sigmaX
         return mean + exploration * sqrt(variance)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.math
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
 import com.eignex.koblas.dense.cholesky
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -74,6 +75,66 @@ class CholeskyTest {
         val norm = l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(3.0, 4.0)))
 
         assertTrue(norm >= 1.0, "expected a rejected downdate, got norm=$norm")
+    }
+
+    @Test
+    fun `downdate reports the norm at the cone boundary rather than silently doing nothing`() {
+        // ||L^-1 x|| == 1 exactly: the downdate cannot proceed, and the factor is left alone.
+        val l = DenseMatrix.of(
+            arrayOf(
+                doubleArrayOf(4.0, 0.0),
+                doubleArrayOf(0.0, 4.0),
+            ),
+        ).cholesky().l
+        val before = product(l)
+
+        val norm = l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(2.0, 0.0)))
+
+        assertEquals(1.0, norm, 1e-12, "the boundary reports rejection, not success")
+        assertMatrixEquals(before, product(l))
+    }
+
+    @Test
+    fun `downdate takes a sparse vector`() {
+        val a = arrayOf(
+            doubleArrayOf(5.0, 1.0, 0.0),
+            doubleArrayOf(1.0, 4.0, 1.0),
+            doubleArrayOf(0.0, 1.0, 3.0),
+        )
+        val l = DenseMatrix.of(a).cholesky().l
+        val x = doubleArrayOf(0.0, 0.4, 0.0)
+
+        val norm = l.choleskyDowndateInPlace(
+            SparseVector.of(size = 3, indices = intArrayOf(1), values = doubleArrayOf(0.4)),
+        )
+
+        assertEquals(0.0, norm)
+        val expected = Array(3) { i -> DoubleArray(3) { j -> a[i][j] - x[i] * x[j] } }
+        assertMatrixEquals(expected, product(l))
+    }
+
+    @Test
+    fun `downdate handles a one by one factor`() {
+        val l = DenseMatrix.of(arrayOf(doubleArrayOf(4.0))).cholesky().l
+
+        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(1.0))))
+
+        assertEquals(3.0, product(l)[0][0], 1e-12)
+    }
+
+    @Test
+    fun `downdate of a zero vector leaves the factor unchanged`() {
+        val l = DenseMatrix.of(
+            arrayOf(
+                doubleArrayOf(2.0, 0.5),
+                doubleArrayOf(0.5, 1.0),
+            ),
+        ).cholesky().l
+        val before = product(l)
+
+        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(0.0, 0.0))))
+
+        assertMatrixEquals(before, product(l))
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,0 +1,99 @@
+package com.eignex.kumulant.math
+
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.dense.cholesky
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CholeskyTest {
+
+    // Reconstruct A = L * LT from the lower triangle of a factor.
+    private fun product(l: DenseMatrix): Array<DoubleArray> {
+        val n = l.rows
+        return Array(n) { i ->
+            DoubleArray(n) { j ->
+                var s = 0.0
+                for (k in 0..minOf(i, j)) s += l[i, k] * l[j, k]
+                s
+            }
+        }
+    }
+
+    private fun assertMatrixEquals(expected: Array<DoubleArray>, actual: Array<DoubleArray>, tol: Double = 1e-9) {
+        for (i in expected.indices) {
+            for (j in expected[i].indices) {
+                assertEquals(expected[i][j], actual[i][j], tol, "entry ($i, $j)")
+            }
+        }
+    }
+
+    @Test
+    fun `downdate subtracts the rank-one term from the factored matrix`() {
+        val a = arrayOf(
+            doubleArrayOf(4.0, 1.0),
+            doubleArrayOf(1.0, 3.0),
+        )
+        val x = doubleArrayOf(0.5, 0.25)
+        val l = DenseMatrix.of(a).cholesky().l
+
+        val norm = l.choleskyDowndateInPlace(DenseVector.of(x))
+
+        assertEquals(0.0, norm, "downdate inside the cone reports success")
+        val expected = Array(2) { i -> DoubleArray(2) { j -> a[i][j] - x[i] * x[j] } }
+        assertMatrixEquals(expected, product(l))
+    }
+
+    @Test
+    fun `downdate handles a three by three factor`() {
+        val a = arrayOf(
+            doubleArrayOf(6.0, 1.0, 0.5),
+            doubleArrayOf(1.0, 5.0, 2.0),
+            doubleArrayOf(0.5, 2.0, 4.0),
+        )
+        val x = doubleArrayOf(0.3, -0.6, 0.2)
+        val l = DenseMatrix.of(a).cholesky().l
+
+        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(x)))
+
+        val expected = Array(3) { i -> DoubleArray(3) { j -> a[i][j] - x[i] * x[j] } }
+        assertMatrixEquals(expected, product(l))
+    }
+
+    @Test
+    fun `downdate reports a norm at or above one when it would leave the cone`() {
+        val l = DenseMatrix.of(
+            arrayOf(
+                doubleArrayOf(1.0, 0.0),
+                doubleArrayOf(0.0, 1.0),
+            ),
+        ).cholesky().l
+
+        // x with ||L^-1 x|| >= 1 cannot be subtracted and stay positive-definite.
+        val norm = l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(3.0, 4.0)))
+
+        assertTrue(norm >= 1.0, "expected a rejected downdate, got norm=$norm")
+    }
+
+    @Test
+    fun `zeroUpperTriangle clears everything above the diagonal`() {
+        val m = DenseMatrix.of(
+            arrayOf(
+                doubleArrayOf(1.0, 2.0, 3.0),
+                doubleArrayOf(4.0, 5.0, 6.0),
+                doubleArrayOf(7.0, 8.0, 9.0),
+            ),
+        )
+
+        m.zeroUpperTriangle()
+
+        for (i in 0 until 3) {
+            for (j in 0 until 3) {
+                if (j > i) assertEquals(0.0, m[i, j], "entry ($i, $j) above the diagonal")
+            }
+        }
+        assertEquals(4.0, m[1, 0])
+        assertEquals(9.0, m[2, 2])
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -65,6 +65,25 @@ class BayesianRegressionStatTest {
     }
 
     @Test
+    fun `the factor survives an update that saturates the downdate at the cone boundary`() {
+        // A weight this large drives the downdate's norm to exactly 1.0, where it rejects and
+        // leaves the factor alone. The repair has to run anyway, or the covariance moves without
+        // its factor.
+        val stat = BayesianRegressionStat(featureSize = 2, priorVariance = 1.0)
+
+        stat.update(doubleArrayOf(1.0, 1.0), 1.0, 1e18)
+
+        val r = stat.read()
+        for (i in 0 until 2) {
+            for (j in 0 until 2) {
+                var s = 0.0
+                for (k in 0..minOf(i, j)) s += r.covarianceL[i, k] * r.covarianceL[j, k]
+                assertEquals(r.covariance[i, j], s, 1e-9, "L * LT disagrees with the covariance at ($i, $j)")
+            }
+        }
+    }
+
+    @Test
     fun `merge on Bayesian combines posteriors via density product`() {
         val a = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)
         val b = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -48,6 +48,23 @@ class BayesianRegressionStatTest {
     }
 
     @Test
+    fun `the tracked factor keeps reproducing the covariance across updates`() {
+        // The factor is downdated alongside the covariance rather than refactorized, so the two
+        // can only be trusted to agree if every downdate lands. L * LT has to stay equal to S.
+        val stat = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)
+        fitLine(stat, doubleArrayOf(0.8, 1.2, -0.5), intercept = 0.3, n = 500)
+        val r = stat.read()
+
+        for (i in 0 until 3) {
+            for (j in 0 until 3) {
+                var s = 0.0
+                for (k in 0..minOf(i, j)) s += r.covarianceL[i, k] * r.covarianceL[j, k]
+                assertEquals(r.covariance[i, j], s, 1e-9, "L * LT disagrees with the covariance at ($i, $j)")
+            }
+        }
+    }
+
+    @Test
     fun `merge on Bayesian combines posteriors via density product`() {
         val a = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)
         val b = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -27,6 +27,23 @@ class BayesianRegressionStatTest {
         }
     }
 
+    // The factor is downdated alongside the covariance rather than refactorized, so the two can
+    // only be trusted to agree if every downdate lands. L * LT has to stay equal to S. The
+    // tolerance is relative because the covariance entries span many orders of magnitude across
+    // these tests.
+    private fun assertFactorReproducesCovariance(r: CovarianceRegressionResult, relativeTolerance: Double = 1e-9) {
+        val n = r.featureSize
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                var s = 0.0
+                for (k in 0..minOf(i, j)) s += r.covarianceL[i, k] * r.covarianceL[j, k]
+                val expected = r.covariance[i, j]
+                val tol = relativeTolerance * maxOf(1.0, abs(expected))
+                assertEquals(expected, s, tol, "L * LT disagrees with the covariance at ($i, $j)")
+            }
+        }
+    }
+
     @Test
     fun `bayesian should recover ground truth and shrink covariance`() {
         val stat = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)
@@ -49,19 +66,10 @@ class BayesianRegressionStatTest {
 
     @Test
     fun `the tracked factor keeps reproducing the covariance across updates`() {
-        // The factor is downdated alongside the covariance rather than refactorized, so the two
-        // can only be trusted to agree if every downdate lands. L * LT has to stay equal to S.
         val stat = BayesianRegressionStat(featureSize = 3, priorVariance = 1.0)
         fitLine(stat, doubleArrayOf(0.8, 1.2, -0.5), intercept = 0.3, n = 500)
-        val r = stat.read()
 
-        for (i in 0 until 3) {
-            for (j in 0 until 3) {
-                var s = 0.0
-                for (k in 0..minOf(i, j)) s += r.covarianceL[i, k] * r.covarianceL[j, k]
-                assertEquals(r.covariance[i, j], s, 1e-9, "L * LT disagrees with the covariance at ($i, $j)")
-            }
-        }
+        assertFactorReproducesCovariance(stat.read())
     }
 
     @Test
@@ -73,14 +81,20 @@ class BayesianRegressionStatTest {
 
         stat.update(doubleArrayOf(1.0, 1.0), 1.0, 1e18)
 
-        val r = stat.read()
-        for (i in 0 until 2) {
-            for (j in 0 until 2) {
-                var s = 0.0
-                for (k in 0..minOf(i, j)) s += r.covarianceL[i, k] * r.covarianceL[j, k]
-                assertEquals(r.covariance[i, j], s, 1e-9, "L * LT disagrees with the covariance at ($i, $j)")
-            }
-        }
+        assertFactorReproducesCovariance(stat.read())
+    }
+
+    @Test
+    fun `the factor survives a saturating update that the diagonal bump cannot lift off the cone`() {
+        // A prior this wide puts the repair's 1e-5 diagonal bump below the covariance's own ULP,
+        // so refactorizing reproduces the same factor and the retried downdate saturates at 1.0
+        // again. That is the case the shrink step exists for: it scales z down until the downdate
+        // lands, and the covariance must be downdated by the same scaled z.
+        val stat = BayesianRegressionStat(featureSize = 2, priorVariance = 1e12)
+
+        stat.update(doubleArrayOf(1.0, 1.0), 1.0, 1e18)
+
+        assertFactorReproducesCovariance(stat.read())
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -189,8 +189,8 @@ class LinearPosteriorsTest {
                 biasPrecision = 1.0,
                 totalWeights = 0.0,
                 step = 0L,
-                covariance = DenseMatrix(3, 3),
-                covarianceL = DenseMatrix(3, 3),
+                covariance = DenseMatrix.zero(3, 3),
+                covarianceL = DenseMatrix.zero(3, 3),
             )
         }
     }


### PR DESCRIPTION
## What changed

- Bumped koblas from 0.1.0 to 0.1.1-SNAPSHOT and added the Sonatype snapshot repository to both modules, since kbuild only wires Maven Central.
- Moved to the reshaped factorization API: `cholesky` returns a `CholeskyDecomposition`, and `solveSpd` / `invertSpd` became `solve` / `invert` on it.
- Replaced `addOuter(m, alpha, x, y)` with `ger(alpha, x, y, m)` and the free `matVec(a, x)` with `a.matVec(x)`.
- Passed `CholeskyPolicy.Regularize()` at the three call sites that relied on the old regularising default, and `CholeskyPolicy.Strict` where the prior covariance is validated.
- Ported the rank-1 Cholesky downdate into `math/Cholesky.kt`, since koblas dropped it as outside its BLAS subset. The port is column-major and covered by a new test.
- Switched the internal `DenseMatrix(rows, cols)` constructor to the `DenseMatrix.zero` factory.
- Fixed the repair condition in `BayesianRegressionStat.update`, which asked for `norm > 1.0` where the downdate rejects at `norm >= 1.0`.

## Why

koblas moved 200 commits past its only release and reshaped its public API on the way, so kumulant could not pick up any of it. The change worth calling out is that dense matrices are now column-major. That one is invisible to the compiler: code indexing `data` directly keeps building and starts reading the wrong entries. kumulant only touches `data` in one elementwise copy between same-shaped matrices, which is layout-agnostic, so nothing there had to change, but the ported downdate had to be written against the new layout rather than copied across.

The repair-condition fix is not a migration artifact; the mismatch predates this branch. The downdate leaves the factor untouched for any norm at or above one, so an exact 1.0 meant the covariance was downdated by `ger` while its factor was not, and the two never agreed again. Thompson draws read the factor, so they kept sampling from a stale and too-wide covariance. A weight of 1e18 saturates the ratio to exactly 1.0 and reproduces it: the factor reports a variance of 1.0 where the covariance says 0.5.

Two things to be aware of before this ships. The dependency is a snapshot, so kumulant cannot be released against it as it stands, and koblas needs a v0.1.1 tag first.

The second is snapshot compatibility. `DenseMatrix` serialises its flat backing, so any matrix persisted under koblas 0.1.0 decodes transposed under this version. Symmetric matrices are unaffected, which covers the regression covariances themselves, but every asymmetric one is wrong on read. That includes `GaussianNaiveBayesStat` means and variances, `SoftmaxRegressionStat` weights, and `CovarianceRegressionResult.covarianceL`, which is lower triangular. The last one fails quietly rather than loudly: an old factor decodes into the upper triangle, leaving a zero diagonal, and `merge` then inverts it and divides by zero. Nothing in the library migrates old payloads, so a decode path for 0.1.0 snapshots is still owed.

## Testing

`./gradlew build` passes: the JVM suite plus the js, wasmJs, wasmWasi and linuxX64 ones. `CholeskyTest` checks the ported downdate against a directly computed `A - x·xᵀ` in two and three dimensions, and covers the sparse input, the one-by-one and zero-vector cases, the cone boundary, and the upper-triangle clear.

Three tests in `BayesianRegressionStatTest` assert that `L·Lᵀ` still equals the covariance: one after five hundred ordinary updates, one after a saturating update, and one after a saturating update under a prior wide enough that the repair's 1e-5 diagonal bump falls below the covariance's own ULP. The second fails on the old `>` condition with the mismatch quoted above. The third is what reaches the shrink step, which no test touched before; I confirmed the coverage by making that line throw and watching only this test fail. All three run on every target, the CBLAS-backed linuxX64 one included.
