### PR TITLE
refactor: name the two guards that were open-coded across the stat catalogue

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireFeatureSize
 import kotlin.random.Random
 
 /**
@@ -87,14 +88,14 @@ class TrackedContextualBandit<B : ContextualBandit>(
         (updateArmRewardTemplate?.create(null) as PairedStat<Result>?)
 
     override fun choose(x: VectorView): Int {
-        require(x.size == contextFeatureSize) { "x.size=${x.size}, expected $contextFeatureSize" }
+        x.requireFeatureSize(contextFeatureSize)
         val i = inner.choose(x)
         chooseStat?.update(x, i.toDouble(), nowNanos(), 1.0)
         return i
     }
 
     override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
-        require(x.size == contextFeatureSize) { "x.size=${x.size}, expected $contextFeatureSize" }
+        x.requireFeatureSize(contextFeatureSize)
         inner.update(armIndex, x, reward, weight)
         val ts = nowNanos()
         if (updateJointStat != null) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -231,7 +231,7 @@ interface HasLinearModel : Result {
      * this is the linear predictor pre-link.
      */
     fun predict(x: VectorView): Double {
-        require(x.size == weights.size) { "x.size=${x.size}, expected ${weights.size}" }
+        x.requireFeatureSize(weights.size)
         var sum = bias
         for (i in 0 until weights.size) sum += x[i] * weights[i]
         return sum

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -1,0 +1,24 @@
+package com.eignex.kumulant.core
+
+import com.eignex.koblas.VectorView
+
+/**
+ * Reject a context vector whose arity does not match the model's.
+ *
+ * Every [RegressionStat] opens its `update` with this check, and every linear-model [Result] repeats
+ * it in `predict` / `logit`, because a mismatched vector does not fail loudly on its own: a *short*
+ * vector simply reads fewer coordinates and returns a plausible number from the wrong model. Fourteen
+ * sites spelled the same `require` out by hand, twice within the same file in two of them.
+ *
+ * The message is deliberately identical to the hand-written form - `x.size=<n>, expected <m>` - so it
+ * stays greppable and so the assertion in `RegressionOpsTest` keeps meaning what it meant. The one
+ * site left spelling it out is `HalfSpaceTreesStat.update`, whose receiver is named `vector` and whose
+ * message says so.
+ *
+ * @param expected the model's feature count.
+ * @throws IllegalArgumentException if [VectorView.size] differs from [expected].
+ */
+@Suppress("NOTHING_TO_INLINE") // as with the weight predicates; the non-JVM targets pay for the call
+internal inline fun VectorView.requireFeatureSize(expected: Int) {
+    require(size == expected) { "x.size=$size, expected $expected" }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
@@ -15,6 +15,23 @@ package com.eignex.kumulant.core
 internal inline fun Double.isInertWeight(): Boolean = this == 0.0 || isNaN()
 
 /**
+ * True when a weight is not a live positive observation, for the stats that cannot downdate.
+ *
+ * The sibling of [isInertWeight], and the difference between them is the whole point of having both
+ * named. [isInertWeight] is for a stat whose recurrence inverts, so a negative weight is a legitimate
+ * downdate and only zero and `NaN` are no-ops. This one is for a stat that has no inverse - a sketch,
+ * a histogram bucket, an SGD step - where a negative weight is not a removal but a corruption, and is
+ * dropped alongside the inert cases. See [Stat] for which stats fall on which side.
+ *
+ * Written as a negated comparison rather than `this <= 0.0 || isNaN()` because `NaN > 0.0` is already
+ * false: the `NaN` case falls out of the comparison instead of needing a second clause a caller has to
+ * remember. Twenty call sites used to spell out the two-clause form, and the sites that spelled it out
+ * slightly differently are exactly where the class-label defects lived.
+ */
+@Suppress("NOTHING_TO_INLINE") // as with isInertWeight; the non-JVM targets pay for the call
+internal inline fun Double.isNotPositiveWeight(): Boolean = !(this > 0.0)
+
+/**
  * Guard the one negative-weight case that corrupts a Welford accumulator.
  *
  * A negative [weight] is a legitimate downdate: it removes an observation that was

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.core.requireFeatureSize
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.random.Random
@@ -193,7 +194,7 @@ internal class FoldRegressionStat<R : Result>(
         require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
     }
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         delegate.update(project(x, y), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
@@ -217,7 +218,7 @@ class HalfSpaceTreesStat(
 
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         for (t in 0 until numTrees) {
             val leafIdx = routeToLeaf(t, vector)
             latestMass.add(t * numLeaves + leafIdx, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
@@ -85,7 +86,7 @@ data class HalfSpaceTreesResult(
      * i.e. it looks normal. Lower score flags an anomaly.
      */
     fun score(x: VectorView): Double {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         var total = 0.0
         val depthFactor = 1 shl height
         for (t in 0 until numTrees) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.LongHasher
@@ -125,7 +126,7 @@ class HyperLogLogStat(
     private val totalSeen: StreamLong = mode.newLong(0L)
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         val hash = hasher.mix(value)
         val idx = (hash ushr (64 - precision)).toInt() and (m - 1)
         val w = hash shl precision

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.cardinality
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.LongHasher
@@ -115,7 +116,7 @@ class LinearCountingStat(
     private val totalSeen: StreamLong = mode.newLong(0L)
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         val hash = hasher.mix(value)
         val pos = hash and mask
         val wordIdx = (pos ushr 6).toInt()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.decay
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.currentTimeNanos
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
@@ -106,7 +107,7 @@ class DecayingVarianceStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         // Both before the lock: a dropped observation neither contends for it nor moves the landmark.
-        if (weight <= 0.0 || weight.isNaN()) return // a zero weight is a no-op; see Stat
+        if (weight.isNotPositiveWeight()) return // no inverse here, so a negative drops too; see Stat
         lock.guarded {
             val scaledWeight = weight * advanceTo(timestampNanos)
             if (scaledWeight <= 0.0) return@guarded // the sample is so late its weight underflowed away

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.ArrayBins
 import com.eignex.kumulant.stream.additiveMode
 import kotlin.math.abs
@@ -92,7 +93,7 @@ class DDSketchStat(
     private val negativeBins = ArrayBins(mode)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         // NaN has no rank, so it cannot go in a bin. Previously it fell through the sign
         // comparisons into the zero bucket and was silently counted as an observation of
         // zero, which shifts every quantile. LinearHistogramStat already drops it.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
@@ -54,7 +55,7 @@ class FrugalQuantileStat(
     private val quantile = mode.newDouble(initialEstimate)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             val m = quantile.load()
             val delta = if (value > m) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.additiveMode
 import kotlin.math.ceil
@@ -118,7 +119,7 @@ class HdrHistogramStat(
     }
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         // `!(value < 0.0)`, not `value >= 0.0`: both reject a negative value, but every comparison
         // against NaN is false, so the `>=` form rejected a NaN as though it were negative and threw.
         // A NaN observation must not become an exception in the caller - it scales to bucket zero and

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.quantile
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.ArrayBins
 import com.eignex.kumulant.stream.additiveMode
 import kotlin.math.abs
@@ -57,7 +58,7 @@ class LinearHistogramStat(
     private val bins = ArrayBins(mode)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         totalWeights.add(weight)
 
         when {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.quantile
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
@@ -213,7 +214,7 @@ class ReservoirHistogramStat(
     }
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         outerLock.guarded {
             val key = drawKey(weight)
             admit(value, key)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.quantile
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
@@ -346,7 +347,7 @@ class TDigestStat(
     }
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         outerLock.guarded {
             while (true) {
                 val claimed = bufferIndex.addAndGet(1L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.guarded
@@ -66,7 +67,7 @@ data class GaussianNaiveBayesResult(
 
     /** Unnormalised log-posterior `log prior[c] + Sum_i log N(x_i | mu_c, var_c)`. */
     fun logPosterior(x: VectorView, c: Int): Double {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         var s = ln(prior(c).coerceAtLeast(SMALL_PROB))
         for (i in 0 until featureSize) {
             val mu = means[c, i]
@@ -155,7 +156,7 @@ class GaussianNaiveBayesStat(
     private val totalWeightCell: StreamDouble = mode.newDouble(0.0)
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.guarded
@@ -155,7 +156,7 @@ class GaussianNaiveBayesStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and
             // slipped past the range check as a valid label. Round-tripping through Double is what

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stream.StreamDouble
@@ -54,7 +55,7 @@ data class SoftmaxRegressionResult(
 
     /** Linear predictor for class [k]: `biases[k] + weights[k] . x`. */
     fun logit(x: VectorView, k: Int): Double {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         var s = biases[k]
         for (i in 0 until featureSize) s += weights[k, i] * x[i]
         return s
@@ -151,7 +152,7 @@ class SoftmaxRegressionStat(
     val crossEntropy: Double by crossEntropyCell
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stream.StreamDouble
@@ -151,7 +152,7 @@ class SoftmaxRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and
             // slipped past the range check as a valid label. Round-tripping through Double is what

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -20,6 +20,7 @@ import com.eignex.koblas.scale
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.choleskyDowndateInPlace
 import com.eignex.kumulant.math.zeroUpperTriangle
 import com.eignex.kumulant.stream.guarded
@@ -137,7 +138,7 @@ class BayesianRegressionStat(
     private var sse: Double = 0.0
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             step++

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -19,6 +19,7 @@ import com.eignex.koblas.matVec
 import com.eignex.koblas.scale
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.math.choleskyDowndateInPlace
 import com.eignex.kumulant.math.zeroUpperTriangle
 import com.eignex.kumulant.stream.guarded
@@ -137,7 +138,7 @@ class BayesianRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             step++
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
@@ -83,7 +84,7 @@ class DiagonalRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             step++
             val eta = learningRate.eval(step.toDouble())

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
@@ -83,7 +84,7 @@ class DiagonalRegressionStat(
     private var sse: Double = 0.0
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             step++

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.requireFeatureSize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -45,7 +46,7 @@ sealed interface LinearRegressionResult :
 
     /** Linear predictor `eta = bias + x . weights`, before the inverse link. */
     fun linearPredictor(x: VectorView): Double {
-        require(x.size == weights.size) { "x.size=${x.size}, expected ${weights.size}" }
+        x.requireFeatureSize(weights.size)
         var sum = bias
         for (i in 0 until weights.size) sum += x[i] * weights[i]
         return sum

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -126,7 +127,7 @@ class StochasticRegressionStat(
     }
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             stepCell.addAndGet(1L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -5,6 +5,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -126,7 +127,7 @@ class StochasticRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             stepCell.addAndGet(1L)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.HasSlope
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stat.summary.VarianceResult
 import com.eignex.kumulant.stream.getValue
 import com.eignex.kumulant.stream.guarded
@@ -116,7 +117,7 @@ class UnivariateRegressionStat(
     val meanY: Double by my
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             val nextW = w.addAndGet(weight)
             val oldW = nextW - weight

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -4,6 +4,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireFeatureSize
 import kotlin.random.Random
 
 /**
@@ -46,7 +47,7 @@ class DecisionTreeClassifierStat(
     )
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight <= 0.0 || y.isNaN()) return
         tree.update(x, y.toInt(), weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.random.Random
@@ -76,7 +77,7 @@ class DecisionTreeRegressionStat(
     )
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         // A zero-weight call still advanced the leaves' observationsSinceLastCheck and shifted the
         // split-audit cadence; see Stat for the contract.
         if (weight.isInertWeight()) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -57,7 +58,7 @@ class RandomForestClassifierStat(
     )
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         if (weight <= 0.0 || y.isNaN()) return
         val c = y.toInt()
         if (c !in 0 until numClasses) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.nextPoissonOne
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -78,7 +79,7 @@ class RandomForestRegressionStat(
     )
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        require(x.size == featureSize) { "x.size=${x.size}, expected $featureSize" }
+        x.requireFeatureSize(featureSize)
         // Return before drawing from baggingRng: a zero-weight call used to consume one draw per
         // tree, desynchronising every later bagging draw and changing the forest's predictions. The
         // classifier already guards this.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
@@ -119,7 +120,7 @@ class BloomFilterStat(
     private val totalSeen: StreamLong = mode.newLong(0L)
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         val h1 = hasher.mix(value)
         val h2 = hasher.mix(h1)
         for (i in 0 until hashes) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.Hashers
@@ -141,7 +142,7 @@ class CountMinSketchStat(
         // `weight <= 0.0` is false for NaN, and `ceil(NaN).toLong()` is 0, which the coerce below
         // lifted to 1 - so a NaN weight silently became a real observation of weight one. Counters
         // are Long and have no NaN to propagate into, so the observation is dropped; see Stat.
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         // Counters are Long, so a fractional weight has to be rounded. Round *up*: rounding to
         // nearest silently discarded everything below 0.5 - including totalSeen, so the stat denied
         // observations it had seen - whereas rounding up keeps every observation and leaves the

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.LongHasher
@@ -129,7 +130,7 @@ class MinHashStat(
     private val totalSeen: StreamLong = mode.newLong(0L)
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         for (i in 0 until numHashes) {
             casMin(signatures, i, hasher.mix(value xor salts[i]))
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.sketch
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
@@ -188,7 +189,7 @@ class SpaceSavingStat(
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         // As in CountMinSketchStat: NaN passes `weight <= 0.0`, and rounding it lands on 1, so a NaN
         // weight became a real observation. Counts are Long, so there is nothing to propagate into.
-        if (weight <= 0.0 || weight.isNaN()) return
+        if (weight.isNotPositiveWeight()) return
         // Counts are Long, so a fractional weight has to be rounded. Round *up*: rounding to nearest
         // dropped everything below 0.5 outright, so a key accumulating many small weights never
         // appeared among the heavy hitters at all. Counts are upper bounds as a result.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.schema.spec.ConfusionMatrix
 import com.eignex.kumulant.schema.spec.CountMinSketch
 import com.eignex.kumulant.schema.spec.Covariance
 import com.eignex.kumulant.schema.spec.DiscreteStatSpec
+import com.eignex.kumulant.schema.spec.HyperLogLog
 import com.eignex.kumulant.schema.spec.IsotonicCalibrator
 import com.eignex.kumulant.schema.spec.LinearCounting
 import com.eignex.kumulant.schema.spec.LogLoss
@@ -47,6 +48,9 @@ class PairedAndDiscreteContractSweepTest {
     )
 
     private val discreteSpecs: List<Pair<String, DiscreteStatSpec<*>>> = listOf(
+        // HyperLogLog was missing from this catalogue, which is how it stayed the one sketch no sweep
+        // covered even though it carries the same weight guard as the other five.
+        "HyperLogLog" to HyperLogLog(),
         "LinearCounting" to LinearCounting(),
         "BloomFilter" to BloomFilter(),
         "CountMinSketch" to CountMinSketch(),
@@ -134,6 +138,44 @@ class PairedAndDiscreteContractSweepTest {
     }
 
     @Test
+    fun `a negative weight is a no-op for every discrete sketch`() {
+        // The discrete modality is entirely no-inverse: there is no bucket decrement that undoes a
+        // hash insert into a Bloom filter or an HLL register, so these all drop a negative weight
+        // rather than downdating it. Sojourn is the one exception in the catalogue - it accumulates
+        // residence time additively and subtracts, so it guards on isInertWeight like the series
+        // accumulators. See isNotPositiveWeight for why the two predicates are named separately.
+        val violations = mutableListOf<String>()
+        for ((name, spec) in discreteSpecs) {
+            if (name in DOWNDATES) continue
+
+            // A key none of the primed updates used, so a live-weight probe visibly moves every
+            // sketch here; without that the negative-weight assertion below would be vacuous.
+            val absorbing = spec.materialize()
+            keys.forEachIndexed { i, k -> absorbing.update(k, i.toLong() * 1_000_000_000L, 1.0) }
+            val baseline = absorbing.read(readAt)
+            absorbing.update(PROBE_KEY, readAt, 1.0)
+            if (absorbing.read(readAt) == baseline) {
+                violations += "$name ignored a positive-weight key, so the negative case proves nothing"
+                continue
+            }
+
+            val stat = spec.materialize()
+            keys.forEachIndexed { i, k -> stat.update(k, i.toLong() * 1_000_000_000L, 1.0) }
+            val before = stat.read(readAt)
+
+            val thrown = runCatching { stat.update(PROBE_KEY, readAt, -1.0) }.exceptionOrNull()
+            if (thrown != null) {
+                violations += "$name threw on a negative weight: ${thrown.message}"
+                continue
+            }
+
+            val after = stat.read(readAt)
+            if (before != after) violations += "$name absorbed a negative-weight key: $before -> $after"
+        }
+        assertEquals(emptyList(), violations.map { it.take(110) }, "a sketch must drop a negative weight")
+    }
+
+    @Test
     fun `no paired stat throws on a NaN value`() {
         // Both positions separately: a paired stat reaches x and y through different arithmetic, so
         // one being safe is no evidence about the other. A NaN value propagates rather than being
@@ -194,5 +236,16 @@ class PairedAndDiscreteContractSweepTest {
             if (fresh != stat.read(readAt)) violations += "$name: ${stat.read(readAt)} != fresh $fresh"
         }
         assertEquals(emptyList(), violations.toList(), "reset must restore the fresh state")
+    }
+
+    private companion object {
+        /**
+         * The one discrete stat whose accumulation inverts, so a negative weight subtracts rather than
+         * being dropped. Everything else in the catalogue is a hash sketch with no decrement.
+         */
+        val DOWNDATES = setOf("Sojourn")
+
+        /** A key none of the primed updates touch, so a live-weight probe moves every sketch. */
+        const val PROBE_KEY = 97L
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
@@ -156,6 +156,45 @@ class SeriesStatContractSweepTest {
     }
 
     @Test
+    fun `a negative weight is a no-op for every stat that cannot invert it`() {
+        // The third weight case, and the one the other two sweeps left open. Zero and NaN are no-ops
+        // library-wide, but a negative weight partitions the catalogue: a stat whose recurrence
+        // inverts treats it as a downdate, and a stat with no inverse - a sketch, a histogram bucket -
+        // has to drop it, because there is no bucket decrement that undoes a hash insert. Both halves
+        // are correct; what is not correct is a stat picking a third answer, which is what happened
+        // when this predicate was open-coded at twenty sites instead of named once as
+        // isNotPositiveWeight. The negative case is also the reason that helper is not isInertWeight.
+        val violations = mutableListOf<String>()
+        for (name in NO_INVERSE) {
+            val spec = specs.first { it.first == name }.second
+
+            // Vacuity guard first: the probe has to be an observation each stat would visibly absorb,
+            // or "state did not change" proves nothing. Without this the sweep would still pass if
+            // someone made every one of these stats ignore its input entirely.
+            val absorbing = primed(spec)
+            val baseline = absorbing.read(readAt)
+            absorbing.update(PROBE, readAt, 1.0)
+            if (absorbing.read(readAt) == baseline) {
+                violations += "$name ignored a positive-weight $PROBE, so the negative case proves nothing"
+                continue
+            }
+
+            val stat = primed(spec)
+            val before = stat.read(readAt)
+
+            val thrown = runCatching { stat.update(PROBE, readAt, -1.0) }.exceptionOrNull()
+            if (thrown != null) {
+                violations += "$name threw on a negative weight: ${thrown.message}"
+                continue
+            }
+
+            val after = stat.read(readAt)
+            if (before != after) violations += "$name absorbed a negative-weight $PROBE: $before -> $after"
+        }
+        assertEquals(emptyList(), violations.toList(), "a stat with no inverse must drop a negative weight")
+    }
+
+    @Test
     fun `no series stat throws on a NaN value`() {
         // A NaN value is not filtered - it propagates, and the stat reads back NaN. The one thing
         // ruled out is turning a gap in the input into an outage in the caller, which HdrHistogram
@@ -224,5 +263,24 @@ class SeriesStatContractSweepTest {
     private companion object {
         /** Stats that deliberately act on a NaN observation; see the exception noted on [Stat]. */
         val NAN_EXEMPT = setOf("RunLength")
+
+        /**
+         * Series stats whose recurrence has no inverse, so a negative weight is dropped rather than
+         * downdated. Membership is exactly the set that guards on `isNotPositiveWeight`; the rest of
+         * the catalogue guards on `isInertWeight` and subtracts. A new sketch or histogram belongs
+         * here, and adding it to the catalogue without adding it here is the drift this pins down.
+         */
+        val NO_INVERSE = setOf(
+            "DDSketch",
+            "DecayingVariance",
+            "FrugalQuantile",
+            "HdrHistogram",
+            "LinearHistogram",
+            "ReservoirHistogram",
+            "TDigest",
+        )
+
+        /** Outside the primed sample range, so every stat above visibly absorbs it at a live weight. */
+        const val PROBE = 999.0
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
@@ -1,0 +1,88 @@
+package com.eignex.kumulant.stat.regression
+
+import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import com.eignex.kumulant.stat.regression.tree.DecisionTreeClassifierStat
+import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
+import com.eignex.kumulant.stat.regression.tree.RandomForestClassifierStat
+import com.eignex.kumulant.stat.regression.tree.RandomForestRegressionStat
+import com.eignex.kumulant.stat.regression.tree.ThresholdSplit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val FEATURES = 3
+
+/**
+ * Arity of the context vector, swept across the regression catalogue.
+ *
+ * A wrong-arity vector is the one input error that does not announce itself: a *short* vector reads
+ * fewer coordinates and returns a perfectly plausible number from the wrong model, so a caller that
+ * reshapes its features and forgets to reshape the stat gets silently degraded predictions rather than
+ * an error. Every stat here guards its `update`, but the guard used to be fourteen hand-written copies
+ * of the same `require`; this sweep is what stops one of them going missing when a stat is added.
+ */
+class RegressionArityGuardTest {
+
+    private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
+
+    private val stats: List<Pair<String, RegressionStat<*>>> = listOf(
+        "StochasticRegression" to StochasticRegressionStat(featureSize = FEATURES),
+        "DiagonalRegression" to DiagonalRegressionStat(featureSize = FEATURES),
+        "BayesianRegression" to BayesianRegressionStat(featureSize = FEATURES),
+        "SoftmaxRegression" to SoftmaxRegressionStat(featureSize = FEATURES, numClasses = 2),
+        "GaussianNaiveBayes" to GaussianNaiveBayesStat(featureSize = FEATURES, numClasses = 2),
+        "DecisionTreeRegression" to DecisionTreeRegressionStat(FEATURES, splits),
+        "DecisionTreeClassifier" to DecisionTreeClassifierStat(FEATURES, numClasses = 2, splitCandidates = splits),
+        "RandomForestRegression" to RandomForestRegressionStat(FEATURES, splits, nbrTrees = 2),
+        "RandomForestClassifier" to RandomForestClassifierStat(FEATURES, numClasses = 2, splitCandidates = splits),
+    )
+
+    @Test
+    fun `every regression stat rejects a wrong-arity context vector`() {
+        // Short and long both, because the two fail differently: a long vector would at worst read
+        // past what the model uses, but a short one is the silent case the guard exists for.
+        val violations = mutableListOf<String>()
+        for ((name, stat) in stats) {
+            for (size in listOf(FEATURES - 1, FEATURES + 1)) {
+                val x = DenseVector.of(DoubleArray(size) { 1.0 })
+                val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
+                when {
+                    thrown == null -> violations += "$name accepted a vector of size $size"
+
+                    thrown !is IllegalArgumentException ->
+                        violations += "$name threw ${thrown::class.simpleName} rather than IllegalArgumentException"
+                }
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "a wrong-arity vector must be rejected")
+    }
+
+    @Test
+    fun `the rejection names both the size it got and the size it wanted`() {
+        // Pinned because the message is the only thing that tells a caller which of the two numbers to
+        // change, and because RegressionOpsTest greps it. requireFeatureSize keeps the wording that the
+        // hand-written copies had for exactly this reason.
+        for ((name, stat) in stats) {
+            val thrown = runCatching {
+                stat.update(DenseVector.of(doubleArrayOf(1.0)), 1.0)
+            }.exceptionOrNull()
+            val message = thrown?.message.orEmpty()
+            assertTrue("x.size=1" in message, "$name did not report the size it got: $message")
+            assertTrue("expected $FEATURES" in message, "$name did not report the size it wanted: $message")
+        }
+    }
+
+    @Test
+    fun `a correctly sized vector is still accepted`() {
+        // Guards the guard: a require that rejected everything would satisfy both tests above.
+        for ((name, stat) in stats) {
+            val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+            val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
+            assertEquals(null, thrown?.message, "$name rejected a correctly sized vector")
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Added `Double.isNotPositiveWeight()` to `core/Weights.kt` and adopted it at the 20 sites that open-coded `weight <= 0.0 || weight.isNaN()`. It is written as `!(this > 0.0)`, so the NaN case falls out of the comparison instead of needing a second clause.
- Added `VectorView.requireFeatureSize(expected)` to a new `core/Vectors.kt` and adopted it at 17 sites that spelled the same `require` out by hand, including twice within the same file in four of them. The message is unchanged.
- Added a negative-weight sweep to `SeriesStatContractSweepTest` and `PairedAndDiscreteContractSweepTest`, naming the stats whose recurrence has no inverse.
- Added `RegressionArityGuardTest`, sweeping the nine regression stats for wrong-arity context vectors.
- Added `HyperLogLog` to the discrete sweep catalogue, which had been missing it.

## Why

The two weight predicates in this library are one character apart when written out. `isInertWeight` is zero-or-NaN, for a stat whose recurrence inverts and can treat a negative weight as a downdate. The other is not-positive, for a stat with no inverse, where a negative weight is corruption rather than a removal. Only the first had a name, so the second was written by hand twenty times, and the sites that wrote it slightly differently are where the class-label defects in the follow-up PR live. Naming it removes the near-miss.

The arity guard is the same argument with less at stake. A short context vector does not fail on its own, it just reads fewer coordinates and returns a plausible number from the wrong model, so the guard has to be present at every entry point and there was no way to check that fourteen copies all were.

Neither change alters behaviour anywhere. The sweeps are new coverage rather than changed expectations, and the negative-weight contract in particular had no catalogue-wide test at all before this.

## Testing

`./gradlew build` passes, which covers all targets plus detekt and the ABI check. The new sweeps each carry a vacuity guard that asserts a live-weight probe does move the stat, so "state did not change" cannot pass by the stat ignoring its input. `RegressionArityGuardTest` has the same shape: one test that a correctly sized vector is still accepted, so a guard that rejected everything would not pass.
