### PR TITLE
refactor: collapse five duplicated helpers, three of which had already diverged

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
@@ -1,0 +1,43 @@
+package com.eignex.kumulant.bandit
+
+/**
+ * Floor applied to the played probability before it divides an importance-weighted reward.
+ *
+ * EXP3 and EXP4 both estimate an unbiased gain as `reward / p(played arm)`, so an arm the policy had
+ * all but written off produces an enormous gain estimate, and one it had written off entirely produces
+ * a non-finite one. The floor bounds that blow-up. It is deliberately far below any probability the
+ * exploration term `gamma / K` can produce, so it never perturbs a live distribution.
+ */
+internal const val MIN_PLAY_PROB: Double = 1e-12
+
+/** Above this maximum weight, rescale before `exp` overflows to infinity. */
+internal const val RENORM_THRESHOLD: Double = 1e100
+
+/** Below this maximum weight, rescale before the whole array underflows to zero. */
+internal const val RENORM_FLOOR: Double = 1e-100
+
+/**
+ * Keep an array of exponential weights inside the range where `exp` still carries information.
+ *
+ * The distribution these weights induce depends only on their *ratios*, so dividing the array through
+ * by its maximum is free: it changes no arm's or expert's relative standing. That is what makes both
+ * ends of the range recoverable rather than just the top one.
+ *
+ * Both ends need guarding, and only the overflow end used to be. A run of large negative rewards drives
+ * every `exp(eta * gain)` toward zero, and once the array is *entirely* zero no later reward can lift
+ * it: every subsequent update multiplies zero by something. Rescaling by the surviving maximum keeps
+ * the array alive; the fully collapsed case has no ratios left to preserve, so it resets to uniform.
+ *
+ * EXP3 and EXP4 carried separate copies of this, spelled with different branch structure - EXP3 tested
+ * the ceiling and the floor in two `if`s, EXP4 in one disjunction - but they compute the same thing.
+ */
+internal fun DoubleArray.renormaliseExponentialWeights() {
+    var maxW = 0.0
+    for (w in this) if (w > maxW) maxW = w
+    when {
+        maxW > RENORM_THRESHOLD || (maxW > 0.0 && maxW < RENORM_FLOOR) ->
+            for (i in indices) this[i] /= maxW
+
+        maxW == 0.0 -> for (i in indices) this[i] = 1.0
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -2,7 +2,9 @@ package com.eignex.kumulant.bandit.contextual
 
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
+import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable
+import com.eignex.kumulant.bandit.renormaliseExponentialWeights
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
@@ -159,13 +161,13 @@ class Exp4Bandit(
         require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)
-        val pPlayed = lastPlayDist[armIndex].coerceAtLeast(MIN_PROB)
+        val pPlayed = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
         val gainPlayed = reward / pPlayed
         for (i in experts.indices) {
             val expertGain = lastAdvice[i][armIndex] * gainPlayed
             weights[i] *= exp(eta * expertGain)
         }
-        normalizeIfNeeded()
+        weights.renormaliseExponentialWeights()
     }
 
     /** Current per-expert weights, normalised to sum to 1. */
@@ -186,7 +188,7 @@ class Exp4Bandit(
         // pool, then renormalise. Use for "roughly combine two parallel runs", not
         // principled aggregation.
         for (i in weights.indices) weights[i] *= other.weights[i]
-        normalizeIfNeeded()
+        weights.renormaliseExponentialWeights()
     }
 
     /** Reset all expert weights to uniform. */
@@ -198,25 +200,8 @@ class Exp4Bandit(
     /** Spawn a fresh bandit with the same experts and tunables; weights reset to uniform. */
     override fun create(random: Random): Exp4Bandit = Exp4Bandit(nbrArms, experts, eta, gamma, random)
 
-    private fun normalizeIfNeeded() {
-        var maxW = 0.0
-        for (w in weights) if (w > maxW) maxW = w
-        if (maxW > RENORM_THRESHOLD || (maxW > 0.0 && maxW < RENORM_FLOOR)) {
-            // Guard both ends. Only overflow was handled, so a run of large negative rewards drove
-            // every weight to zero with no way back; rescaling by the surviving maximum preserves
-            // the experts' relative standing, which is all the mixture depends on.
-            for (i in weights.indices) weights[i] /= maxW
-        } else if (maxW == 0.0) {
-            for (i in weights.indices) weights[i] = 1.0
-        }
-    }
-
     /** Default-tuning helpers. */
     companion object {
-        private const val MIN_PROB = 1e-12
-        private const val RENORM_THRESHOLD = 1e100
-        private const val RENORM_FLOOR = 1e-100
-
         /** Default learning rate from the EXP4 regret analysis: `sqrt(ln(N) / (T * K))`
          *  collapsed to a horizon-free form using `T = 1` as a starting heuristic. */
         fun defaultEta(nbrArms: Int, nbrExperts: Int): Double =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -1,7 +1,9 @@
 package com.eignex.kumulant.bandit.univariate
 
+import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.renormaliseExponentialWeights
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -111,10 +113,10 @@ class Exp3Bandit(
     override fun update(armIndex: Int, value: Double, weight: Double) {
         require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
         playDistribution().also { lastPlayDist = it }
-        val p = lastPlayDist[armIndex].coerceAtLeast(MIN_PROB)
+        val p = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
         val gain = (value * weight) / p
         weights[armIndex] *= exp(eta * gain)
-        renormaliseIfNeeded()
+        weights.renormaliseExponentialWeights()
     }
 
     /** Current per-arm weights, normalised to sum to 1. */
@@ -135,7 +137,7 @@ class Exp3Bandit(
         // then renormalise. Use for "roughly combine two parallel runs", not principled
         // aggregation.
         for (i in 0 until nbrArms) weights[i] *= other[i].weight
-        renormaliseIfNeeded()
+        weights.renormaliseExponentialWeights()
     }
 
     /** Reset all weights to uniform. */
@@ -147,30 +149,8 @@ class Exp3Bandit(
     /** Spawn a fresh bandit with the same tunables; weights reset. */
     override fun create(random: Random): Exp3Bandit = Exp3Bandit(nbrArms, eta, gamma, random)
 
-    private fun renormaliseIfNeeded() {
-        var maxW = 0.0
-        for (w in weights) if (w > maxW) maxW = w
-        if (maxW > RENORM_THRESHOLD) {
-            for (i in weights.indices) weights[i] /= maxW
-            return
-        }
-        // The overflow side was guarded but not the underflow side: a run of large negative rewards
-        // drives every exp(eta*gain) to zero, and once the whole array is zero no later reward can
-        // ever lift it. Rescaling by the surviving maximum keeps the arms' *relative* standing,
-        // which is all the distribution depends on.
-        if (maxW > 0.0 && maxW < RENORM_FLOOR) {
-            for (i in weights.indices) weights[i] /= maxW
-        } else if (maxW == 0.0) {
-            for (i in weights.indices) weights[i] = 1.0
-        }
-    }
-
     /** EXP3 tuning defaults from Auer et al. */
     companion object {
-        private const val MIN_PROB = 1e-12
-        private const val RENORM_THRESHOLD = 1e100
-        private const val RENORM_FLOOR = 1e-100
-
         /** Horizon-free default `eta = sqrt(ln(K) / K)`. */
         fun defaultEta(nbrArms: Int): Double = sqrt(ln(nbrArms.toDouble().coerceAtLeast(2.0)) / nbrArms)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
@@ -1,0 +1,39 @@
+package com.eignex.kumulant.math
+
+import kotlin.math.exp
+
+/**
+ * Turn an array of logits into probabilities in place, and report whether the sum was usable.
+ *
+ * Standard max-subtracting softmax: `exp(z - max)` before summing, so the largest exponent is exactly
+ * `exp(0) == 1` and nothing overflows however large the logits get. Subtracting a constant from every
+ * logit leaves the softmax unchanged, which is what makes the trick free.
+ *
+ * In place because all three call sites already own a scratch array they built for this, so returning a
+ * fresh one would add an allocation per observation on the softmax training path.
+ *
+ * @return `true` if the array now holds probabilities. The `false` case is carried over from the three
+ *  copies this replaces, all of which guarded on the sum being positive, and it is retained so this
+ *  behaves exactly as they did - but it cannot currently fire. The shift guarantees one element is
+ *  `exp(0) == 1`, so a finite input always sums to at least 1; and a non-finite input makes the sum
+ *  `NaN`, which fails `<= 0.0` too. A `NaN` logit therefore returns `true` with a `NaN` array, which is
+ *  how a single `NaN` feature poisons a softmax model's weights for good. That is a real defect, older
+ *  than this function and unchanged by it, and fixing it means deciding what a model should do with an
+ *  unusable feature rather than tightening this guard alone.
+ */
+internal fun DoubleArray.softmaxInPlace(): Boolean {
+    if (isEmpty()) return false
+    var maxLogit = this[0]
+    for (i in 1 until size) if (this[i] > maxLogit) maxLogit = this[i]
+    var z = 0.0
+    for (i in indices) {
+        this[i] = exp(this[i] - maxLogit)
+        z += this[i]
+    }
+    if (z <= 0.0) return false
+    // One reciprocal and a multiply per element rather than a divide per element; this runs once per
+    // observation on the training path, and the update site already spelled it this way.
+    val invZ = 1.0 / z
+    for (i in indices) this[i] *= invZ
+    return true
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -70,9 +70,8 @@ internal fun <R : Result> SeriesStat<R>.foldRegression(
     project: (VectorView, Double) -> Double,
 ): RegressionStat<R> = FoldRegressionStat(this, featureSize, project)
 
-private fun checkEvery(every: Int) = require(every >= 1) { "throttle every must be >= 1, got $every" }
-
-private fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate must be in [0, 1], got $rate" }
+// checkEvery and checkRate now come from Sampling.kt, which owns the other four modalities' throttle
+// and sample wrappers. This file used to carry byte-identical private copies.
 
 internal class FilterRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -51,9 +51,16 @@ internal fun <R : Result> VectorStat<R>.sample(rate: Double, random: Random): Ve
 internal fun <R : Result> DiscreteStat<R>.sample(rate: Double, random: Random): DiscreteStat<R> =
     SampleDiscreteStat(this, rate, random)
 
-private fun checkEvery(every: Int) = require(every >= 1) { "throttle every must be >= 1, got $every" }
+/**
+ * Reject a throttle period that would forward nothing or everything unpredictably.
+ *
+ * `internal` rather than file-private because the regression modality's wrappers live over in
+ * `RegressionOps.kt` and had their own byte-identical copy of this and [checkRate].
+ */
+internal fun checkEvery(every: Int) = require(every >= 1) { "throttle every must be >= 1, got $every" }
 
-private fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate must be in [0, 1], got $rate" }
+/** Reject a sampling rate outside the unit interval; see [checkEvery] on why this is `internal`. */
+internal fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate must be in [0, 1], got $rate" }
 
 internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val every: Int) :
     SeriesStat<R>,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.guarded
@@ -15,7 +16,6 @@ import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.max
 
@@ -81,14 +81,7 @@ data class GaussianNaiveBayesResult(
     /** Normalised class probabilities via log-sum-exp on the log-posterior. */
     fun probabilities(x: VectorView): DoubleArray {
         val logs = DoubleArray(numClasses) { logPosterior(x, it) }
-        var maxL = logs[0]
-        for (k in 1 until numClasses) if (logs[k] > maxL) maxL = logs[k]
-        var z = 0.0
-        for (k in 0 until numClasses) {
-            logs[k] = exp(logs[k] - maxL)
-            z += logs[k]
-        }
-        if (z > 0.0) for (k in 0 until numClasses) logs[k] /= z
+        logs.softmaxInPlace()
         return logs
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stream.StreamDouble
@@ -19,7 +20,6 @@ import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.exp
 import kotlin.math.ln
 
 /**
@@ -64,14 +64,7 @@ data class SoftmaxRegressionResult(
     /** Softmax probabilities across all classes for [x]; length [numClasses]. */
     fun probabilities(x: VectorView): DoubleArray {
         val etas = DoubleArray(numClasses) { logit(x, it) }
-        var maxEta = etas[0]
-        for (k in 1 until numClasses) if (etas[k] > maxEta) maxEta = etas[k]
-        var z = 0.0
-        for (k in 0 until numClasses) {
-            etas[k] = exp(etas[k] - maxEta)
-            z += etas[k]
-        }
-        if (z > 0.0) for (k in 0 until numClasses) etas[k] /= z
+        etas.softmaxInPlace()
         return etas
     }
 
@@ -170,17 +163,9 @@ class SoftmaxRegressionStat(
                 x.forEachStored { i, v -> dot += weightsCell.load(k * featureSize + i) * v }
                 etas[k] = dot
             }
-            var maxEta = etas[0]
-            for (k in 1 until numClasses) if (etas[k] > maxEta) maxEta = etas[k]
-            var z = 0.0
-            for (k in 0 until numClasses) {
-                etas[k] = exp(etas[k] - maxEta)
-                z += etas[k]
-            }
-            if (z <= 0.0) return@guarded
-            val invZ = 1.0 / z
-            // Probabilities live in etas[] now.
-            for (k in 0 until numClasses) etas[k] *= invZ
+            // Probabilities live in etas[] from here on. A false return means every exponential
+            // underflowed, so there is no distribution to take a gradient against.
+            if (!etas.softmaxInPlace()) return@guarded
             val logProbC = ln(etas[c].coerceAtLeast(SOFTMAX_EPS))
             crossEntropyCell.add(-logProbC * weight)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -113,12 +113,7 @@ class DiagonalRegressionStat(
                     precision[i] += weight * curvature * v * v
                     weights[i] -= eta * weight * (negResidual * v) / precision[i]
                     val threshold = eta * weight * p.lambda / precision[i]
-                    val wi = weights[i]
-                    weights[i] = when {
-                        wi > threshold -> wi - threshold
-                        wi < -threshold -> wi + threshold
-                        else -> 0.0
-                    }
+                    weights[i] = softThreshold(weights[i], threshold)
                 }
             }
             biasPrecision += weight * curvature

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Penalty.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Penalty.kt
@@ -33,3 +33,29 @@ sealed interface Penalty {
         val lambda: Double,
     ) : Penalty
 }
+
+/**
+ * Soft-thresholding (the proximal operator of the L1 norm): shrink [w] toward zero by [threshold],
+ * stopping at zero rather than crossing it.
+ *
+ * This is the one operation every L1 path in the package needs, and all three hosts had their own copy:
+ * [StochasticRegressionStat] as a named private function, [DiagonalRegressionStat] open-coded in its
+ * proximal step, [UnivariateRegressionStat] open-coded in its `read`-time projection.
+ *
+ * The non-positive guard is not decoration, and it is why the three copies were not equivalent. A
+ * [Penalty.L1] carries no positivity requirement on its `lambda`, so a negative one is constructible,
+ * and every host derives its threshold by multiplying lambda by something positive. Without the guard
+ * the `when` below reads inside out: at `w = 0` and `threshold = -t`, the first branch matches and
+ * returns `+t`, so a negative lambda pushed weights *away* from zero instead of toward it. Shrinking by
+ * a negative amount is not shrinking, so the guard returns [w] untouched and the penalty simply does
+ * nothing, which is what the stochastic host already did.
+ *
+ * @param w the current coefficient.
+ * @param threshold shrinkage magnitude; a non-positive value leaves [w] alone.
+ */
+internal fun softThreshold(w: Double, threshold: Double): Double = when {
+    threshold <= 0.0 -> w
+    w > threshold -> w - threshold
+    w < -threshold -> w + threshold
+    else -> 0.0
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -119,13 +119,6 @@ class StochasticRegressionStat(
     private fun requireSgdLearningRate(): ScalarExpr = sgdLearningRate ?: error("Sgd learning rate required")
     private fun requireSgdBiasRate(): ScalarExpr = sgdBiasRate ?: error("Sgd bias rate required")
 
-    private fun softThreshold(w: Double, threshold: Double): Double = when {
-        threshold <= 0.0 -> w
-        w > threshold -> w - threshold
-        w < -threshold -> w + threshold
-        else -> 0.0
-    }
-
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/UnivariateRegressionStat.kt
@@ -180,12 +180,7 @@ class UnivariateRegressionStat(
             Penalty.None -> if (ssx > 0.0) ssxy / ssx else 0.0
 
             is Penalty.L1 -> {
-                val threshold = p.lambda * totalW
-                val shrunk = when {
-                    ssxy > threshold -> ssxy - threshold
-                    ssxy < -threshold -> ssxy + threshold
-                    else -> 0.0
-                }
+                val shrunk = softThreshold(ssxy, p.lambda * totalW)
                 if (ssx > 0.0) shrunk / ssx else 0.0
             }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -9,8 +9,6 @@ import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.ceil
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
@@ -103,8 +101,6 @@ class RandomForestClassifierStat(
 
     /** Live underlying classification trees. Use for inspection. */
     fun trees(): List<ClassificationTree> = trees.toList()
-
-    private fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble())).toInt().coerceAtLeast(1)
 }
 
 /** Snapshot of a [RandomForestClassifierStat]: per-tree immutable snapshots plus

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -12,8 +12,6 @@ import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.ceil
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
@@ -121,8 +119,6 @@ class RandomForestRegressionStat(
 
     /** Live underlying trees. Use for inspection. */
     fun trees(): List<RegressionTree<VectorView>> = trees.toList()
-
-    private fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble())).toInt().coerceAtLeast(1)
 }
 
 /** Snapshot of a [RandomForestRegressionStat]: per-tree immutable snapshots. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -1,0 +1,17 @@
+package com.eignex.kumulant.stat.regression.tree
+
+import kotlin.math.ceil
+import kotlin.math.sqrt
+
+/**
+ * Breiman's default random-subspace size: `ceil(sqrt(p))` candidates drawn per audit leaf.
+ *
+ * Both forests default `mtry` to this when the caller leaves it null, and both used to carry their own
+ * private copy of the expression. The clamp matters at the small end - `ceil(sqrt(1))` is already 1, but
+ * `coerceAtLeast(1)` keeps an mtry of zero from disabling growth silently if the arithmetic is ever
+ * changed - and `p <= 0` returns 0 rather than 1 because an empty candidate pool means no growth at all
+ * rather than growth on one candidate that does not exist.
+ *
+ * @param p size of the tree's full candidate-split pool.
+ */
+internal fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble())).toInt().coerceAtLeast(1)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
@@ -1,0 +1,99 @@
+package com.eignex.kumulant.bandit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val DELTA = 1e-12
+
+/**
+ * The shared EXP3 / EXP4 weight renormaliser. Both policies had their own copy, spelled with different
+ * branch structure, and the tests below are the ratio-preservation argument that makes the rescale safe.
+ */
+class ExponentialWeightsTest {
+
+    @Test
+    fun `weights inside the usable range are left alone`() {
+        val w = doubleArrayOf(1.0, 2.0, 0.5)
+
+        w.renormaliseExponentialWeights()
+
+        assertEquals(1.0, w[0], DELTA)
+        assertEquals(2.0, w[1], DELTA)
+        assertEquals(0.5, w[2], DELTA)
+    }
+
+    @Test
+    fun `an overflowing array is rescaled and keeps every ratio`() {
+        val w = doubleArrayOf(1e200, 5e199, 2e200)
+        val ratioBefore = w[0] / w[2]
+
+        w.renormaliseExponentialWeights()
+
+        assertTrue(w.all { it <= 1.0 }, "not brought back into range: ${w.toList()}")
+        assertEquals(1.0, w[2], DELTA, "the maximum should land on exactly one")
+        assertEquals(ratioBefore, w[0] / w[2], DELTA, "the rescale changed an arm's relative standing")
+    }
+
+    @Test
+    fun `an underflowing array is rescaled rather than left to die`() {
+        // The half that used to be unguarded in EXP3. A run of large negative rewards drives every
+        // exp(eta * gain) toward zero; if the array is left there, one more step reaches exactly zero
+        // and no later reward can lift it, because every update multiplies.
+        val w = doubleArrayOf(1e-200, 5e-201, 2e-200)
+        val ratioBefore = w[0] / w[2]
+
+        w.renormaliseExponentialWeights()
+
+        assertTrue(w.all { it >= 1e-100 }, "still in the underflow band: ${w.toList()}")
+        assertEquals(1.0, w[2], DELTA, "the maximum should land on exactly one")
+        assertEquals(ratioBefore, w[0] / w[2], DELTA, "the rescale changed an arm's relative standing")
+    }
+
+    @Test
+    fun `a fully collapsed array resets to uniform`() {
+        // Once every weight is exactly zero there are no ratios left to preserve, so there is nothing
+        // to restore it to except a fresh uniform prior. Anything else divides by zero.
+        val w = doubleArrayOf(0.0, 0.0, 0.0)
+
+        w.renormaliseExponentialWeights()
+
+        assertTrue(w.all { it == 1.0 }, "expected a uniform reset: ${w.toList()}")
+    }
+
+    @Test
+    fun `a partly collapsed array survives on its remaining mass`() {
+        // Distinct from the case above: one arm still carries weight, so the zeros stay zero and the
+        // survivor is what the distribution rides on. Resetting to uniform here would throw away
+        // everything the policy had learned.
+        val w = doubleArrayOf(0.0, 1e-200, 0.0)
+
+        w.renormaliseExponentialWeights()
+
+        assertEquals(0.0, w[0], DELTA)
+        assertEquals(1.0, w[1], DELTA)
+        assertEquals(0.0, w[2], DELTA)
+    }
+
+    @Test
+    fun `rescaling is idempotent`() {
+        // A second pass must be a no-op, or the policies would drift every time they called it.
+        val w = doubleArrayOf(1e200, 5e199, 2e200)
+
+        w.renormaliseExponentialWeights()
+        val once = w.copyOf()
+        w.renormaliseExponentialWeights()
+
+        for (i in w.indices) assertEquals(once[i], w[i], DELTA, "coordinate $i moved on the second pass")
+    }
+
+    @Test
+    fun `an empty array is handled`() {
+        DoubleArray(0).renormaliseExponentialWeights()
+    }
+
+    private fun DoubleArray.all(predicate: (Double) -> Boolean): Boolean {
+        for (v in this) if (!predicate(v)) return false
+        return true
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
@@ -1,0 +1,125 @@
+package com.eignex.kumulant.math
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val DELTA = 1e-12
+
+/**
+ * Properties of the shared softmax, which three call sites previously each implemented for themselves.
+ */
+class SoftmaxTest {
+
+    @Test
+    fun `probabilities sum to one and preserve order`() {
+        val p = doubleArrayOf(1.0, 3.0, 2.0, -5.0)
+
+        assertTrue(p.softmaxInPlace())
+
+        assertEquals(1.0, p.sum(), DELTA)
+        assertTrue(p.all { it > 0.0 }, "every probability must be positive: ${p.toList()}")
+        assertTrue(p[1] > p[2] && p[2] > p[0] && p[0] > p[3], "order was not preserved: ${p.toList()}")
+    }
+
+    @Test
+    fun `a constant shift in the logits changes nothing`() {
+        // The identity the max-subtraction relies on. If this ever stopped holding, the overflow
+        // guard below would be changing the answer rather than just making it computable.
+        val plain = doubleArrayOf(0.5, -1.25, 4.0)
+        val shifted = DoubleArray(plain.size) { plain[it] + 137.0 }
+
+        plain.softmaxInPlace()
+        shifted.softmaxInPlace()
+
+        for (i in plain.indices) {
+            assertEquals(plain[i], shifted[i], DELTA, "coordinate $i moved under a constant shift")
+        }
+    }
+
+    @Test
+    fun `enormous logits do not overflow`() {
+        // Without the shift every one of these is exp(inf) and the array comes back all-NaN. This is
+        // the whole reason the loop is not two lines long.
+        val p = doubleArrayOf(1000.0, 1001.0, 999.0)
+
+        assertTrue(p.softmaxInPlace())
+
+        assertEquals(1.0, p.sum(), DELTA)
+        assertTrue(p.all { it.isFinite() }, "overflowed: ${p.toList()}")
+        // The winner by one nat, so exactly the two-way logistic split against each rival.
+        assertTrue(p[1] > 0.5, "the largest logit should dominate: ${p.toList()}")
+    }
+
+    @Test
+    fun `tiny logits do not underflow to an empty distribution`() {
+        // The mirror case. Every exponential here would be zero unshifted, leaving nothing to
+        // normalise by; after the shift the largest is exp(0) and the sum cannot be zero.
+        val p = doubleArrayOf(-1000.0, -1000.5, -1001.0)
+
+        assertTrue(p.softmaxInPlace())
+
+        assertEquals(1.0, p.sum(), DELTA)
+        assertTrue(p.all { it > 0.0 }, "underflowed: ${p.toList()}")
+    }
+
+    @Test
+    fun `a uniform input stays uniform`() {
+        val p = DoubleArray(4) { 7.0 }
+
+        assertTrue(p.softmaxInPlace())
+
+        for (v in p) assertEquals(0.25, v, DELTA)
+    }
+
+    @Test
+    fun `an empty array reports failure rather than dividing by zero`() {
+        assertFalse(DoubleArray(0).softmaxInPlace())
+    }
+
+    @Test
+    fun `a single class is certain`() {
+        val p = doubleArrayOf(-42.0)
+
+        assertTrue(p.softmaxInPlace())
+
+        assertEquals(1.0, p[0], DELTA)
+    }
+
+    @Test
+    fun `a NaN logit yields NaN rather than being rejected`() {
+        // Pinned as the current behaviour, not as desirable behaviour. The post-shift sum is NaN,
+        // which fails the `<= 0.0` guard the three previous copies all carried, so this returns true
+        // with an unusable array - and on the training path that NaN reaches the weights and stays
+        // there. Kept exactly as it was so this extraction changes nothing; the fix is its own task.
+        val p = doubleArrayOf(1.0, Double.NaN, 2.0)
+
+        assertTrue(p.softmaxInPlace(), "the sum guard cannot catch a NaN, so this still reports success")
+
+        assertTrue(p.all { it.isNaN() }, "expected the NaN to spread: ${p.toList()}")
+    }
+
+    private fun DoubleArray.sum(): Double {
+        var s = 0.0
+        for (v in this) s += v
+        return s
+    }
+
+    private fun DoubleArray.all(predicate: (Double) -> Boolean): Boolean {
+        for (v in this) if (!predicate(v)) return false
+        return true
+    }
+
+    @Test
+    fun `the two-class case matches the logistic function`() {
+        // Cross-check against a formula that does not share this implementation's shape.
+        val p = doubleArrayOf(0.0, 2.0)
+
+        p.softmaxInPlace()
+
+        val logistic = 1.0 / (1.0 + kotlin.math.exp(-2.0))
+        assertTrue(abs(p[1] - logistic) < DELTA, "expected $logistic, got ${p[1]}")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
@@ -1,0 +1,90 @@
+package com.eignex.kumulant.operation
+
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Argument validation on `throttle` and `sample`, across all five modalities.
+ *
+ * The regression modality carried its own byte-identical copies of these two checks, which is the kind
+ * of duplication that only shows up when one copy is deleted and nothing fails. Nothing did fail,
+ * because neither check had a test; these are that test.
+ */
+class SamplingValidationTest {
+
+    @Test
+    fun `throttle rejects a period below one in every modality`() {
+        // A period of zero would divide by zero in the tick test, and a negative one would forward on a
+        // schedule nobody could predict. Both are caller errors rather than degenerate-but-valid
+        // configurations, so they throw at construction rather than at the first update.
+        for (every in listOf(0, -1, -7)) {
+            assertFailsWith<IllegalArgumentException>("series accepted every=$every") {
+                SumStat().throttle(every)
+            }
+            assertFailsWith<IllegalArgumentException>("paired accepted every=$every") {
+                SumStat().atY().throttle(every)
+            }
+            assertFailsWith<IllegalArgumentException>("vector accepted every=$every") {
+                VectorizedStat(2, SumStat()).throttle(every)
+            }
+            assertFailsWith<IllegalArgumentException>("regression accepted every=$every") {
+                StochasticRegressionStat(featureSize = 2).throttle(every)
+            }
+        }
+    }
+
+    @Test
+    fun `throttle accepts a period of one as forward-everything`() {
+        // The boundary the check has to leave open: `every = 1` is the identity, not a rejection.
+        val stat = SumStat().throttle(1)
+        stat.update(3.0)
+        stat.update(4.0)
+        assertEquals(7.0, stat.read().sum, 1e-12)
+    }
+
+    @Test
+    fun `sample rejects a rate outside the unit interval in every modality`() {
+        for (rate in listOf(-0.1, 1.1, Double.NaN)) {
+            assertFailsWith<IllegalArgumentException>("series accepted rate=$rate") {
+                SumStat().sample(rate, Random(0))
+            }
+            assertFailsWith<IllegalArgumentException>("paired accepted rate=$rate") {
+                SumStat().atY().sample(rate, Random(0))
+            }
+            assertFailsWith<IllegalArgumentException>("vector accepted rate=$rate") {
+                VectorizedStat(2, SumStat()).sample(rate, Random(0))
+            }
+            assertFailsWith<IllegalArgumentException>("regression accepted rate=$rate") {
+                StochasticRegressionStat(featureSize = 2).sample(rate, Random(0))
+            }
+        }
+    }
+
+    @Test
+    fun `sample accepts both endpoints`() {
+        // Zero and one are the drop-everything and keep-everything ends, both legitimate.
+        val none = SumStat().sample(0.0, Random(0))
+        repeat(20) { none.update(1.0) }
+        assertEquals(0.0, none.read().sum, 1e-12, "a rate of zero should drop every update")
+
+        val all = SumStat().sample(1.0, Random(0))
+        repeat(20) { all.update(1.0) }
+        assertEquals(20.0, all.read().sum, 1e-12, "a rate of one should keep every update")
+    }
+
+    @Test
+    fun `the rejection says which bound was violated`() {
+        val every = assertFailsWith<IllegalArgumentException> { SumStat().throttle(0) }
+        assertTrue("throttle every must be >= 1" in every.message.orEmpty(), "unhelpful: ${every.message}")
+        assertTrue("got 0" in every.message.orEmpty(), "did not name the value: ${every.message}")
+
+        val rate = assertFailsWith<IllegalArgumentException> { SumStat().sample(1.5, Random(0)) }
+        assertTrue("sample rate must be in [0, 1]" in rate.message.orEmpty(), "unhelpful: ${rate.message}")
+        assertTrue("got 1.5" in rate.message.orEmpty(), "did not name the value: ${rate.message}")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
@@ -1,0 +1,116 @@
+package com.eignex.kumulant.stat.regression.glm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val DELTA = 1e-12
+
+/**
+ * The shared L1 proximal operator, and the one case where the three copies it replaces disagreed.
+ */
+class SoftThresholdTest {
+
+    @Test
+    fun `shrinks toward zero by the threshold`() {
+        assertEquals(0.7, softThreshold(1.0, 0.3), DELTA)
+        assertEquals(-0.7, softThreshold(-1.0, 0.3), DELTA)
+    }
+
+    @Test
+    fun `stops at zero rather than crossing it`() {
+        // The property that makes this sparsity-inducing rather than just a shift: a coefficient
+        // smaller than the threshold lands exactly on zero and stays there.
+        assertEquals(0.0, softThreshold(0.2, 0.3), DELTA)
+        assertEquals(0.0, softThreshold(-0.2, 0.3), DELTA)
+        assertEquals(0.0, softThreshold(0.3, 0.3), DELTA)
+    }
+
+    @Test
+    fun `a zero threshold is the identity`() {
+        for (w in listOf(-2.5, -0.001, 0.0, 0.001, 2.5)) {
+            assertEquals(w, softThreshold(w, 0.0), DELTA, "a zero threshold moved $w")
+        }
+    }
+
+    @Test
+    fun `a negative threshold leaves the coefficient alone instead of growing it`() {
+        // Penalty.L1 puts no positivity requirement on lambda, and every host multiplies lambda by
+        // something positive to get its threshold, so a negative threshold is reachable from a
+        // negative lambda. Two of the three copies of this operator lacked the guard, and without it
+        // the branches read inside out: at w = 0.0 and threshold = -0.5 the first comparison matches
+        // and returns +0.5, so a negative lambda pushed coefficients *away* from zero. Shrinking by a
+        // negative amount is not shrinking, so the penalty does nothing at all.
+        assertEquals(0.0, softThreshold(0.0, -0.5), DELTA)
+        assertEquals(1.0, softThreshold(1.0, -0.5), DELTA)
+        assertEquals(-1.0, softThreshold(-1.0, -0.5), DELTA)
+    }
+
+    @Test
+    fun `is monotone and never increases magnitude`() {
+        // Two properties a proximal operator must have, checked over a grid rather than at points, so
+        // an alternative implementation cannot pass by matching the examples above.
+        val threshold = 0.4
+        var previous = Double.NEGATIVE_INFINITY
+        var w = -3.0
+        while (w <= 3.0) {
+            val shrunk = softThreshold(w, threshold)
+            assertTrue(shrunk >= previous - DELTA, "not monotone at w=$w: $previous then $shrunk")
+            assertTrue(
+                kotlin.math.abs(shrunk) <= kotlin.math.abs(w) + DELTA,
+                "magnitude grew at w=$w: |$shrunk| > |$w|",
+            )
+            previous = shrunk
+            w += 0.05
+        }
+    }
+
+    @Test
+    fun `the three hosts now agree on a negative lambda`() {
+        // The behaviour this extraction changed, pinned end to end rather than on the helper alone.
+        // The univariate and diagonal fits used to grow their coefficients under a negative lambda
+        // while the stochastic fit ignored it; all three now ignore it. A negative lambda remains a
+        // caller error - this only settles what happens when one is passed.
+        val univariate = UnivariateRegressionStat(penalty = Penalty.L1(lambda = -1.0))
+        val unpenalised = UnivariateRegressionStat()
+        repeat(6) { i ->
+            univariate.update(i.toDouble(), 2.0 * i)
+            unpenalised.update(i.toDouble(), 2.0 * i)
+        }
+        assertEquals(
+            unpenalised.read().slope,
+            univariate.read().slope,
+            1e-9,
+            "a negative lambda still moved the univariate slope",
+        )
+
+        val diagonal = DiagonalRegressionStat(featureSize = 1, penalty = Penalty.L1(lambda = -1.0))
+        val plain = DiagonalRegressionStat(featureSize = 1)
+        repeat(6) { i ->
+            diagonal.update(doubleArrayOf(i.toDouble()), 2.0 * i)
+            plain.update(doubleArrayOf(i.toDouble()), 2.0 * i)
+        }
+        assertEquals(
+            plain.read().weights[0],
+            diagonal.read().weights[0],
+            1e-9,
+            "a negative lambda still moved the diagonal weight",
+        )
+    }
+
+    @Test
+    fun `a positive lambda still shrinks each host`() {
+        // Guards the guard: if the negative case now no-ops, the positive case has to still bite, or
+        // the change above would have quietly disabled L1 everywhere.
+        val penalised = UnivariateRegressionStat(penalty = Penalty.L1(lambda = 0.5))
+        val unpenalised = UnivariateRegressionStat()
+        repeat(6) { i ->
+            penalised.update(i.toDouble(), 2.0 * i)
+            unpenalised.update(i.toDouble(), 2.0 * i)
+        }
+        val shrunk = penalised.read().slope
+        val full = unpenalised.read().slope
+        assertTrue(shrunk < full, "L1 did not shrink the univariate slope: $shrunk vs $full")
+        assertTrue(shrunk >= 0.0, "L1 shrank past zero: $shrunk")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
@@ -1,0 +1,72 @@
+package com.eignex.kumulant.stat.regression.tree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Breiman's `ceil(sqrt(p))` subspace default, which both forests previously computed for themselves.
+ */
+class DefaultMtryTest {
+
+    @Test
+    fun `matches ceil of the square root`() {
+        assertEquals(1, defaultMtry(1))
+        assertEquals(2, defaultMtry(2))
+        assertEquals(2, defaultMtry(4))
+        assertEquals(3, defaultMtry(5))
+        assertEquals(3, defaultMtry(9))
+        assertEquals(4, defaultMtry(10))
+        assertEquals(10, defaultMtry(100))
+        assertEquals(11, defaultMtry(101))
+    }
+
+    @Test
+    fun `an empty candidate pool means no growth rather than one candidate`() {
+        // The distinction that makes this worth pinning: a forest built with no split candidates should
+        // report an mtry of zero, not clamp up to one and then try to draw from an empty list.
+        assertEquals(0, defaultMtry(0))
+        assertEquals(0, defaultMtry(-1))
+    }
+
+    @Test
+    fun `never exceeds the pool it draws from`() {
+        // mtry larger than the pool would make the per-leaf subset draw meaningless. sqrt(p) <= p for
+        // every p >= 1, but the clamp is easy to get wrong, so check the whole small range.
+        for (p in 1..64) {
+            val mtry = defaultMtry(p)
+            assertEquals(true, mtry in 1..p, "defaultMtry($p) = $mtry is outside 1..$p")
+        }
+    }
+
+    @Test
+    fun `both forests default to it and honour an explicit override`() {
+        val splits = List(9) { ThresholdSplit(featureIndex = it % 3, threshold = 0.5) }
+
+        assertEquals(3, RandomForestRegressionStat(3, splits, nbrTrees = 2).config.mtry)
+        assertEquals(
+            3,
+            RandomForestClassifierStat(3, numClasses = 2, splitCandidates = splits, nbrTrees = 2).config.mtry,
+        )
+
+        // An explicit mtry has to survive the defaulting, or the config knob would be unreachable.
+        assertEquals(
+            2,
+            RandomForestRegressionStat(
+                3,
+                splits,
+                config = RegressionTreeConfig(mtry = 2),
+                nbrTrees = 2,
+            ).config.mtry,
+        )
+        assertEquals(
+            2,
+            RandomForestClassifierStat(
+                3,
+                numClasses = 2,
+                splitCandidates = splits,
+                config = ClassificationTreeConfig(mtry = 2),
+                nbrTrees = 2,
+            ).config.mtry,
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- `checkEvery` and `checkRate` are now `internal` in `Sampling.kt`. `RegressionOps.kt` had byte-identical private copies.
- Added `defaultMtry` to a new `TreeInternals.kt`. Both random forests had the same private one-liner.
- Added `renormaliseExponentialWeights` and its three constants to a new `bandit/ExponentialWeights.kt`. EXP3 and EXP4 had separate copies of the whole function, spelled with different branch structure.
- Added `softThreshold` to `Penalty.kt`. It existed as a private function in `StochasticRegressionStat` and open-coded in `DiagonalRegressionStat` and `UnivariateRegressionStat`.
- Added `softmaxInPlace` to a new `math/Softmax.kt`, replacing three copies of the max-subtracting normalisation loop.
- Added tests for each of the five, none of which had direct coverage before.

## Why

Each of these is one idea that had been written down more than once, and in three of the five the copies had already stopped agreeing.

The renormalisers were the mild case. EXP3 tested the overflow ceiling and the underflow floor in two separate `if`s and EXP4 in one disjunction, but they compute the same thing, so sharing the function rather than just the constants was the honest reduction.

The L1 proximal operator was not the mild case, and it is why one commit here is a fix rather than a refactor. `Penalty.L1` puts no positivity requirement on its `lambda`, so a negative one is constructible, and every host multiplies lambda by something positive to derive a threshold. Two of the three copies lacked the non-positive guard, and without it the branches read inside out: at `w = 0` with `threshold = -0.5` the first comparison matches and returns `+0.5`, so a negative lambda pushed coefficients away from zero instead of toward it. The univariate and diagonal fits grew their coefficients under a negative lambda while the stochastic fit ignored it. All three now ignore it. A negative lambda is still a caller error; this only settles what happens when one arrives.

## Testing

`./gradlew build` passes. Beyond that, two things are worth calling out.

The negative-lambda test was checked against the old code before being kept. Reverting the two adoption sites to their open-coded form makes `the three hosts now agree on a negative lambda` fail, so it pins the change rather than passing either way.

While extracting the softmax I found that its `z <= 0.0` guard, which all three copies carried, cannot fire. After the max-shift one element is always `exp(0) == 1`, so a finite input sums to at least 1, and a non-finite input makes the sum `NaN`, which fails `<= 0.0` as well. Verified across five logit shapes including both infinities and `NaN`. The consequence is that a single `NaN` feature poisons a softmax model's weights permanently, which a probe confirms: weights go to all-`NaN` and a later clean update does not recover them. That is older than this change and unaffected by it, so the extraction keeps the dead guard rather than quietly tightening it. It is filed separately, because the fix is a decision about what a model owes a caller who supplies an unusable feature, not a refactor. The test suite pins the current behaviour so the decision is a visible change when it happens.
