### PR TITLE
fix: give every classifier the same answer about what names a class

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
@@ -63,3 +63,31 @@ internal fun requireLiveWeight(currentTotal: Double, weight: Double) {
             "${currentTotal + weight}; a downdate must leave a positive total"
     }
 }
+
+/**
+ * Interpret a `Double` as a class index, or reject it.
+ *
+ * A classifier takes its label through the same `Double` channel every other stat takes a value
+ * through, so it has to decide which `Double`s name a class. [Stat] explains why a label is not a
+ * value: a value is an observation and propagates, whereas a label is an *identifier*, and an
+ * identifier that is not one of the identifiers cannot be folded in at all.
+ *
+ * Round-tripping through `Double` is what does the work, because `toInt()` alone is far too
+ * permissive. It truncates toward zero, so `1.5` becomes class 1 and `-0.5` becomes class 0, and
+ * `NaN.toInt()` is `0`, which means the most obviously invalid label in the language arrives looking
+ * like a perfectly ordinary first class. Demanding `c.toDouble() == this` rejects all three: only a
+ * `Double` that is exactly an integer survives.
+ *
+ * This was open-coded at five sites with three different policies. The two GLM classifiers
+ * round-tripped, the forest and the tree truncated, and `ClassCountsStat` truncated as well - so the
+ * same `y = 1.5` trained as class 1 on the tree path and was refused on the GLM path.
+ *
+ * @param numClasses exclusive upper bound on the index; `numClasses` itself is not a class.
+ * @return the class index, or `-1` if this `Double` does not name one. `-1` rather than `null` to keep
+ *  the check allocation-free on the update path for the targets without escape analysis.
+ */
+@Suppress("NOTHING_TO_INLINE") // as with the weight predicates; the non-JVM targets pay for the call
+internal inline fun Double.asClassLabel(numClasses: Int): Int {
+    val c = toInt()
+    return if (c.toDouble() == this && c >= 0 && c < numClasses) c else -1
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.softmaxInPlace
@@ -152,12 +153,10 @@ class GaussianNaiveBayesStat(
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
-            // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and
-            // slipped past the range check as a valid label. Round-tripping through Double is what
-            // rejects them: it demands an exact integer, which NaN fails alongside 1.5 and -0.5. The
-            // tree classifiers already guard this; see Stat on why a label is not a value.
-            val c = y.toInt()
-            if (c.toDouble() != y || c !in 0 until numClasses) return@guarded
+            // See asClassLabel on why an exact integer is required. The tree classifiers used to
+            // truncate instead, so this stat and those disagreed about y = 1.5.
+            val c = y.asClassLabel(numClasses)
+            if (c < 0) return@guarded
             val priorW = classWeightCell.load(c)
             val newW = priorW + weight
             classWeightCell.store(c, newW)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.softmaxInPlace
@@ -148,12 +149,10 @@ class SoftmaxRegressionStat(
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
-            // toInt() truncates toward zero, so NaN and anything in (-1, 0) both became class 0 and
-            // slipped past the range check as a valid label. Round-tripping through Double is what
-            // rejects them: it demands an exact integer, which NaN fails alongside 1.5 and -0.5. The
-            // tree classifiers already guard this; see Stat on why a label is not a value.
-            val c = y.toInt()
-            if (c.toDouble() != y || c !in 0 until numClasses) return@guarded
+            // See asClassLabel on why an exact integer is required. The tree classifiers used to
+            // truncate instead, so this stat and those disagreed about y = 1.5.
+            val c = y.asClassLabel(numClasses)
+            if (c < 0) return@guarded
             stepCell.addAndGet(1L)
 
             // Softmax over current logits.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -3,6 +3,8 @@ package com.eignex.kumulant.stat.regression.tree
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.asClassLabel
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
@@ -108,9 +110,14 @@ class ClassCountsStat(
     private val cells: StreamDoubleArray = mode.newDoubleArray(numClasses)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight == 0.0 || value.isNaN()) return
-        val c = value.toInt()
-        if (c !in 0 until numClasses) return
+        // The guard checked the NaN *value* but not the NaN *weight*, and `weight == 0.0` is false for
+        // NaN, so a NaN weight reached `cells.add` and pinned a class count to NaN permanently. A
+        // negative weight stays legal: a count cell subtracts exactly, so retracting an observation
+        // that was folded in earlier is a downdate rather than corruption. The label now goes through
+        // asClassLabel like every other classifier's, which is what rejects 1.5 as a class index.
+        if (weight.isInertWeight()) return
+        val c = value.asClassLabel(numClasses)
+        if (c < 0) return
         cells.add(c, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -4,6 +4,8 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.asClassLabel
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import kotlin.random.Random
 
@@ -48,8 +50,14 @@ class DecisionTreeClassifierStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        if (weight <= 0.0 || y.isNaN()) return
-        tree.update(x, y.toInt(), weight)
+        // Was `weight <= 0.0`, which is false for NaN, and `y.toInt()` with no validation at all - the
+        // range check happened downstream in ClassificationTree.update but the truncation did not, so
+        // y = 1.5 arrived as a legitimate class 1. A NaN weight got all the way to the leaf counts.
+        // isInertWeight, like the regression counterpart: a class count downdates exactly.
+        if (weight.isInertWeight()) return
+        val c = y.asClassLabel(numClasses)
+        if (c < 0) return
+        tree.update(x, c, weight)
     }
 
     override fun read(timestampNanos: Long): TreeClassificationResult =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -5,6 +5,8 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.asClassLabel
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
@@ -57,9 +59,18 @@ class RandomForestClassifierStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        if (weight <= 0.0 || y.isNaN()) return
-        val c = y.toInt()
-        if (c !in 0 until numClasses) return
+        // The weight guard used to be `weight <= 0.0`, which is false for NaN, so a NaN weight reached
+        // the leaf counts and pinned one to NaN for good - no later observation could clear it. The
+        // label guard used to truncate, so y = 1.5 trained as class 1 here while the GLM classifiers
+        // refused it. Both now go through the same helpers as every other stat.
+        //
+        // isInertWeight rather than isNotPositiveWeight: a class count subtracts exactly, so a negative
+        // weight is a real downdate here, exactly as it is for the regression forest. Returning before
+        // the bagging draw also matters - an inert call used to consume one Poisson draw per tree and
+        // desynchronise every later one.
+        if (weight.isInertWeight()) return
+        val c = y.asClassLabel(numClasses)
+        if (c < 0) return
         if (!bagging) {
             for (t in trees) t.update(x, c, weight)
             return

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -1,0 +1,174 @@
+package com.eignex.kumulant.core
+
+import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
+import com.eignex.kumulant.stat.regression.SoftmaxRegressionStat
+import com.eignex.kumulant.stat.regression.tree.ClassCountsStat
+import com.eignex.kumulant.stat.regression.tree.DecisionTreeClassifierStat
+import com.eignex.kumulant.stat.regression.tree.RandomForestClassifierStat
+import com.eignex.kumulant.stat.regression.tree.ThresholdSplit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val CLASSES = 3
+private const val DELTA = 1e-12
+
+/**
+ * Which `Double`s name a class, checked on the helper and then on every classifier that uses it.
+ *
+ * The five call sites disagreed before this: two round-tripped through `Double`, three truncated, and
+ * they used three different weight predicates between them. The sweep is the part that matters, because
+ * the helper being right does not help if a stat stops calling it.
+ */
+class ClassLabelAdmissionTest {
+
+    /** One classifier, with a way to feed it and a way to see whether it moved. */
+    private class Probe(val name: String, val update: (Double, Double) -> Unit, val snapshot: () -> String)
+
+    private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
+    private val x = DenseVector.of(DoubleArray(2) { 1.0 })
+
+    // Fresh instances per test. Every snapshot reads the learned numbers out explicitly rather than
+    // stringifying the result: ClassCountsResult has no toString override, so on the JVM a snapshot
+    // taken that way is a fresh identity hash every time and compares unequal to itself, which made an
+    // earlier version of the "still absorbed" test pass without proving anything. Kotlin/JS renders
+    // those objects differently and failed honestly, which is how it was caught.
+    private fun probes(): List<Probe> {
+        val softmax = SoftmaxRegressionStat(featureSize = 2, numClasses = CLASSES)
+        val gnb = GaussianNaiveBayesStat(featureSize = 2, numClasses = CLASSES)
+        val tree = DecisionTreeClassifierStat(2, numClasses = CLASSES, splitCandidates = splits)
+        val forest = RandomForestClassifierStat(
+            2,
+            numClasses = CLASSES,
+            splitCandidates = splits,
+            nbrTrees = 2,
+            bagging = false,
+        )
+        val counts = ClassCountsStat(CLASSES)
+        return listOf(
+            Probe("Softmax", { y, w -> softmax.update(x, y, weight = w) }) {
+                val r = softmax.read()
+                val w = (0 until CLASSES).joinToString { k -> (0 until 2).joinToString { i -> "${r.weights[k, i]}" } }
+                "$w|${(0 until CLASSES).joinToString { "${r.biases[it]}" }}|${r.totalWeights}|${r.step}"
+            },
+            Probe("GaussianNaiveBayes", { y, w -> gnb.update(x, y, weight = w) }) {
+                val r = gnb.read()
+                val m = (0 until CLASSES).joinToString { c -> (0 until 2).joinToString { i -> "${r.means[c, i]}" } }
+                "$m|${(0 until CLASSES).joinToString { "${r.classWeights[it]}" }}|${r.totalWeights}"
+            },
+            Probe("DecisionTreeClassifier", { y, w -> tree.update(x, y, weight = w) }) {
+                tree.tree().rootSnapshot().counts.joinToString()
+            },
+            Probe("RandomForestClassifier", { y, w -> forest.update(x, y, weight = w) }) {
+                forest.trees().joinToString(";") { it.rootSnapshot().counts.joinToString() }
+            },
+            Probe("ClassCounts", { y, w -> counts.update(y, weight = w) }) {
+                counts.read().counts.joinToString()
+            },
+        )
+    }
+
+    @Test
+    fun `asClassLabel accepts exactly the integers in range`() {
+        for (c in 0 until CLASSES) {
+            assertEquals(c, c.toDouble().asClassLabel(CLASSES), "class $c was rejected")
+        }
+    }
+
+    @Test
+    fun `asClassLabel rejects a label that is not an integer`() {
+        // The case that used to differ between the tree path and the GLM path: toInt() truncates, so
+        // 1.5 arrived as a perfectly ordinary class 1 on three of the five sites.
+        for (y in listOf(0.5, 1.5, 2.5, -0.5, 1.0000001, 0.9999999)) {
+            assertEquals(-1, y.asClassLabel(CLASSES), "$y was accepted as a class index")
+        }
+    }
+
+    @Test
+    fun `asClassLabel rejects NaN`() {
+        // NaN.toInt() is 0, so an unvalidated NaN label is indistinguishable from the first class.
+        assertEquals(-1, Double.NaN.asClassLabel(CLASSES))
+    }
+
+    @Test
+    fun `asClassLabel rejects out-of-range integers and the infinities`() {
+        for (y in listOf(-1.0, -2.0, CLASSES.toDouble(), CLASSES + 1.0, 1e18)) {
+            assertEquals(-1, y.asClassLabel(CLASSES), "$y was accepted as a class index")
+        }
+        // toInt() saturates the infinities to Int.MIN/MAX_VALUE, which the round-trip rejects because
+        // neither converts back to an infinity.
+        assertEquals(-1, Double.POSITIVE_INFINITY.asClassLabel(CLASSES))
+        assertEquals(-1, Double.NEGATIVE_INFINITY.asClassLabel(CLASSES))
+    }
+
+    @Test
+    fun `negative zero is the first class`() {
+        // -0.0 == 0.0 under IEEE comparison and the round-trip uses ==, so this is class 0 rather than
+        // a rejected negative. Worth pinning because the sign bit makes it look like neither.
+        assertEquals(0, (-0.0).asClassLabel(CLASSES))
+    }
+
+    @Test
+    fun `every classifier refuses a label that is not a class index`() {
+        val violations = mutableListOf<String>()
+        for (y in listOf(1.5, -0.5, Double.NaN, -1.0, CLASSES.toDouble())) {
+            for (probe in probes()) {
+                val before = probe.snapshot()
+
+                probe.update(y, 1.0)
+
+                if (probe.snapshot() != before) violations += "${probe.name} absorbed the label $y"
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "a label that is not a class index must be dropped")
+    }
+
+    @Test
+    fun `every classifier treats a NaN weight as a no-op`() {
+        // The half of this that was a live defect rather than an inconsistency. `weight <= 0.0` and
+        // `weight == 0.0` are both false for NaN, so on three of the five paths a NaN weight reached
+        // the leaf counts and pinned one to NaN permanently: a later valid observation could not clear
+        // it, because every subsequent add started from NaN.
+        val violations = mutableListOf<String>()
+        for (probe in probes()) {
+            probe.update(1.0, 1.0)
+            val before = probe.snapshot()
+
+            probe.update(1.0, Double.NaN)
+
+            if (probe.snapshot() != before) violations += "${probe.name} absorbed a NaN weight"
+            if ("NaN" in probe.snapshot()) violations += "${probe.name} is now holding a NaN"
+
+            // And it still works afterwards, which is the part a state comparison alone would miss.
+            probe.update(2.0, 1.0)
+            if ("NaN" in probe.snapshot()) violations += "${probe.name} was poisoned by the NaN weight"
+        }
+        assertEquals(emptyList(), violations.toList(), "a NaN weight must not reach any classifier's state")
+    }
+
+    @Test
+    fun `a valid label at a live weight is still absorbed`() {
+        // Guards the guards above: a stat that rejected everything would satisfy all of them.
+        for (probe in probes()) {
+            val before = probe.snapshot()
+
+            probe.update(1.0, 1.0)
+
+            assertTrue(probe.snapshot() != before, "${probe.name} ignored a valid label at weight 1.0")
+        }
+    }
+
+    @Test
+    fun `a class count still downdates on a negative weight`() {
+        // ClassCounts guards on isInertWeight rather than isNotPositiveWeight, because a count cell
+        // subtracts exactly: retracting an observation folded in earlier is a downdate, not corruption.
+        // The regression trees already worked this way and the classification side now matches, so the
+        // fix to the NaN-weight hole did not cost the legitimate negative-weight case.
+        val counts = ClassCountsStat(CLASSES)
+        counts.update(1.0, weight = 3.0)
+        counts.update(1.0, weight = -1.0)
+
+        assertEquals(2.0, counts.read().counts[1], DELTA, "the downdate did not subtract")
+    }
+}


### PR DESCRIPTION
## What changed

- Added `Double.asClassLabel(numClasses)` to `core/Weights.kt`, returning the class index or -1.
- Adopted it at all five sites that decided this for themselves: `SoftmaxRegressionStat`, `GaussianNaiveBayesStat`, `RandomForestClassifierStat`, `DecisionTreeClassifierStat`, `ClassCountsStat`.
- Replaced the three different weight guards on those paths with the two named predicates. The GLM classifiers keep `isNotPositiveWeight`. The three tree-side sites now use `isInertWeight`, matching their regression counterparts.
- Added `ClassLabelAdmissionTest`, covering the helper directly and then sweeping all five classifiers.

## Two behaviour changes

A non-integer label is now refused everywhere. It used to be refused by the two GLM classifiers and accepted by the three tree-side sites, because `toInt()` truncates, so `y = 1.5` trained as class 1 on one path and was rejected on the other. Measured before the change on the forest with bagging off: `y = 1.5` produced counts `[0.0, 1.0]` while the same label left `SoftmaxRegressionStat` at `step = 0`.

A NaN weight is now a no-op everywhere. This was the live defect rather than an inconsistency. Both `weight <= 0.0` and `weight == 0.0` are false for NaN, so on the three tree-side paths a NaN weight reached `ClassCounts.cells.add` and pinned a class count to NaN permanently, since every later add started from NaN. Measured: counts went to `[0.0, NaN]` and a subsequent valid observation could not clear it.

## Why

Five copies of one decision produced three answers, and the same library gave opposite verdicts on the same input depending on which classifier the caller reached for. Round-tripping through `Double` is the strict answer and the right one: `toInt()` alone truncates, so `1.5` becomes class 1 and `-0.5` becomes class 0, and `NaN.toInt()` is 0, which means the least valid label in the language arrives looking like an ordinary first class.

One correction to my own first pass here. I initially gave the three tree-side sites `isNotPositiveWeight`, which also drops negative weights. That was wrong. A class count subtracts exactly, so a negative weight is a legitimate downdate there, and the regression trees already treat it that way. Using the stricter predicate would have removed a real capability and replaced one asymmetry with another. They use `isInertWeight` now, which fixes the NaN hole without touching the negative case, and there is a test for the downdate still working.

## Testing

`./gradlew build` passes on all targets.

Both behaviour changes are pinned against the old code, not just asserted. Reverting `DecisionTreeClassifierStat` to its previous guard makes the sweep fail with `DecisionTreeClassifier absorbed the label 1.5, DecisionTreeClassifier absorbed the label -0.5`, so the test targets the actual change.

Kotlin/JS caught a flaw in the test itself, which is worth recording. The first version snapshotted state by stringifying each result. `ClassCountsResult` has no `toString` override, so on the JVM every snapshot was a fresh identity hash that compared unequal to itself, and the test that checks a valid label is still absorbed passed without proving anything. Kotlin/JS renders those objects differently and failed honestly. Every snapshot now reads the learned numbers out explicitly.
