### PR TITLE
refactor: lift the shared VFDT growth helpers and tunables out of both trees

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -7563,7 +7563,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTree {
 	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/VectorView;IDILjava/lang/Object;)V
 }
 
-public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig {
+public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig$Companion;
 	public fun <init> ()V
 	public fun <init> (DDDDDIIILcom/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric;Ljava/lang/Integer;)V
@@ -7581,16 +7581,16 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeCo
 	public final fun copy (DDDDDIIILcom/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric;Ljava/lang/Integer;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;DDDDDIIILcom/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDelta ()D
-	public final fun getDeltaDecay ()D
-	public final fun getMaxDepth ()I
-	public final fun getMaxNodes ()I
+	public fun getDelta ()D
+	public fun getDeltaDecay ()D
+	public fun getMaxDepth ()I
+	public fun getMaxNodes ()I
 	public final fun getMetric ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric;
-	public final fun getMinSamplesLeaf ()D
-	public final fun getMinSamplesSplit ()D
-	public final fun getMtry ()Ljava/lang/Integer;
-	public final fun getSplitPeriod ()I
-	public final fun getTau ()D
+	public fun getMinSamplesLeaf ()D
+	public fun getMinSamplesSplit ()D
+	public fun getMtry ()Ljava/lang/Integer;
+	public fun getSplitPeriod ()I
+	public fun getTau ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7758,6 +7758,18 @@ public final class com/eignex/kumulant/stat/regression/tree/GiniReduction : com/
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
+	public abstract fun getDelta ()D
+	public abstract fun getDeltaDecay ()D
+	public abstract fun getMaxDepth ()I
+	public abstract fun getMaxNodes ()I
+	public abstract fun getMinSamplesLeaf ()D
+	public abstract fun getMinSamplesSplit ()D
+	public abstract fun getMtry ()Ljava/lang/Integer;
+	public abstract fun getSplitPeriod ()I
+	public abstract fun getTau ()D
+}
+
 public final class com/eignex/kumulant/stat/regression/tree/InformationGain : com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/InformationGain;
 	public fun equals (Ljava/lang/Object;)Z
@@ -7886,7 +7898,7 @@ public final class com/eignex/kumulant/stat/regression/tree/RegressionTree {
 	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/RegressionTree;Ljava/lang/Object;DDILjava/lang/Object;)V
 }
 
-public final class com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig {
+public final class com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/RegressionTreeConfig$Companion;
 	public fun <init> ()V
 	public fun <init> (DDDDDIIILcom/eignex/kumulant/stat/regression/tree/SplitMetric;Ljava/lang/Integer;)V
@@ -7904,16 +7916,16 @@ public final class com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig
 	public final fun copy (DDDDDIIILcom/eignex/kumulant/stat/regression/tree/SplitMetric;Ljava/lang/Integer;)Lcom/eignex/kumulant/stat/regression/tree/RegressionTreeConfig;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/RegressionTreeConfig;DDDDDIIILcom/eignex/kumulant/stat/regression/tree/SplitMetric;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/RegressionTreeConfig;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDelta ()D
-	public final fun getDeltaDecay ()D
-	public final fun getMaxDepth ()I
-	public final fun getMaxNodes ()I
+	public fun getDelta ()D
+	public fun getDeltaDecay ()D
+	public fun getMaxDepth ()I
+	public fun getMaxNodes ()I
 	public final fun getMetric ()Lcom/eignex/kumulant/stat/regression/tree/SplitMetric;
-	public final fun getMinSamplesLeaf ()D
-	public final fun getMinSamplesSplit ()D
-	public final fun getMtry ()Ljava/lang/Integer;
-	public final fun getSplitPeriod ()I
-	public final fun getTau ()D
+	public fun getMinSamplesLeaf ()D
+	public fun getMinSamplesSplit ()D
+	public fun getMtry ()Ljava/lang/Integer;
+	public fun getSplitPeriod ()I
+	public fun getTau ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -294,6 +294,27 @@ abstract interface com.eignex.kumulant.math/LongHasher { // com.eignex.kumulant.
 
 abstract interface com.eignex.kumulant.schema.runtime/GroupedStat : com.eignex.kumulant.core/Stat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/GroupedStat|null[0]
 
+abstract interface com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig|null[0]
+    abstract val delta // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.delta|{}delta[0]
+        abstract fun <get-delta>(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.delta.<get-delta>|<get-delta>(){}[0]
+    abstract val deltaDecay // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.deltaDecay|{}deltaDecay[0]
+        abstract fun <get-deltaDecay>(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.deltaDecay.<get-deltaDecay>|<get-deltaDecay>(){}[0]
+    abstract val maxDepth // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.maxDepth|{}maxDepth[0]
+        abstract fun <get-maxDepth>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.maxDepth.<get-maxDepth>|<get-maxDepth>(){}[0]
+    abstract val maxNodes // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.maxNodes|{}maxNodes[0]
+        abstract fun <get-maxNodes>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.maxNodes.<get-maxNodes>|<get-maxNodes>(){}[0]
+    abstract val minSamplesLeaf // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.minSamplesLeaf|{}minSamplesLeaf[0]
+        abstract fun <get-minSamplesLeaf>(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.minSamplesLeaf.<get-minSamplesLeaf>|<get-minSamplesLeaf>(){}[0]
+    abstract val minSamplesSplit // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.minSamplesSplit|{}minSamplesSplit[0]
+        abstract fun <get-minSamplesSplit>(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.minSamplesSplit.<get-minSamplesSplit>|<get-minSamplesSplit>(){}[0]
+    abstract val mtry // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.mtry|{}mtry[0]
+        abstract fun <get-mtry>(): kotlin/Int? // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.mtry.<get-mtry>|<get-mtry>(){}[0]
+    abstract val splitPeriod // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.splitPeriod|{}splitPeriod[0]
+        abstract fun <get-splitPeriod>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.splitPeriod.<get-splitPeriod>|<get-splitPeriod>(){}[0]
+    abstract val tau // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.tau|{}tau[0]
+        abstract fun <get-tau>(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig.tau.<get-tau>|<get-tau>(){}[0]
+}
+
 abstract interface com.eignex.kumulant.stream/Mutex { // com.eignex.kumulant.stream/Mutex|null[0]
     abstract fun <#A1: kotlin/Any?> withLock(kotlin/Function0<#A1>): #A1 // com.eignex.kumulant.stream/Mutex.withLock|withLock(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 }
@@ -6649,7 +6670,7 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationTree { // com
     final fun update(com.eignex.koblas/VectorView, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.VectorView;kotlin.Int;kotlin.Double){}[0]
 }
 
-final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
+final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
     constructor <init>(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric = ..., kotlin/Int? = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Int;kotlin.Int;kotlin.Int;com.eignex.kumulant.stat.regression.tree.ClassificationSplitMetric;kotlin.Int?){}[0]
 
     final val delta // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig.delta|{}delta[0]
@@ -6892,7 +6913,7 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat 
     final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
-final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
+final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
     constructor <init>(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., com.eignex.kumulant.stat.regression.tree/SplitMetric = ..., kotlin/Int? = ...) // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Int;kotlin.Int;kotlin.Int;com.eignex.kumulant.stat.regression.tree.SplitMetric;kotlin.Int?){}[0]
 
     final val delta // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig.delta|{}delta[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -12,9 +12,6 @@ import com.eignex.kumulant.stream.guarded
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.math.ln
-import kotlin.math.pow
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
@@ -200,19 +197,13 @@ class ClassificationTree(
         if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
             return ClassificationTerminalLeaf(leafArmFactory())
         }
-        val subset = pickCandidates()
+        val subset = splitCandidates.pickCandidates(config.mtry, random)
         return ClassificationAuditLeaf(
             arm = leafArmFactory(),
             candidates = subset,
             pos = List(subset.size) { leafArmFactory() },
             neg = List(subset.size) { leafArmFactory() },
         )
-    }
-
-    private fun pickCandidates(): List<SerializableSplit> {
-        val k = config.mtry ?: return splitCandidates
-        if (k >= splitCandidates.size) return splitCandidates
-        return splitCandidates.shuffled(random).take(k)
     }
 
     private fun updateNode(
@@ -263,6 +254,8 @@ class ClassificationTree(
         if (ticks < config.splitPeriod) return leaf
 
         return splitLock.guarded {
+            // Double-check inside the lock: another thread may have already audited
+            // (and reset the counter) or replaced this leaf.
             if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@guarded leaf
             leaf.observationsSinceLastCheck.store(0L)
 
@@ -278,6 +271,10 @@ class ClassificationTree(
             val passesTau = eps < config.tau
             if (!passesHoeffding && !passesTau) return@guarded leaf
 
+            // Stash the pre-split aggregate as the new split's carryover so it shows up
+            // in subtree aggregates without burdening the hot path. New leaves start
+            // empty so prior-driven Thompson/UCB exploration behaves as it did before
+            // the split fired.
             nbrNodes.addAndFetch(2)
             ClassificationSplitNode(
                 split = leaf.candidates[ranked.bestIndex],
@@ -286,11 +283,5 @@ class ClassificationTree(
                 carryover = leaf.arm,
             )
         }
-    }
-
-    private fun hoeffdingBound(delta: Double, n: Double, depth: Int, decay: Double): Double {
-        if (n <= 0.0) return Double.POSITIVE_INFINITY
-        val adjusted = delta * decay.pow(depth.toDouble())
-        return sqrt(-ln(adjusted) / (2.0 * n))
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
@@ -3,29 +3,23 @@ package com.eignex.kumulant.stat.regression.tree
 import kotlinx.serialization.Serializable
 
 /**
- * Classification analogue of [RegressionTreeConfig]. Same tunables, but the split [metric]
- * defaults to [GiniReduction] and the criterion is a [ClassificationSplitMetric].
+ * Classification analogue of [RegressionTreeConfig]. The same tunables, but the split [metric] defaults
+ * to [GiniReduction] and the criterion is a [ClassificationSplitMetric].
+ *
+ * Every field except [metric] is described on [HoeffdingTreeConfig]. It used to be described here too,
+ * in a copy that had already lost the explanations of what `tau` and `mtry` do.
  */
 @Serializable
 data class ClassificationTreeConfig(
-    /** Hoeffding-bound confidence threshold. */
-    val delta: Double = 0.05,
-    /** Multiplicative decay applied to [delta] per depth. */
-    val deltaDecay: Double = 0.9,
-    /** Hoeffding-bound shrinkage threshold for the VFDT tie-break. */
-    val tau: Double = 0.05,
-    /** Minimum total weighted samples at a leaf before split evaluation. */
-    val minSamplesSplit: Double = 30.0,
-    /** Minimum weighted samples on each side of a candidate split. */
-    val minSamplesLeaf: Double = 5.0,
-    /** Audit every Nth observation rather than every update. */
-    val splitPeriod: Int = 10,
-    /** Hard ceiling on tree depth. */
-    val maxDepth: Int = 16,
-    /** Hard ceiling on internal + leaf nodes. */
-    val maxNodes: Int = 1024,
-    /** Split criterion. */
+    override val delta: Double = 0.05,
+    override val deltaDecay: Double = 0.9,
+    override val tau: Double = 0.05,
+    override val minSamplesSplit: Double = 30.0,
+    override val minSamplesLeaf: Double = 5.0,
+    override val splitPeriod: Int = 10,
+    override val maxDepth: Int = 16,
+    override val maxNodes: Int = 1024,
+    /** Split criterion; ranks candidates by the class impurity they remove. */
     val metric: ClassificationSplitMetric = GiniReduction,
-    /** Breiman-style random-subspace size; `null` disables. */
-    val mtry: Int? = null,
-)
+    override val mtry: Int? = null,
+) : HoeffdingTreeConfig

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
@@ -1,0 +1,69 @@
+package com.eignex.kumulant.stat.regression.tree
+
+/**
+ * Growth tunables common to both VFDT trees.
+ *
+ * [RegressionTreeConfig] and [ClassificationTreeConfig] were field-for-field identical except for the
+ * split criterion, and their KDoc had already drifted apart - the classification copy lost the
+ * explanations of what [tau] and [mtry] actually do. They stay separate types because each is
+ * `@Serializable` and part of the wire format, and because [RegressionTreeConfig.metric] and
+ * [ClassificationTreeConfig.metric] have different types; this interface is where the shared half is
+ * described once, and it is what lets the growth logic read tunables without knowing which tree it is
+ * driving.
+ */
+interface HoeffdingTreeConfig {
+
+    /**
+     * Hoeffding-bound confidence threshold. Lower means splits require more evidence.
+     *
+     * This is the `delta` of the bound `sqrt(-ln(delta) / 2n)`, so it enters logarithmically: an order
+     * of magnitude buys only a modest widening of the margin a candidate has to clear.
+     */
+    val delta: Double
+
+    /**
+     * Multiplicative decay applied to [delta] per depth, which slows growth near the leaves.
+     *
+     * Deeper leaves see less of the stream, so a fixed confidence level would let them split on
+     * proportionally thinner evidence. Shrinking delta with depth counteracts that.
+     */
+    val deltaDecay: Double
+
+    /**
+     * If the Hoeffding bound itself shrinks below this, the leaf may split even when the runner-up is
+     * close: the classic VFDT tie-break parameter.
+     *
+     * Without it, two candidates of genuinely equal merit deadlock forever, because the margin between
+     * them never exceeds any bound. This gives the tree permission to pick one once it has enough
+     * evidence to know the choice does not matter much.
+     */
+    val tau: Double
+
+    /** Minimum total weighted samples at a leaf before split evaluation runs at all. */
+    val minSamplesSplit: Double
+
+    /** Minimum weighted samples required on each side of a candidate split. */
+    val minSamplesLeaf: Double
+
+    /**
+     * Audit every Nth observation rather than every update.
+     *
+     * Evaluating every candidate at every observation is the dominant cost in a VFDT, and the bound
+     * moves slowly, so checking periodically loses almost nothing.
+     */
+    val splitPeriod: Int
+
+    /** Hard ceiling on tree depth. */
+    val maxDepth: Int
+
+    /** Hard ceiling on internal plus leaf nodes. */
+    val maxNodes: Int
+
+    /**
+     * Breiman-style random-subspace size: at every audit-leaf birth, draw a fresh random subset of this
+     * many candidates from the tree's full pool. `null` disables the trick and considers every candidate.
+     *
+     * This is what decorrelates the trees in a forest. A single tree usually leaves it null.
+     */
+    val mtry: Int?
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -13,9 +13,6 @@ import com.eignex.kumulant.stream.guarded
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.math.ln
-import kotlin.math.pow
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
@@ -179,19 +176,13 @@ class RegressionTree<Row>(
         if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
             return RegressionTerminalLeaf(leafArmFactory())
         }
-        val subset = pickCandidates()
+        val subset = splitCandidates.pickCandidates(config.mtry, random)
         return RegressionAuditLeaf(
             arm = leafArmFactory(),
             candidates = subset,
             pos = List(subset.size) { leafArmFactory() },
             neg = List(subset.size) { leafArmFactory() },
         )
-    }
-
-    private fun pickCandidates(): List<Split<Row>> {
-        val k = config.mtry ?: return splitCandidates
-        if (k >= splitCandidates.size) return splitCandidates
-        return splitCandidates.shuffled(random).take(k)
     }
 
     private fun updateNode(
@@ -270,11 +261,5 @@ class RegressionTree<Row>(
                 carryover = leaf.arm,
             )
         }
-    }
-
-    private fun hoeffdingBound(delta: Double, n: Double, depth: Int, decay: Double): Double {
-        if (n <= 0.0) return Double.POSITIVE_INFINITY
-        val adjusted = delta * decay.pow(depth.toDouble())
-        return sqrt(-ln(adjusted) / (2.0 * n))
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig.kt
@@ -5,29 +5,21 @@ import kotlinx.serialization.Serializable
 /**
  * Tunables for [RegressionTree] growth, shared by [DecisionTreeRegressionStat] and
  * [RandomForestRegressionStat].
+ *
+ * Every field except [metric] is described on [HoeffdingTreeConfig], which the classification
+ * counterpart also implements.
  */
 @Serializable
 data class RegressionTreeConfig(
-    /** Hoeffding-bound confidence threshold. Lower -> splits require more evidence. */
-    val delta: Double = 0.05,
-    /** Multiplicative decay applied to [delta] per depth; slows growth near leaves. */
-    val deltaDecay: Double = 0.9,
-    /** If the Hoeffding bound itself shrinks below this, the leaf may split even when
-     *  the runner-up is close (the classic VFDT "tie-break" parameter). */
-    val tau: Double = 0.05,
-    /** Minimum total weighted samples at a leaf before split evaluation. */
-    val minSamplesSplit: Double = 30.0,
-    /** Minimum weighted samples on each side of a candidate split. */
-    val minSamplesLeaf: Double = 5.0,
-    /** Audit every Nth observation rather than every update. */
-    val splitPeriod: Int = 10,
-    /** Hard ceiling on tree depth. */
-    val maxDepth: Int = 16,
-    /** Hard ceiling on internal + leaf nodes. */
-    val maxNodes: Int = 1024,
-    /** Split criterion. */
+    override val delta: Double = 0.05,
+    override val deltaDecay: Double = 0.9,
+    override val tau: Double = 0.05,
+    override val minSamplesSplit: Double = 30.0,
+    override val minSamplesLeaf: Double = 5.0,
+    override val splitPeriod: Int = 10,
+    override val maxDepth: Int = 16,
+    override val maxNodes: Int = 1024,
+    /** Split criterion; ranks candidates by the variance they remove. */
     val metric: SplitMetric = VarianceReduction,
-    /** Breiman-style random-subspace size: at every audit-leaf birth, draw a fresh random
-     *  subset of this many candidates from the tree's full pool. `null` disables the trick. */
-    val mtry: Int? = null,
-)
+    override val mtry: Int? = null,
+) : HoeffdingTreeConfig

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -1,7 +1,10 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import kotlin.math.ceil
+import kotlin.math.ln
+import kotlin.math.pow
 import kotlin.math.sqrt
+import kotlin.random.Random
 
 /**
  * Breiman's default random-subspace size: `ceil(sqrt(p))` candidates drawn per audit leaf.
@@ -15,3 +18,49 @@ import kotlin.math.sqrt
  * @param p size of the tree's full candidate-split pool.
  */
 internal fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble())).toInt().coerceAtLeast(1)
+
+/**
+ * The VFDT split margin: how far ahead a candidate must be before the tree believes the ordering.
+ *
+ * Hoeffding's inequality bounds how far a mean over [n] observations can sit from the true mean at
+ * confidence [delta], and a split fires when the best candidate beats the runner-up by more than this.
+ * That is what makes the tree's decisions stable rather than a reaction to whichever candidate happened
+ * to look good first.
+ *
+ * [delta] is decayed by [decay] raised to [depth] before use: a deeper leaf sees less of the stream, so
+ * holding confidence fixed would let it split on proportionally thinner evidence. An empty leaf returns
+ * an infinite bound, so no margin can ever clear it and the leaf cannot split on no data.
+ *
+ * Both trees carried a byte-identical private copy of this.
+ *
+ * @param delta confidence threshold before depth decay.
+ * @param n total observation weight at the leaf.
+ * @param depth the leaf's depth, driving the decay.
+ * @param decay per-depth multiplier on [delta].
+ */
+internal fun hoeffdingBound(delta: Double, n: Double, depth: Int, decay: Double): Double {
+    if (n <= 0.0) return Double.POSITIVE_INFINITY
+    val adjusted = delta * decay.pow(depth.toDouble())
+    return sqrt(-ln(adjusted) / (2.0 * n))
+}
+
+/**
+ * Draw the random subspace of candidate splits a newly born audit leaf will consider.
+ *
+ * With [mtry] null, or at least as large as the pool, the leaf considers everything and the list is
+ * returned as is rather than copied. Otherwise it gets a fresh random subset, which is what decorrelates
+ * the trees in a forest: two trees seeing the same stream still grow differently because they were
+ * offered different candidates.
+ *
+ * Generic in the split type because the regression tree is generic in its row type while the
+ * classification tree is fixed to `VectorView`; both trees had their own copy of this.
+ *
+ * @param S the split type, which differs between the two trees.
+ * @param mtry subspace size, or null for the full pool.
+ * @param random the tree's PRNG, so a seeded tree stays reproducible.
+ */
+internal fun <S> List<S>.pickCandidates(mtry: Int?, random: Random): List<S> {
+    val k = mtry ?: return this
+    if (k >= size) return this
+    return shuffled(random).take(k)
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
@@ -1,0 +1,141 @@
+package com.eignex.kumulant.stat.regression.tree
+
+import kotlin.math.ln
+import kotlin.math.sqrt
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val DELTA = 1e-12
+
+/**
+ * The growth helpers both VFDT trees share, which each tree used to keep its own copy of.
+ */
+class TreeInternalsTest {
+
+    @Test
+    fun `the hoeffding bound is infinite at an empty leaf`() {
+        // No margin can clear an infinite bound, which is what stops a leaf splitting on no data. The
+        // guard also keeps the division below from producing an infinity by accident.
+        assertEquals(Double.POSITIVE_INFINITY, hoeffdingBound(0.05, 0.0, depth = 0, decay = 0.9))
+        assertEquals(Double.POSITIVE_INFINITY, hoeffdingBound(0.05, -1.0, depth = 0, decay = 0.9))
+    }
+
+    @Test
+    fun `the hoeffding bound matches the closed form at depth zero`() {
+        // decay^0 is 1, so at the root the bound is exactly sqrt(-ln(delta) / 2n) with no adjustment.
+        val expected = sqrt(-ln(0.05) / (2.0 * 100.0))
+        assertEquals(expected, hoeffdingBound(0.05, 100.0, depth = 0, decay = 0.9), DELTA)
+    }
+
+    @Test
+    fun `the bound shrinks as evidence accumulates`() {
+        // The property the whole split rule rests on: more observations means a tighter margin, so a
+        // candidate that was not yet convincing becomes convincing without changing.
+        var previous = Double.MAX_VALUE
+        for (n in listOf(1.0, 10.0, 100.0, 1_000.0, 10_000.0)) {
+            val bound = hoeffdingBound(0.05, n, depth = 0, decay = 0.9)
+            assertTrue(bound < previous, "the bound did not shrink at n=$n: $previous then $bound")
+            previous = bound
+        }
+    }
+
+    @Test
+    fun `the bound widens with depth`() {
+        // The decay makes a deeper leaf demand a larger margin from the same amount of evidence, which
+        // is the point: a deep leaf sees less of the stream, so equal confidence would be cheaper there.
+        var previous = 0.0
+        for (depth in 0..8) {
+            val bound = hoeffdingBound(0.05, 100.0, depth = depth, decay = 0.9)
+            assertTrue(bound > previous, "the bound did not widen at depth $depth: $previous then $bound")
+            previous = bound
+        }
+    }
+
+    @Test
+    fun `a decay of one makes depth irrelevant`() {
+        val root = hoeffdingBound(0.05, 100.0, depth = 0, decay = 1.0)
+        for (depth in 1..5) {
+            assertEquals(root, hoeffdingBound(0.05, 100.0, depth = depth, decay = 1.0), DELTA)
+        }
+    }
+
+    @Test
+    fun `a tighter confidence demands a wider margin`() {
+        val loose = hoeffdingBound(0.5, 100.0, depth = 0, decay = 0.9)
+        val tight = hoeffdingBound(0.001, 100.0, depth = 0, decay = 0.9)
+        assertTrue(tight > loose, "a smaller delta should widen the bound: $tight vs $loose")
+    }
+
+    @Test
+    fun `a null mtry keeps the whole pool without copying it`() {
+        val pool = listOf("a", "b", "c")
+
+        val picked = pool.pickCandidates(mtry = null, random = Random(0))
+
+        // Identity, not just equality: the full-pool path is the common one and should not allocate.
+        assertTrue(picked === pool, "the full pool was copied")
+    }
+
+    @Test
+    fun `an mtry at least the pool size keeps the whole pool`() {
+        val pool = listOf("a", "b", "c")
+
+        assertTrue(pool.pickCandidates(mtry = 3, random = Random(0)) === pool)
+        assertTrue(pool.pickCandidates(mtry = 99, random = Random(0)) === pool)
+    }
+
+    @Test
+    fun `a smaller mtry draws that many distinct candidates from the pool`() {
+        val pool = (0 until 20).toList()
+
+        for (k in 1..19) {
+            val picked = pool.pickCandidates(mtry = k, random = Random(k))
+            assertEquals(k, picked.size, "wrong subspace size for mtry=$k")
+            assertEquals(k, picked.toSet().size, "mtry=$k drew a duplicate: $picked")
+            assertTrue(picked.all { it in pool }, "mtry=$k drew something outside the pool: $picked")
+        }
+    }
+
+    @Test
+    fun `the draw is reproducible from the seed and varies across seeds`() {
+        // Both halves matter. Reproducibility is what makes a seeded forest testable at all; variation
+        // is what actually decorrelates the trees, and a subspace draw that ignored the PRNG would
+        // still pass every other test here.
+        val pool = (0 until 20).toList()
+
+        assertEquals(
+            pool.pickCandidates(mtry = 5, random = Random(7)),
+            pool.pickCandidates(mtry = 5, random = Random(7)),
+            "the same seed drew a different subspace",
+        )
+
+        val draws = (0 until 8).map { pool.pickCandidates(mtry = 5, random = Random(it)) }.toSet()
+        assertTrue(draws.size > 1, "every seed drew the same subspace: $draws")
+    }
+
+    @Test
+    fun `an empty pool stays empty`() {
+        val pool = emptyList<String>()
+        assertEquals(pool, pool.pickCandidates(mtry = 3, random = Random(0)))
+        assertEquals(pool, pool.pickCandidates(mtry = null, random = Random(0)))
+    }
+
+    @Test
+    fun `both configs expose the shared tunables through one interface`() {
+        // What makes the growth logic able to read tunables without knowing which tree it drives.
+        val configs: List<HoeffdingTreeConfig> = listOf(RegressionTreeConfig(), ClassificationTreeConfig())
+        for (config in configs) {
+            assertEquals(0.05, config.delta, DELTA)
+            assertEquals(0.9, config.deltaDecay, DELTA)
+            assertEquals(0.05, config.tau, DELTA)
+            assertEquals(30.0, config.minSamplesSplit, DELTA)
+            assertEquals(5.0, config.minSamplesLeaf, DELTA)
+            assertEquals(10, config.splitPeriod)
+            assertEquals(16, config.maxDepth)
+            assertEquals(1024, config.maxNodes)
+            assertEquals(null, config.mtry)
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Moved `hoeffdingBound` to `TreeInternals.kt`. Both trees had a byte-identical private copy.
- Moved `pickCandidates` there too, generic in the split type, since the regression tree is generic in its row type while the classification tree is fixed to `VectorView`.
- Added a `HoeffdingTreeConfig` interface carrying the nine tunables both configs share. `RegressionTreeConfig` and `ClassificationTreeConfig` now implement it.
- Restored two explanatory comments in `ClassificationTree` that only the regression copy still had: the double-check-inside-the-lock rationale and the carryover rationale.
- Added `TreeInternalsTest`.

## Why

`RegressionTree` and `ClassificationTree` are 280 and 296 lines that a structural diff shows to be the same algorithm with different identifiers. They are also visibly drifting: the regression copy still carries three explanations of why the audit path does what it does, and the classification copy has lost them. Whichever way the larger refactor goes, these pieces do not depend on the leaf payload at all, so lifting them first shrinks the diff that does.

The two configs stay separate types deliberately. Each is `@Serializable` and part of the wire format, and their `metric` fields have different types, so merging them would be a breaking change for no real gain. The interface is where the shared half gets described once, and it is what will let the growth logic read tunables without knowing which tree it is driving.

Beyond deduplication, this fills in what the classification config's KDoc had lost. Its `tau` was documented as "Hoeffding-bound shrinkage threshold for the VFDT tie-break", which names the parameter without saying what it is for; the interface now explains that without it two candidates of equal merit deadlock forever, because the margin between them never exceeds any bound.

## ABI

`kumulant.api` and `kumulant.klib.api` are regenerated. The change is the new supertype plus the shared getters going from `final` to open, which is what implementing an interface does. No signature changes, no removals, and the serialized form of both configs is untouched: same field names, same order, same defaults. `RegressionSpecsRoundTripTest` covers a tree config through JSON and passes.

## Testing

`./gradlew build` passes on all targets, including detekt and the ABI check against the regenerated dumps.

`TreeInternalsTest` covers the two lifted helpers as properties rather than as fixed values, so it checks the bound tightens as evidence accumulates and widens with depth, rather than only matching numbers. Two of its cases exist to catch a helper that looks right but is not wired up: the subspace draw is checked for reproducibility from a seed and for variation across seeds, because a draw that ignored the PRNG entirely would pass every other assertion while quietly refusing to decorrelate the trees in a forest.
