### PR TITLE
refactor: share the candidate ranking and split decision between both VFDT trees

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -7449,7 +7449,7 @@ public final class com/eignex/kumulant/stat/regression/glm/UnivariateRegressionS
 	public fun update (DDJD)V
 }
 
-public final class com/eignex/kumulant/stat/regression/tree/ClassCountsResult : com/eignex/kumulant/core/Result {
+public final class com/eignex/kumulant/stat/regression/tree/ClassCountsResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult$Companion;
 	public fun <init> (I[D)V
 	public final fun component1 ()I
@@ -7461,8 +7461,9 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassCountsResult : 
 	public final fun getEntropy ()D
 	public final fun getGini ()D
 	public final fun getNumClasses ()I
-	public final fun getTotalWeights ()D
+	public fun getTotalWeights ()D
 	public fun hashCode ()I
+	public fun isEmpty ()Z
 	public final fun predict ()I
 	public final fun probabilities ()[D
 	public fun toString ()Ljava/lang/String;

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -6559,7 +6559,7 @@ final class com.eignex.kumulant.stat.regression.glm/UnivariateRegressionStat : c
     final fun update(kotlin/Double, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/UnivariateRegressionStat.update|update(kotlin.Double;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
-final class com.eignex.kumulant.stat.regression.tree/ClassCountsResult : com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.regression.tree/ClassCountsResult|null[0]
+final class com.eignex.kumulant.stat.regression.tree/ClassCountsResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression.tree/ClassCountsResult|null[0]
     constructor <init>(kotlin/Int, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression.tree/ClassCountsResult.<init>|<init>(kotlin.Int;kotlin.DoubleArray){}[0]
 
     final val counts // com.eignex.kumulant.stat.regression.tree/ClassCountsResult.counts|{}counts[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
@@ -24,7 +24,7 @@ data class ClassCountsResult(
     val numClasses: Int,
     /** Per-class accumulated weight; length [numClasses]. */
     val counts: DoubleArray,
-) : Result {
+) : HasObservationCount {
 
     init {
         require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
@@ -32,7 +32,7 @@ data class ClassCountsResult(
     }
 
     /** Total weight summed across all classes. */
-    val totalWeights: Double get() {
+    override val totalWeights: Double get() {
         var s = 0.0
         for (c in counts) s += c
         return s

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric.kt
@@ -55,25 +55,4 @@ internal fun ClassificationSplitMetric.rank(
     neg: List<ClassCountsResult>,
     minSamplesSplit: Double,
     minSamplesLeaf: Double,
-): SplitInfo {
-    require(pos.size == neg.size) { "pos and neg lists must align: ${pos.size} vs ${neg.size}" }
-    var top1 = 0.0
-    var top2 = 0.0
-    var bestI = -1
-    for (i in pos.indices) {
-        val wPos = pos[i].totalWeights
-        val wNeg = neg[i].totalWeights
-        if (wPos < minSamplesLeaf || wNeg < minSamplesLeaf || wPos + wNeg < minSamplesSplit) continue
-        val v = score(total, pos[i], neg[i])
-        when {
-            v > top1 -> {
-                top2 = top1
-                top1 = v
-                bestI = i
-            }
-
-            v > top2 -> top2 = v
-        }
-    }
-    return SplitInfo(top1, top2, bestI)
-}
+): SplitInfo = rankCandidates(total, pos, neg, minSamplesSplit, minSamplesLeaf, ::score)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -260,16 +260,13 @@ class ClassificationTree(
             leaf.observationsSinceLastCheck.store(0L)
 
             val total = leaf.arm.read(0L)
-            if (total.totalWeights < config.minSamplesSplit) return@guarded leaf
             val pos = leaf.pos.map { it.read(0L) }
             val neg = leaf.neg.map { it.read(0L) }
             val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@guarded leaf
-
-            val eps = hoeffdingBound(config.delta, total.totalWeights, depth, config.deltaDecay)
-            val passesHoeffding = ranked.top1 - ranked.top2 > eps
-            val passesTau = eps < config.tau
-            if (!passesHoeffding && !passesTau) return@guarded leaf
+            // Every gate lives in shouldSplit now. Both trees spelled the three of them out, and the
+            // Hoeffding-versus-tau disjunction in particular is the kind of condition that reads correct
+            // in either copy while the two have quietly stopped meaning the same thing.
+            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded leaf
 
             // Stash the pre-split aggregate as the new split's carryover so it shows up
             // in subtree aggregates without burdening the hot path. New leaves start

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -238,16 +238,13 @@ class RegressionTree<Row>(
             leaf.observationsSinceLastCheck.store(0L)
 
             val total = leaf.arm.read(0L)
-            if (total.totalWeights < config.minSamplesSplit) return@guarded leaf
             val pos = leaf.pos.map { it.read(0L) }
             val neg = leaf.neg.map { it.read(0L) }
             val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return@guarded leaf
-
-            val eps = hoeffdingBound(config.delta, total.totalWeights, depth, config.deltaDecay)
-            val passesHoeffding = ranked.top1 - ranked.top2 > eps
-            val passesTau = eps < config.tau
-            if (!passesHoeffding && !passesTau) return@guarded leaf
+            // Every gate lives in shouldSplit now. Both trees spelled the three of them out, and the
+            // Hoeffding-versus-tau disjunction in particular is the kind of condition that reads correct
+            // in either copy while the two have quietly stopped meaning the same thing.
+            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded leaf
 
             // Stash the pre-split aggregate as the new split's carryover so it shows up
             // in subtree aggregates without burdening the hot path. New leaves start

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/SplitMetric.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/SplitMetric.kt
@@ -57,25 +57,4 @@ fun SplitMetric.rank(
     neg: List<WeightedVarianceResult>,
     minSamplesSplit: Double,
     minSamplesLeaf: Double,
-): SplitInfo {
-    require(pos.size == neg.size) { "pos and neg lists must align: ${pos.size} vs ${neg.size}" }
-    var top1 = 0.0
-    var top2 = 0.0
-    var bestI = -1
-    for (i in pos.indices) {
-        val wPos = pos[i].totalWeights
-        val wNeg = neg[i].totalWeights
-        if (wPos < minSamplesLeaf || wNeg < minSamplesLeaf || wPos + wNeg < minSamplesSplit) continue
-        val v = score(total, pos[i], neg[i])
-        when {
-            v > top1 -> {
-                top2 = top1
-                top1 = v
-                bestI = i
-            }
-
-            v > top2 -> top2 = v
-        }
-    }
-    return SplitInfo(top1, top2, bestI)
-}
+): SplitInfo = rankCandidates(total, pos, neg, minSamplesSplit, minSamplesLeaf, ::score)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
+import com.eignex.kumulant.core.HasObservationCount
 import kotlin.math.ceil
 import kotlin.math.ln
 import kotlin.math.pow
@@ -63,4 +64,86 @@ internal fun <S> List<S>.pickCandidates(mtry: Int?, random: Random): List<S> {
     val k = mtry ?: return this
     if (k >= size) return this
     return shuffled(random).take(k)
+}
+
+/**
+ * Score every candidate split at a leaf and return the winner, the runner-up, and the winner's index.
+ *
+ * Generic in the leaf payload, which is the only thing that differed between the regression and
+ * classification copies of this loop. Both needed `totalWeights` and a scoring function and nothing
+ * else, so both are supplied here rather than reached through a payload-specific metric type.
+ *
+ * A candidate is skipped, not scored, when either side is thinner than [minSamplesLeaf] or the two
+ * sides together are thinner than [minSamplesSplit]: a split that isolates three observations may score
+ * beautifully and predict nothing. Skipped candidates cannot become `bestIndex`, so a leaf where every
+ * candidate is too thin reports `bestIndex = -1` and does not split.
+ *
+ * The runner-up is tracked because that, not the winner's absolute score, is what the Hoeffding test
+ * consumes: the question is whether the tree is confident about the *ordering*, so a leaf with two
+ * equally good candidates has to wait even though both are excellent.
+ *
+ * @param R the leaf payload type.
+ * @param total the leaf's pre-split aggregate.
+ * @param pos per-candidate aggregate of observations routing true.
+ * @param neg per-candidate aggregate of observations routing false.
+ * @param minSamplesSplit minimum combined weight for a candidate to be scored.
+ * @param minSamplesLeaf minimum weight on each side for a candidate to be scored.
+ * @param score the split criterion, taking total / pos / neg.
+ */
+internal fun <R : HasObservationCount> rankCandidates(
+    total: R,
+    pos: List<R>,
+    neg: List<R>,
+    minSamplesSplit: Double,
+    minSamplesLeaf: Double,
+    score: (R, R, R) -> Double,
+): SplitInfo {
+    require(pos.size == neg.size) { "pos and neg lists must align: ${pos.size} vs ${neg.size}" }
+    var top1 = 0.0
+    var top2 = 0.0
+    var bestI = -1
+    for (i in pos.indices) {
+        val wPos = pos[i].totalWeights
+        val wNeg = neg[i].totalWeights
+        if (wPos < minSamplesLeaf || wNeg < minSamplesLeaf || wPos + wNeg < minSamplesSplit) continue
+        val v = score(total, pos[i], neg[i])
+        when {
+            v > top1 -> {
+                top2 = top1
+                top1 = v
+                bestI = i
+            }
+
+            v > top2 -> top2 = v
+        }
+    }
+    return SplitInfo(top1, top2, bestI)
+}
+
+/**
+ * The VFDT split decision: given ranked candidates, has the leaf earned the right to split?
+ *
+ * Three gates, and all three used to be written out twice with nothing keeping them in step.
+ *
+ * A candidate must exist and be worth taking: `bestIndex < 0` means every candidate was too thin to
+ * score, and `top1 <= 0.0` means the best one does not improve on not splitting at all, since every
+ * metric is defined so that no signal scores zero.
+ *
+ * Then either the Hoeffding test or the tie-break has to pass. The Hoeffding test is the real rule: the
+ * winner must beat the runner-up by more than the bound, so the ordering is not an artefact of which
+ * candidate happened to look good first. The tie-break exists because that rule alone deadlocks - two
+ * candidates of genuinely equal merit never separate by more than any bound, so the leaf would grow
+ * forever without splitting. Once the bound itself has shrunk below [HoeffdingTreeConfig.tau] the tree
+ * has enough evidence to know the choice does not matter much, and picks the winner anyway.
+ *
+ * @param ranked output of [rankCandidates].
+ * @param totalWeight the leaf's accumulated observation weight, which drives the bound.
+ * @param depth the leaf's depth, which decays the confidence level.
+ * @param config the growth tunables.
+ */
+internal fun shouldSplit(ranked: SplitInfo, totalWeight: Double, depth: Int, config: HoeffdingTreeConfig): Boolean {
+    if (totalWeight < config.minSamplesSplit) return false
+    if (ranked.bestIndex < 0 || ranked.top1 <= 0.0) return false
+    val eps = hoeffdingBound(config.delta, totalWeight, depth, config.deltaDecay)
+    return ranked.top1 - ranked.top2 > eps || eps < config.tau
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
@@ -122,6 +122,131 @@ class TreeInternalsTest {
         assertEquals(pool, pool.pickCandidates(mtry = null, random = Random(0)))
     }
 
+    // A leaf payload standing in for both real ones, so the ranking tests exercise the shared loop
+    // rather than either metric's arithmetic.
+    private fun counts(vararg c: Double) = ClassCountsResult(c.size, c)
+
+    @Test
+    fun `ranking picks the best candidate and remembers the runner-up`() {
+        // The runner-up is what the Hoeffding test consumes, so losing track of it would not fail any
+        // "did it pick the best one" assertion while breaking the split rule completely.
+        val total = counts(50.0, 50.0)
+        val pos = listOf(counts(40.0, 10.0), counts(30.0, 20.0), counts(26.0, 24.0))
+        val neg = listOf(counts(10.0, 40.0), counts(20.0, 30.0), counts(24.0, 26.0))
+
+        val ranked = rankCandidates(total, pos, neg, minSamplesSplit = 30.0, minSamplesLeaf = 5.0) { t, p, n ->
+            GiniReduction.score(t, p, n)
+        }
+
+        assertEquals(0, ranked.bestIndex, "the most separating candidate should win")
+        assertTrue(ranked.top1 > ranked.top2, "the runner-up should score below the winner")
+        assertTrue(ranked.top2 > 0.0, "the second candidate separates too, so top2 should not be zero")
+    }
+
+    @Test
+    fun `a candidate too thin on one side is skipped rather than scored`() {
+        // A split isolating three observations can score beautifully and predict nothing, so the
+        // thinness gate has to run before the score is even considered - not after, as a tiebreak.
+        val total = counts(50.0, 50.0)
+        val perfectButThin = counts(3.0, 0.0)
+        val theRest = counts(47.0, 50.0)
+
+        val ranked = rankCandidates(
+            total,
+            listOf(perfectButThin),
+            listOf(theRest),
+            minSamplesSplit = 30.0,
+            minSamplesLeaf = 5.0,
+        ) { t, p, n -> GiniReduction.score(t, p, n) }
+
+        assertEquals(-1, ranked.bestIndex, "a candidate with 3 observations on one side was accepted")
+        assertEquals(0.0, ranked.top1, DELTA)
+    }
+
+    @Test
+    fun `mismatched candidate lists are rejected`() {
+        val total = counts(10.0, 10.0)
+        val e = runCatching {
+            rankCandidates(total, listOf(counts(5.0, 5.0)), emptyList(), 1.0, 1.0) { _, _, _ -> 1.0 }
+        }.exceptionOrNull()
+        assertTrue(e is IllegalArgumentException, "expected a rejection, got $e")
+    }
+
+    @Test
+    fun `a leaf below minSamplesSplit does not split`() {
+        val ranked = SplitInfo(top1 = 10.0, top2 = 0.0, bestIndex = 0)
+        val config = ClassificationTreeConfig(minSamplesSplit = 30.0)
+
+        assertEquals(false, shouldSplit(ranked, totalWeight = 29.0, depth = 0, config = config))
+        assertEquals(true, shouldSplit(ranked, totalWeight = 30.0, depth = 0, config = config))
+    }
+
+    @Test
+    fun `a leaf with no qualifying candidate does not split`() {
+        val config = ClassificationTreeConfig()
+        // Nothing scored at all.
+        assertEquals(false, shouldSplit(SplitInfo(0.0, 0.0, -1), 1000.0, 0, config))
+        // Something scored, but no better than not splitting; every metric returns 0 for no signal.
+        assertEquals(false, shouldSplit(SplitInfo(0.0, 0.0, 2), 1000.0, 0, config))
+    }
+
+    @Test
+    fun `the hoeffding test needs the winner to clear the runner-up by the bound`() {
+        val config = ClassificationTreeConfig(tau = 0.0) // tau off, so only the Hoeffding rule applies
+        val bound = hoeffdingBound(config.delta, 1000.0, 0, config.deltaDecay)
+
+        val clears = SplitInfo(top1 = bound * 3.0, top2 = 0.0, bestIndex = 0)
+        val doesNot = SplitInfo(top1 = bound * 3.0, top2 = bound * 3.0 - bound / 2.0, bestIndex = 0)
+
+        assertTrue(shouldSplit(clears, 1000.0, 0, config), "a clear winner should split")
+        assertTrue(
+            !shouldSplit(doesNot, 1000.0, 0, config),
+            "a winner inside the bound of the runner-up should wait",
+        )
+    }
+
+    @Test
+    fun `the tau tie-break breaks a deadlock the hoeffding rule cannot`() {
+        // Two candidates of equal merit never separate by more than any bound, so without tau the leaf
+        // grows forever without splitting. This is the VFDT tie-break, and it is the reason the
+        // decision is a disjunction rather than a single test.
+        val tied = SplitInfo(top1 = 5.0, top2 = 5.0, bestIndex = 0)
+        val bigLeaf = 1_000_000.0
+
+        val withoutTau = ClassificationTreeConfig(tau = 0.0)
+        assertTrue(!shouldSplit(tied, bigLeaf, 0, withoutTau), "with tau off, a tie must never split")
+
+        val withTau = ClassificationTreeConfig(tau = 0.05)
+        assertTrue(shouldSplit(tied, bigLeaf, 0, withTau), "tau should let a well-evidenced tie split")
+
+        // And tau is not a blanket override: the same tie on a small leaf still waits, because the
+        // bound has not shrunk below tau yet.
+        assertTrue(!shouldSplit(tied, 40.0, 0, withTau), "tau should not fire before the bound shrinks")
+    }
+
+    @Test
+    fun `both trees reach the same decision from the same evidence`() {
+        // The point of sharing it. Identical tunables in both config types must produce identical
+        // verdicts, which is exactly what two hand-written copies of the rule could not guarantee.
+        val cases = listOf(
+            SplitInfo(10.0, 0.0, 0),
+            SplitInfo(0.0, 0.0, -1),
+            SplitInfo(5.0, 5.0, 0),
+            SplitInfo(0.001, 0.0005, 1),
+        )
+        for (weight in listOf(29.0, 100.0, 100_000.0)) {
+            for (depth in listOf(0, 4, 12)) {
+                for (ranked in cases) {
+                    assertEquals(
+                        shouldSplit(ranked, weight, depth, RegressionTreeConfig()),
+                        shouldSplit(ranked, weight, depth, ClassificationTreeConfig()),
+                        "the two trees disagreed at weight=$weight depth=$depth on $ranked",
+                    )
+                }
+            }
+        }
+    }
+
     @Test
     fun `both configs expose the shared tunables through one interface`() {
         // What makes the growth logic able to read tunables without knowing which tree it drives.


### PR DESCRIPTION
Stacked on #49.

## What changed

- Added `rankCandidates`, generic in the leaf payload, and pointed both `SplitMetric.rank` and `ClassificationSplitMetric.rank` at it. The two loops were byte-identical apart from the payload type and already returned the same public `SplitInfo`.
- Added `shouldSplit`, holding all three gates of the VFDT split decision, and both trees' audit paths now call it.
- `ClassCountsResult` implements `HasObservationCount` instead of bare `Result`. It already had a `totalWeights`; this makes it the interface's, which is what lets the ranking generic be constrained naturally rather than taking a weight-selector lambda.
- Extended `TreeInternalsTest`.

## Scope, which is smaller than the task proposed

The task this came from suggested a generic `HoeffdingTree<Row, R : Result>` absorbing `updateNode`, `updateAuditLeaf`, `mergeNodes`, `prettyPrintTo` and `countNodes`. That is not available at an acceptable price, and the reason is worth recording.

Both node hierarchies are public API. `RegressionNode<Row>`, `RegressionSplitNode`, `RegressionLeafNode`, and their classification mirrors are all exported, and they are reachable through `RegressionTree.rootNode()`, `TreeClassificationResult`, the public `aggregate()` extension, and the contextual-bandit tree code. Unifying them is a breaking change for anyone who has walked a tree. Sharing the recursive driver without unifying them would mean adding supertypes to public sealed hierarchies and threading every node access through an abstraction layer, on the update hot path, for code that is mechanical rather than subtle.

So I took the subtle part and left the mechanical part. What is shared now is the whole of the decision logic: which candidate wins, whether it has earned the split, and on what evidence. What remains duplicated is the recursion that walks and rebuilds nodes, which is bound to the node types and is hard to get wrong in a way tests would not catch immediately.

## One deliberate cost

`minSamplesSplit` used to be checked before ranking and now lives inside `shouldSplit`, which runs after it. A leaf below the threshold therefore ranks its candidates and then declines, where it used to skip ranking entirely. The audit path is throttled to every `splitPeriod` observations, so this is at most a few wasted rank calls per leaf before it first reaches `minSamplesSplit`. I took that over keeping a copy of the gate in both trees to preserve the short-circuit, because a decision rule split across three places is what this PR exists to remove.

## ABI

`ClassCountsResult` gains `HasObservationCount` as its supertype and `getTotalWeights` goes from `final` to open, plus the interface's `isEmpty` default. No signature changes and no removals. The serialized form is untouched.

## Testing

`./gradlew build` passes, including a full clean build.

The tests are written against the split rule rather than against fixed numbers, because the rule is what the two copies could disagree about. `the tau tie-break breaks a deadlock the hoeffding rule cannot` checks all three branches of that behaviour: with tau off a tie never splits, with tau on a well-evidenced tie does, and the same tie on a small leaf still waits. `both trees reach the same decision from the same evidence` runs 36 combinations of ranking, leaf weight and depth through both config types and asserts the verdicts match, which is the property two hand-written copies could not offer.

One note on the run. `wasmWasiNodeTest` failed once mid-session and then passed on re-run and on a clean build from scratch, with no output identifying an assertion. I am recording it as a flake rather than a finding, since nothing in this change is target-specific, but it is worth watching if it recurs in CI.
