### PR TITLE
test: replace eighty per-file tolerance constants with one shared value

### DIFF
--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestTolerance.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestTolerance.kt
@@ -1,0 +1,23 @@
+package com.eignex.kumulant
+
+/**
+ * The comparison tolerance for floating-point assertions across the test suite.
+ *
+ * Eighty test files each declared their own `private const val DELTA`, at three different values: 45 at
+ * `1e-12`, 34 at `1e-9`, and one at `1e-6`. The spread encoded nothing. Every one of those files passes
+ * at `1e-12` on all thirteen targets, including the native and wasm ones, whose libm differs from the
+ * JVM's - so the looser values were not headroom anybody had measured a need for, they were just the
+ * number the file's author happened to write.
+ *
+ * One value, so that a file which genuinely needs slack has to say so with a local override and a reason.
+ * That is the point of consolidating: not saving seventy-nine lines, but making a loosened tolerance
+ * visible as a decision instead of indistinguishable from the default.
+ *
+ * `1e-12` rather than something tighter because these are `Double` comparisons after accumulation over a
+ * stream, not single operations. Roughly three decimal digits of slack against the `2.2e-16` epsilon
+ * absorbs the reassociation a Welford or Chan recurrence performs without absorbing a real error.
+ *
+ * A test asserting something that should be *bit*-exact - a downdate restoring a prior state, a merge
+ * matching a direct accumulation - should assert equality rather than reach for a smaller delta here.
+ */
+internal const val DELTA: Double = 1e-12

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.bandit
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 /**
  * The shared EXP3 / EXP4 weight renormaliser. Both policies had their own copy, spelled with different

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.bandit
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
@@ -19,8 +20,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class TrackedBanditTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.core
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionStat
 import com.eignex.kumulant.stat.regression.tree.ClassCountsStat
@@ -12,7 +13,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 private const val CLASSES = 3
-private const val DELTA = 1e-12
 
 /**
  * Which `Double`s name a class, checked on the helper and then on every classifier that uses it.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.math
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 /**
  * Properties of the shared softmax, which three call sites previously each implemented for themselves.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/AxisBindingsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/AxisBindingsTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.glm.UnivariateRegressionStat
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-9
 
 class AxisBindingsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/BandTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/BandTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.BandResult
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-9
 
 class BandTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/FeedbackTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/FeedbackTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.Center
 import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.expr.IfExpr
@@ -16,8 +17,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 /** Standard-scaler projection: emits 0 while stdDev is still zero (first update). */
 private val standardScalerExpr = IfExpr(Scale gt 0.0, (X - Center) / Scale, Const(0.0))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/HysteresisTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/HysteresisTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-12
 
 class HysteresisTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/MapResultsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/MapResultsTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.MeanResult
 import com.eignex.kumulant.stat.summary.SumResult
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class MapResultsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/PerIndexFeedbackTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/PerIndexFeedbackTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.Center
 import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.expr.IfExpr
@@ -16,8 +17,6 @@ import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-9
 
 class PerIndexFeedbackTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RegressionTreeConfig
@@ -12,7 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private const val DELTA = 1e-12
 private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionOpsTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.spec.ResampleAggregator
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
-
-private const val DELTA = 1e-12
 
 class ResampleTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.random.Random
@@ -8,8 +9,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class SamplingTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ScalersTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ScalersTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class ScalersTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SelectorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SelectorsTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class SelectorsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ShiftsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ShiftsTest.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-private const val DELTA = 1e-12
 private const val NS_PER_SEC = 1_000_000_000L
 
 class ShiftsTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/TransformsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/TransformsTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.cardinality.LinearCountingStat
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class TransformsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorScalersTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorScalersTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class VectorScalersTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.SparseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.SumResult
@@ -8,8 +9,6 @@ import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-12
 
 private fun sumVector(dimensions: Int): VectorizedStat<SumResult> = VectorizedStat(dimensions, SumStat())
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.summary.CountStat
@@ -9,7 +10,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private const val DELTA = 1e-12
 private fun sumVector(d: Int) = VectorizedStat(d, SumStat())
 
 class WeightsTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
@@ -9,8 +10,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
-
-private const val DELTA = 1e-12
 
 private const val T0 = 0L
 private const val T3 = 3_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WithSelfLagTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WithSelfLagTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.operation
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.CovarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class WithSelfLagTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprSugarTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprSugarTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.schema.decay.*
 import com.eignex.kumulant.schema.expr.*
@@ -14,8 +15,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class ExprSugarTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.decay.*
@@ -17,7 +18,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-private const val DELTA = 1e-12
 
 class ExprTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsSchemaTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsSchemaTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.schema.decay.*
 import com.eignex.kumulant.schema.expr.*
@@ -18,7 +19,6 @@ import kotlin.test.assertTrue
  * matching modality helper (`seriesSpecs`/`pairedSpecs`/...) and turn it into
  * positional `(name, stat)` entries.
  */
-private const val DELTA = 1e-12
 
 class ListStatsSchemaTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.ResultList
@@ -19,8 +20,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
-
-private const val DELTA = 1e-12
 
 class ListStatsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/OperationsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/OperationsRoundTripTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.decay.*
@@ -45,7 +46,6 @@ import com.eignex.kumulant.operation.withWeight as liveWithWeight
  * Round-trip tests for the operation specs in [Operations.kt]: encode, decode,
  * materialize, drive a small fixed input, compare against a live composition.
  */
-private const val DELTA = 1e-12
 
 class OperationsRoundTripTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.schema
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.operation.foldRegression
 import com.eignex.kumulant.schema.decay.*
@@ -18,7 +19,6 @@ import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private const val DELTA = 1e-9
 private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionListStatsTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.schema
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.schema.decay.*
 import com.eignex.kumulant.schema.expr.*
@@ -18,7 +19,6 @@ import com.eignex.skema.SchemaJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private const val DELTA = 1e-9
 private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionSpecsRoundTripTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.schema
 
 import com.eignex.koblas.VectorView
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -37,8 +38,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 private fun sumVector(d: Int) = VectorizedStat(d, SumStat())
 private fun meanVector(d: Int) = VectorizedStat(d, MeanStat())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.anomaly
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class GaussianScorerStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.calibration
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.exp
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class PlattCalibratorStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.calibration
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class ReliabilityTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinStatTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stat.change
 
+import com.eignex.kumulant.DELTA
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class AdwinStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/CusumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/CusumStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.change
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class CusumStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.change
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class PageHinkleyStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStatTest.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-private const val DELTA = 1e-9
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L
 private const val T3 = 11_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStatTest.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-private const val DELTA = 1e-9
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L
 private const val T2 = 3_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStatTest.kt
@@ -1,12 +1,12 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-private const val DELTA = 1e-9
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L
 private const val T3 = 11_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class EwmaMeanStatTest {
     private val delta = 1e-9

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class EwmaVarianceStatTest {
     private val delta = 1e-9

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/ExcursionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/ExcursionStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.event
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class ExcursionStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/HoltStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/HoltStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.forecast
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.exp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class HoltStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStatTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.forecast
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-9
 
 class RecursiveVarianceStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.forecast
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class SeasonalSmoothingStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/HistogramResultsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/HistogramResultsTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.quantile
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class HistogramResultsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.quantile
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-12
 
 class ThresholdBucketStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.rate
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-9
 
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.rate
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
-
-private const val DELTA = 1e-9
 
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.rate
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-
-private const val DELTA = 1e-9
 
 private const val T0 = 1_000_000_000L
 private const val T1 = 2_000_000_000L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class GaussianNaiveBayesStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 /**
  * The shared L1 proximal operator, and the one case where the three copies it replaces disagreed.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCountsResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCountsResultTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.regression.tree
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-9
 
 class ClassCountsResultTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stat.regression.tree
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 /**
  * The growth helpers both VFDT trees share, which each tree used to keep its own copy of.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-9
 
 class AccuracyStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AucTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AucTest.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-private const val DELTA = 1e-6
 
 class AucTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/BrierScoreTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/BrierScoreTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class BrierScoreTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStatTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-9
 
 class ConfusionMatrixStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/LossTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/LossTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.ln
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class MseLossTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PinballLossTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PinballLossTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-12
 
 class PinballLossTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitHistogramTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitHistogramTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class PitHistogramTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitTestsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitTestsTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.quantile.SparseHistogramResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-9
 
 class PitTestsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMaxStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class ArgMaxStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMinStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/ArgMinStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class ArgMinStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/BernoulliSumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/BernoulliSumStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class BernoulliSumStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/CountStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/CountStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class CountStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MaxStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MaxStatTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class MaxStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MeanStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MeanStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class MeanStatTest {
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MinStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MinStatTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class MinStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/PairedSumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/PairedSumStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class PairedSumStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/RangeStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/RangeStatTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class RangeStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SumStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class SumStatTest {
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-
-private const val DELTA = 1e-9
 
 class SummaryStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/TotalWeightsStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/TotalWeightsStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class TotalWeightsStatTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/VarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/VarianceStatTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class VarianceStatTest {
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/ArrayBinsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/ArrayBinsTest.kt
@@ -1,10 +1,9 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class ArrayBinsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/AtomicModeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/AtomicModeTest.kt
@@ -1,12 +1,11 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class AtomicDoubleTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.SumResult
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
-
-private const val DELTA = 1e-12
 
 class SliceRingMergeAtTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamModesTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamModesTest.kt
@@ -1,11 +1,10 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val DELTA = 1e-12
 
 class SerialLongTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamMonotonicTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamMonotonicTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val DELTA = 1e-12
 
 class CasMaxLongTest {
 


### PR DESCRIPTION
## What changed

- Added `commonTest/.../TestTolerance.kt` with a single `internal const val DELTA = 1e-12`.
- Deleted the 80 per-file `private const val DELTA` declarations and imported the shared one instead. No assertion site changed, because the name did not.

## The tightening, which is the part to look at

The 80 declarations carried three different values: 45 at `1e-12`, 34 at `1e-9`, and one at `1e-6`. Standardising means 35 files now assert more strictly than they did.

I checked that before doing it rather than after. Every one of those files passes at `1e-12` on all thirteen targets, including the native and wasm ones whose libm differs from the JVM's. So the looser values were not headroom anyone had measured a need for. They were the number that file's author happened to write, and `1e-6` in `AucTest` was indistinguishable from a deliberate choice about an interpolated statistic when in fact the same tests pass six orders of magnitude tighter.

That is the actual argument for consolidating. Saving 79 lines is not worth a PR; making a loosened tolerance legible as a decision is. Right now a reader cannot tell a considered `1e-9` from a copied one. After this, a file that needs slack has to declare a local override, which is a line a reviewer will ask about.

Two assertions in `SoftThresholdTest` keep an explicit inline `1e-9`, because they compare across two different regression stats rather than against an expected constant, and that is a different kind of claim.

## Why 1e-12 and not tighter

These are `Double` comparisons after accumulation over a stream, not single operations, so some slack is right. `1e-12` leaves roughly three decimal digits against the `2.2e-16` epsilon, which absorbs the reassociation a Welford or Chan recurrence performs without absorbing a real error. A test asserting something that should be bit-exact, like a downdate restoring a prior state, should assert equality instead of reaching for a smaller delta.

## Testing

`./gradlew build` passes on all thirteen targets. That is the whole of the verification here, and it is also the evidence for the paragraph above: the suite was run at `1e-12` across every target before the declarations were removed, so the tightening is measured rather than assumed.
