### PR TITLE
fix: treat a non-finite weight as inert and sweep the whole weight contract

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -21,7 +21,7 @@ import com.eignex.kumulant.stream.currentTimeNanos
  * observation weight, sums multiply by it, histograms add it to the destination
  * bin. A weight of 1 (the default) is the unweighted case.
  *
- * Three guarantees hold across every stat:
+ * Four guarantees hold across every stat:
  *
  * - A weight of `0.0` is a no-op. The observation is not folded in and no state
  *   changes, whatever the modality. This is not a policy choice but an identity:
@@ -30,6 +30,13 @@ import com.eignex.kumulant.stream.currentTimeNanos
  * - A weight of `NaN` is a no-op too, for a related reason: a weight is the
  *   multiplicity of an observation, and `NaN` is not a multiplicity. It carries no
  *   observation, so there is nothing to fold in.
+ * - A weight of `+Infinity` or `-Infinity` is a no-op, by the same argument: an
+ *   infinity is not a multiplicity either. `+Infinity` has a tempting reading, since
+ *   the weighted-mean update tends to 1 and so the mean would tend to the observed
+ *   value, but the recurrences reach that limit through `Infinity / Infinity` and
+ *   report `NaN` rather than the limit. Pinning a stat to a value is a different
+ *   operation and deserves to be asked for directly rather than encoded as an
+ *   infinite weight. A non-finite *value* still propagates; see below.
  * - A negative weight carries whatever meaning is standard for that particular
  *   statistic. For the accumulating families that is a downdate: it removes an
  *   observation previously folded in. Where a statistic has no sensible inverse,
@@ -172,8 +179,8 @@ interface Stat<R : Result> {
  * sketches, the rate family, the decay family) implement this shape.
  *
  * See [Stat] for the per-observation `weight` contract, which is library-wide:
- * zero is a no-op, and a negative weight downdates or throws depending on the
- * statistic.
+ * any non-finite weight is a no-op, as is zero, and a negative weight downdates or
+ * throws depending on the statistic.
  */
 interface SeriesStat<R : Result> : Stat<R> {
     /** Record an observation with the given [weight], stamped at the current time. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
@@ -4,15 +4,27 @@ package com.eignex.kumulant.core
  * True when a weight carries no observation, and the update is therefore a no-op.
  *
  * Exactly zero, because every weighted recurrence in the library reduces to the identity at `w = 0`;
- * and `NaN`, because a weight is the multiplicity of an observation and `NaN` is not a multiplicity.
- * Note that this is the *weight*, not the value: a `NaN` value is a real observation of an unusable
- * number and propagates. See [Stat] for the contract and why the two differ.
+ * and any non-finite weight, because a weight is the multiplicity of an observation and neither `NaN`
+ * nor an infinity is a multiplicity.
+ *
+ * The infinities are the less obvious half. `+Infinity` does have a clean mathematical reading - the
+ * weighted mean update `w / (W + w)` tends to 1, so the mean tends to the observed value and the
+ * variance to zero - but almost nothing in the library computed that limit. The recurrences evaluate
+ * `Infinity / Infinity` and `Infinity * 0` and reported the resulting `NaN` as an answer, in 22 stat and
+ * weight combinations across three modalities. Supporting the limit properly would mean rewriting eleven
+ * recurrences, up to and including the third and fourth moments, and would still leave every affected
+ * stat with `totalWeights = Infinity` permanently, wedging the bias corrections that divide by it. A
+ * caller who wants to pin a stat to a value is better served by saying so than by smuggling an infinity
+ * through the weight channel.
+ *
+ * Note that this is the *weight*, not the value: a `NaN` or infinite value is a real observation of an
+ * unusable number and propagates. See [Stat] for the contract and why the two differ.
  */
 // Inlined against the compiler's advice: it judges the impact by JVM standards, where the JIT would
 // have inlined this anyway. The targets that matter here are the others - this call showed up once per
 // update in the generated JS, across every stat that guards on it.
 @Suppress("NOTHING_TO_INLINE")
-internal inline fun Double.isInertWeight(): Boolean = this == 0.0 || isNaN()
+internal inline fun Double.isInertWeight(): Boolean = !isFinite() || this == 0.0
 
 /**
  * True when a weight is not a live positive observation, for the stats that cannot downdate.
@@ -23,13 +35,17 @@ internal inline fun Double.isInertWeight(): Boolean = this == 0.0 || isNaN()
  * a histogram bucket, an SGD step - where a negative weight is not a removal but a corruption, and is
  * dropped alongside the inert cases. See [Stat] for which stats fall on which side.
  *
- * Written as a negated comparison rather than `this <= 0.0 || isNaN()` because `NaN > 0.0` is already
- * false: the `NaN` case falls out of the comparison instead of needing a second clause a caller has to
- * remember. Twenty call sites used to spell out the two-clause form, and the sites that spelled it out
- * slightly differently are exactly where the class-label defects lived.
+ * `!(this > 0.0)` rather than `this <= 0.0 || isNaN()` because `NaN > 0.0` is already false: the `NaN`
+ * case falls out of the comparison instead of needing a second clause a caller has to remember. Twenty
+ * call sites used to spell out the two-clause form, and the sites that spelled it out slightly
+ * differently are exactly where the class-label defects lived.
+ *
+ * The `isFinite` clause is not redundant with that: `+Infinity > 0.0` is true, so an infinite weight
+ * used to pass here as an ordinary live observation and land in a histogram bucket or a sketch register
+ * as infinite mass. See [isInertWeight] for why an infinity is not a multiplicity.
  */
 @Suppress("NOTHING_TO_INLINE") // as with isInertWeight; the non-JVM targets pay for the call
-internal inline fun Double.isNotPositiveWeight(): Boolean = !(this > 0.0)
+internal inline fun Double.isNotPositiveWeight(): Boolean = !(this > 0.0) || !isFinite()
 
 /**
  * Guard the one negative-weight case that corrupts a Welford accumulator.
@@ -54,10 +70,12 @@ internal inline fun Double.isNotPositiveWeight(): Boolean = !(this > 0.0)
  * @throws IllegalArgumentException if the update would leave a non-positive total.
  */
 internal fun requireLiveWeight(currentTotal: Double, weight: Double) {
-    // Callers drop a NaN weight before reaching here, but keep the guard local too: `NaN > 0.0` is
-    // false, so the require below would fire and report a NaN weight as a downdate emptying the
-    // accumulator - wrong, and the one thing a NaN weight must not do now that it is a no-op.
-    if (weight.isNaN()) return
+    // Callers drop a non-finite weight before reaching here, but keep the guard local too. `NaN > 0.0`
+    // is false, so the require below would fire and report a NaN weight as a downdate emptying the
+    // accumulator - wrong, and the one thing a NaN weight must not do now that it is a no-op. A
+    // `-Infinity` weight would trip it for the same spurious reason, reporting an unrepresentable
+    // downdate rather than the inert weight it now is.
+    if (!weight.isFinite()) return
     require(currentTotal + weight > 0.0) {
         "weight $weight would take the accumulated weight from $currentTotal to " +
             "${currentTotal + weight}; a downdate must leave a positive total"

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
@@ -138,6 +138,44 @@ class PairedAndDiscreteContractSweepTest {
     }
 
     @Test
+    fun `an infinite weight is a no-op for every paired and discrete stat`() {
+        // The paired modality was the worst of the three here: nine of its twelve stats reported NaN
+        // after a `+Infinity` weight, because a loss or a calibration curve divides an accumulated total
+        // by an accumulated weight and both had gone infinite. See isInertWeight on why an infinity is
+        // not a multiplicity and why the limit was not worth chasing.
+        val violations = mutableListOf<String>()
+        for (weight in doubleArrayOf(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            for ((name, spec) in pairedSpecs) {
+                val stat = spec.materialize()
+                pairs.forEachIndexed { i, (x, y) -> stat.update(x, y, i.toLong() * 1_000_000_000L, 1.0) }
+                val before = stat.read(readAt)
+
+                val thrown = runCatching { stat.update(0.99, 0.0, readAt, weight) }.exceptionOrNull()
+                if (thrown != null) {
+                    violations += "$name threw on a weight of $weight: ${thrown.message}"
+                    continue
+                }
+
+                if (stat.read(readAt) != before) violations += "$name absorbed a $weight weight"
+            }
+            for ((name, spec) in discreteSpecs) {
+                val stat = spec.materialize()
+                keys.forEachIndexed { i, k -> stat.update(k, i.toLong() * 1_000_000_000L, 1.0) }
+                val before = stat.read(readAt)
+
+                val thrown = runCatching { stat.update(2L, readAt, weight) }.exceptionOrNull()
+                if (thrown != null) {
+                    violations += "$name threw on a weight of $weight: ${thrown.message}"
+                    continue
+                }
+
+                if (stat.read(readAt) != before) violations += "$name absorbed a $weight weight"
+            }
+        }
+        assertEquals(emptyList(), violations.map { it.take(110) }, "an infinite weight must not change state")
+    }
+
+    @Test
     fun `a negative weight is a no-op for every discrete sketch`() {
         // The discrete modality is entirely no-inverse: there is no bucket decrement that undoes a
         // hash insert into a Bloom filter or an HLL register, so these all drop a negative weight

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
@@ -156,6 +156,39 @@ class SeriesStatContractSweepTest {
     }
 
     @Test
+    fun `an infinite weight is a no-op for every series stat`() {
+        // The fourth and last weight case, and the one nothing guarded. Both predicates let an infinity
+        // through: `isInertWeight` tested only zero and NaN, and `+Infinity > 0.0` is true, so
+        // `isNotPositiveWeight` waved it past as an ordinary live observation.
+        //
+        // A weight is the multiplicity of an observation, and an infinity is no more a multiplicity than
+        // a NaN is, so it belongs with the other inert cases. `+Infinity` does have a clean reading -
+        // the update `w / (W + w)` tends to 1, so the mean tends to the value - but essentially nothing
+        // here computed that limit. The recurrences evaluated `Infinity / Infinity` and `Infinity * 0`
+        // and published the NaN as a result, in 22 stat and weight combinations across three modalities.
+        // See isInertWeight for why supporting the limit was not worth eleven rewritten recurrences.
+        val violations = mutableListOf<String>()
+        for ((name, spec) in specs) {
+            for (weight in doubleArrayOf(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+                for (probe in doubleArrayOf(999.0, -999.0)) {
+                    val stat = primed(spec)
+                    val before = stat.read(readAt)
+
+                    val thrown = runCatching { stat.update(probe, readAt, weight) }.exceptionOrNull()
+                    if (thrown != null) {
+                        violations += "$name threw on a weight of $weight: ${thrown.message}"
+                        continue
+                    }
+
+                    val after = stat.read(readAt)
+                    if (before != after) violations += "$name absorbed a $weight-weighted $probe: $after"
+                }
+            }
+        }
+        assertEquals(emptyList(), violations.map { it.take(110) }, "an infinite weight must not change state")
+    }
+
+    @Test
     fun `a negative weight is a no-op for every stat that cannot invert it`() {
         // The third weight case, and the one the other two sweeps left open. Zero and NaN are no-ops
         // library-wide, but a negative weight partitions the catalogue: a stat whose recurrence

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -1,0 +1,168 @@
+package com.eignex.kumulant.stat.regression
+
+import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import com.eignex.kumulant.stat.regression.tree.DecisionTreeClassifierStat
+import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
+import com.eignex.kumulant.stat.regression.tree.RandomForestClassifierStat
+import com.eignex.kumulant.stat.regression.tree.RandomForestRegressionStat
+import com.eignex.kumulant.stat.regression.tree.ThresholdSplit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val FEATURES = 2
+private const val CLASSES = 2
+
+/**
+ * The four special weights, over the regression modality.
+ *
+ * The series, paired, and discrete modalities each have a contract sweep covering these. Regression had
+ * none, which is how it stayed the modality where nobody had checked what an infinite weight does to a
+ * model - and unlike a histogram bucket, a model absorbs a bad weight into state that no later
+ * observation can clean.
+ */
+class RegressionWeightContractTest {
+
+    /**
+     * One model, with a way to train it and a way to read its learned numbers back.
+     *
+     * The snapshot reads fields explicitly rather than stringifying the result, and that is not
+     * fastidiousness: `ClassCountsResult` holds a `DoubleArray`, whose `toString` is an identity hash, so
+     * a stringified tree snapshot differs from itself on every read. An earlier version of this test did
+     * exactly that and passed on the JVM while proving nothing. Kotlin/JS renders arrays differently and
+     * failed honestly, which is the second time in this work that JS caught a vacuous JVM assertion.
+     */
+    private class Model(val name: String, val train: (Double) -> Unit, val snapshot: () -> String)
+
+    private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
+    private val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+
+    // Bagging is off on the two forests. With it on, each tree draws Poisson(1) per observation and can
+    // legitimately draw zero, so a single update may reach no tree at all. The early return that stops an
+    // inert weight consuming a bagging draw has its own coverage in RandomForestRegressionStatTest.
+    private fun models(): List<Model> {
+        val stochastic = StochasticRegressionStat(FEATURES)
+        val diagonal = DiagonalRegressionStat(FEATURES)
+        val bayesian = BayesianRegressionStat(FEATURES)
+        val softmax = SoftmaxRegressionStat(FEATURES, numClasses = CLASSES)
+        val gnb = GaussianNaiveBayesStat(FEATURES, numClasses = CLASSES)
+        val dtReg = DecisionTreeRegressionStat(FEATURES, splits)
+        val dtClf = DecisionTreeClassifierStat(FEATURES, CLASSES, splits)
+        val rfReg = RandomForestRegressionStat(FEATURES, splits, nbrTrees = 2, bagging = false)
+        val rfClf = RandomForestClassifierStat(FEATURES, CLASSES, splits, nbrTrees = 2, bagging = false)
+        return listOf(
+            Model("StochasticRegression", { w -> stochastic.update(x, 2.0, weight = w) }) {
+                val r = stochastic.read()
+                "${r.weights[0]},${r.weights[1]},${r.bias},${r.totalWeights},${r.step},${r.sse}"
+            },
+            Model("DiagonalRegression", { w -> diagonal.update(x, 2.0, weight = w) }) {
+                val r = diagonal.read()
+                "${r.weights[0]},${r.weights[1]},${r.bias},${r.totalWeights},${r.precision[0]},${r.sse}"
+            },
+            Model("BayesianRegression", { w -> bayesian.update(x, 2.0, weight = w) }) {
+                val r = bayesian.read()
+                "${r.weights[0]},${r.weights[1]},${r.bias},${r.totalWeights},${r.covariance[0, 0]},${r.sse}"
+            },
+            Model("SoftmaxRegression", { w -> softmax.update(x, 1.0, weight = w) }) {
+                val r = softmax.read()
+                val coefs = (0 until CLASSES).joinToString(",") { k ->
+                    (0 until FEATURES).joinToString(",") { i -> "${r.weights[k, i]}" }
+                }
+                "$coefs,${r.biases[0]},${r.totalWeights},${r.step},${r.crossEntropy}"
+            },
+            Model("GaussianNaiveBayes", { w -> gnb.update(x, 1.0, weight = w) }) {
+                val r = gnb.read()
+                val moments = (0 until CLASSES).joinToString(",") { c ->
+                    (0 until FEATURES).joinToString(",") { i -> "${r.means[c, i]},${r.variances[c, i]}" }
+                }
+                "$moments,${r.classWeights[0]},${r.classWeights[1]},${r.totalWeights}"
+            },
+            Model("DecisionTreeRegression", { w -> dtReg.update(x, 2.0, weight = w) }) {
+                val r = dtReg.tree().rootSnapshot()
+                "${r.totalWeights},${r.mean},${r.variance}"
+            },
+            Model("DecisionTreeClassifier", { w -> dtClf.update(x, 1.0, weight = w) }) {
+                dtClf.tree().rootSnapshot().counts.joinToString(",")
+            },
+            Model("RandomForestRegression", { w -> rfReg.update(x, 2.0, weight = w) }) {
+                rfReg.trees().joinToString(";") { t ->
+                    val r = t.rootSnapshot()
+                    "${r.totalWeights},${r.mean},${r.variance}"
+                }
+            },
+            Model("RandomForestClassifier", { w -> rfClf.update(x, 1.0, weight = w) }) {
+                rfClf.trees().joinToString(";") { it.rootSnapshot().counts.joinToString(",") }
+            },
+        )
+    }
+
+    @Test
+    fun `an inert weight leaves every model untouched`() {
+        // Zero, NaN, and both infinities. The infinities are the ones that were unguarded:
+        // `isInertWeight` tested only zero and NaN, and `+Infinity > 0.0` is true, so
+        // `isNotPositiveWeight` let an infinite weight through as an ordinary live observation and into
+        // the gradient step.
+        val inert = doubleArrayOf(0.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
+        val violations = mutableListOf<String>()
+        for (weight in inert) {
+            for (model in models()) {
+                model.train(1.0)
+                val before = model.snapshot()
+
+                val thrown = runCatching { model.train(weight) }.exceptionOrNull()
+                if (thrown != null) {
+                    violations += "${model.name} threw on a weight of $weight: ${thrown.message}"
+                    continue
+                }
+
+                if (model.snapshot() != before) violations += "${model.name} absorbed a weight of $weight"
+            }
+        }
+        assertEquals(emptyList(), violations.map { it.take(110) }, "an inert weight must not train a model")
+    }
+
+    @Test
+    fun `no weight puts a non-finite number into a model`() {
+        // Stated in terms of what a caller sees, and the reason this modality matters most: a NaN in a
+        // weight vector is permanent. Every later update multiplies it forward, so unlike a bad quantile
+        // bucket there is no recovery and no way for the caller to tell the model is dead. An infinity is
+        // no better, because it looks like a number a caller might trust and becomes NaN on the next
+        // update via Infinity minus Infinity.
+        val weights = doubleArrayOf(0.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -1.0)
+        val violations = mutableListOf<String>()
+        for (weight in weights) {
+            for (model in models()) {
+                model.train(1.0)
+                runCatching { model.train(weight) }.exceptionOrNull()?.let { continue }
+
+                val after = model.snapshot()
+                if ("NaN" in after) violations += "${model.name} reports NaN after a weight of $weight"
+                if ("Infinity" in after) violations += "${model.name} reports an infinity after $weight"
+
+                // And it still trains, which a state comparison alone would not catch.
+                model.train(1.0)
+                val recovered = model.snapshot()
+                if ("NaN" in recovered || "Infinity" in recovered) {
+                    violations += "${model.name} was poisoned by a weight of $weight"
+                }
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "no weight may put a non-finite number into a model")
+    }
+
+    @Test
+    fun `a live weight still trains every model`() {
+        // Guards the rules above: a model that ignored every weight would satisfy all of them, and so
+        // would a snapshot that could not see the model change.
+        for (model in models()) {
+            val before = model.snapshot()
+
+            model.train(1.0)
+
+            assertTrue(model.snapshot() != before, "${model.name} ignored a live observation")
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- `isInertWeight` is now `!isFinite() || this == 0.0`, and `isNotPositiveWeight` is `!(this > 0.0) || !isFinite()`. Both are single definitions, so a non-finite weight is now inert across the whole library.
- `requireLiveWeight` returns early on any non-finite weight rather than only on NaN.
- Documented the case on `Stat`, which now states four weight guarantees rather than three.
- Added the infinite-weight sweep to the series and paired/discrete contract tests, and a new `RegressionWeightContractTest` for the modality that had no sweep at all.

## Why

Neither predicate rejected an infinity. `isInertWeight` tested only zero and NaN, and `+Infinity > 0.0` is true, so an infinite weight passed both as an ordinary live observation. Measured across the catalogue, 22 stat and weight combinations then reported NaN: 7 series stats on `+Infinity`, 5 on `-Infinity`, 9 paired stats on `+Infinity`, 1 on `-Infinity`.

The two families break at different expressions, which is what you get when the same arithmetic is arranged eleven ways. The Welford stats compute `weight / (W + weight)`, which is `Infinity / Infinity`. The decay stats compute `1 - exp(-alpha * w)`, which is `1 - Infinity` at a negative infinity. Neither is a policy failure, both are indeterminate forms published as answers.

`+Infinity` does have a clean reading, and it is worth recording why we are not implementing it. The weighted-mean update tends to 1, so the mean tends to the observed value and the variance to zero, and `EwmaMean` and `EwmaVariance` already produce exactly that because their update factor saturates at 1.0. Getting the other eleven there means rewriting each recurrence up to and including the third and fourth moments, and every affected stat would still be left with `totalWeights = Infinity` permanently, which wedges any bias correction that divides by it. A caller who wants to pin a stat to a value is better served asking for that directly than encoding it as an infinite weight. So the infinity joins NaN as not-a-multiplicity, and the sweep asserts it universally with no allowlist.

## Testing

`./gradlew build` passes on all thirteen targets.

All four new assertions were checked against the pre-fix predicates and all four fail there, so they pin the change rather than passing either way.

Two notes on how the tests are written, both learned the hard way in this branch.

They snapshot state by reading numbers out explicitly, not by stringifying results. `ClassCountsResult` holds a `DoubleArray`, whose `toString` is an identity hash, so a stringified tree snapshot differs from itself on every read: the first version of `RegressionWeightContractTest` passed on the JVM while proving nothing, and Kotlin/JS failed it honestly. That is the second time in this series that JS caught a vacuous JVM assertion.

I also dropped two `toString`-based "reports a NaN" sweeps I had written for the series and paired modalities. `toString` renders a scalar NaN but hides one inside an array field for the four results that do not override it, so those tests were partly blind, and they were redundant: the equality-based no-op sweeps already cover all four weight cases soundly, because those results override `equals` with `contentEquals`.

The forests run with bagging off in the new test. With it on, each tree draws Poisson(1) per observation and can legitimately draw zero, so the check that a live weight still trains the model failed for the right reason. The early return that stops an inert weight consuming a bagging draw keeps its own coverage in `RandomForestRegressionStatTest`.
