### PR TITLE
Sweep the library for dead code, duplication and magic constants

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -3052,11 +3052,30 @@ public final class com/eignex/kumulant/schema/runtime/VectorStatGroup : com/eign
 }
 
 public final class com/eignex/kumulant/schema/spec/Accuracy : com/eignex/kumulant/schema/spec/PairedStatSpec {
-	public static final field INSTANCE Lcom/eignex/kumulant/schema/spec/Accuracy;
+	public static final field Companion Lcom/eignex/kumulant/schema/spec/Accuracy$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/eignex/kumulant/schema/spec/Accuracy;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/schema/spec/Accuracy;IILjava/lang/Object;)Lcom/eignex/kumulant/schema/spec/Accuracy;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumClasses ()I
 	public fun hashCode ()I
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/eignex/kumulant/schema/spec/Accuracy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/eignex/kumulant/schema/spec/Accuracy$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/eignex/kumulant/schema/spec/Accuracy;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/eignex/kumulant/schema/spec/Accuracy;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/eignex/kumulant/schema/spec/Accuracy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/eignex/kumulant/schema/spec/Adwin : com/eignex/kumulant/schema/spec/SeriesStatSpec {
@@ -8320,13 +8339,13 @@ public final class com/eignex/kumulant/stat/regression/tree/VarianceReduction : 
 }
 
 public final class com/eignex/kumulant/stat/score/AccuracyStat : com/eignex/kumulant/core/PairedStat {
-	public fun <init> ()V
-	public fun <init> (Lcom/eignex/kumulant/core/Concurrency;)V
-	public synthetic fun <init> (Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILcom/eignex/kumulant/core/Concurrency;)V
+	public synthetic fun <init> (ILcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/PairedStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/score/AccuracyStat;
 	public fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
+	public final fun getNumClasses ()I
 	public synthetic fun merge (Lcom/eignex/kumulant/core/Result;)V
 	public fun merge (Lcom/eignex/kumulant/stat/summary/WeightedMeanResult;)V
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -2857,6 +2857,32 @@ final class com.eignex.kumulant.schema.runtime/VectorStatGroup : com.eignex.kumu
     final fun update(com.eignex.koblas/VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.VectorView;kotlin.Long;kotlin.Double){}[0]
 }
 
+final class com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
+    constructor <init>(kotlin/Int) // com.eignex.kumulant.schema.spec/Accuracy.<init>|<init>(kotlin.Int){}[0]
+
+    final val numClasses // com.eignex.kumulant.schema.spec/Accuracy.numClasses|{}numClasses[0]
+        final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.schema.spec/Accuracy.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
+
+    final fun component1(): kotlin/Int // com.eignex.kumulant.schema.spec/Accuracy.component1|component1(){}[0]
+    final fun copy(kotlin/Int = ...): com.eignex.kumulant.schema.spec/Accuracy // com.eignex.kumulant.schema.spec/Accuracy.copy|copy(kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.schema.spec/Accuracy.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.eignex.kumulant.schema.spec/Accuracy.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.eignex.kumulant.schema.spec/Accuracy.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.schema.spec/Accuracy> { // com.eignex.kumulant.schema.spec/Accuracy.$serializer|null[0]
+        final val descriptor // com.eignex.kumulant.schema.spec/Accuracy.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.eignex.kumulant.schema.spec/Accuracy.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.eignex.kumulant.schema.spec/Accuracy.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.eignex.kumulant.schema.spec/Accuracy // com.eignex.kumulant.schema.spec/Accuracy.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.eignex.kumulant.schema.spec/Accuracy) // com.eignex.kumulant.schema.spec/Accuracy.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.eignex.kumulant.schema.spec.Accuracy){}[0]
+    }
+
+    final object Companion { // com.eignex.kumulant.schema.spec/Accuracy.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.schema.spec/Accuracy> // com.eignex.kumulant.schema.spec/Accuracy.Companion.serializer|serializer(){}[0]
+    }
+}
+
 final class com.eignex.kumulant.schema.spec/Adwin : com.eignex.kumulant.schema.spec/SeriesStatSpec<com.eignex.kumulant.stat.change/AdwinResult> { // com.eignex.kumulant.schema.spec/Adwin|null[0]
     constructor <init>(kotlin/Double = ..., kotlin/Int = ...) // com.eignex.kumulant.schema.spec/Adwin.<init>|<init>(kotlin.Double;kotlin.Int){}[0]
 
@@ -7551,10 +7577,12 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionStat : com.eign
 }
 
 final class com.eignex.kumulant.stat.score/AccuracyStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.stat.score/AccuracyStat|null[0]
-    constructor <init>(com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.stat.score/AccuracyStat.<init>|<init>(com.eignex.kumulant.core.Concurrency){}[0]
+    constructor <init>(kotlin/Int, com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.stat.score/AccuracyStat.<init>|<init>(kotlin.Int;com.eignex.kumulant.core.Concurrency){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.score/AccuracyStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.score/AccuracyStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
+    final val numClasses // com.eignex.kumulant.stat.score/AccuracyStat.numClasses|{}numClasses[0]
+        final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.stat.score/AccuracyStat.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.stat.score/AccuracyStat // com.eignex.kumulant.stat.score/AccuracyStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
     final fun merge(com.eignex.kumulant.stat.summary/WeightedMeanResult) // com.eignex.kumulant.stat.score/AccuracyStat.merge|merge(com.eignex.kumulant.stat.summary.WeightedMeanResult){}[0]
@@ -8880,14 +8908,6 @@ final object com.eignex.kumulant.schema.expr/Y : com.eignex.kumulant.schema.expr
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.schema.expr/Y> // com.eignex.kumulant.schema.expr/Y.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.schema.expr/Y.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.schema.expr/Y.toString|toString(){}[0]
-}
-
-final object com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.schema.spec/Accuracy.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.eignex.kumulant.schema.spec/Accuracy.hashCode|hashCode(){}[0]
-    final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.schema.spec/Accuracy> // com.eignex.kumulant.schema.spec/Accuracy.serializer|serializer(){}[0]
-    final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.schema.spec/Accuracy.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
-    final fun toString(): kotlin/String // com.eignex.kumulant.schema.spec/Accuracy.toString|toString(){}[0]
 }
 
 final object com.eignex.kumulant.schema.spec/ArgMax : com.eignex.kumulant.schema.spec/SeriesStatSpec<com.eignex.kumulant.stat.summary/ArgMaxResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.schema.spec/ArgMax|null[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -110,9 +110,7 @@ fun BoltzmannSpec.materialize(random: Random = Random.Default): BoltzmannBandit 
 /** Build a live [Exp3Bandit] from its spec, resolving null `eta` / `gamma` to defaults. */
 fun Exp3Spec.materialize(random: Random = Random.Default): Exp3Bandit {
     val resolvedEta = eta ?: Exp3Bandit.defaultEta(nbrArms)
-    // Via defaultGamma, not the `K * eta` rule this used to inline. See its KDoc: against the
-    // horizon-free eta above that formula saturates at 1.0 for every arm count, and a gamma of 1.0
-    // makes playDistribution exactly uniform, so every EXP3 built from a spec ignored its weights.
+    // Resolve through defaultGamma so a spec-built bandit tunes identically to a directly-built one.
     val resolvedGamma = gamma ?: Exp3Bandit.defaultGamma(resolvedEta)
     return Exp3Bandit(nbrArms, resolvedEta, resolvedGamma, random)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -110,7 +110,10 @@ fun BoltzmannSpec.materialize(random: Random = Random.Default): BoltzmannBandit 
 /** Build a live [Exp3Bandit] from its spec, resolving null `eta` / `gamma` to defaults. */
 fun Exp3Spec.materialize(random: Random = Random.Default): Exp3Bandit {
     val resolvedEta = eta ?: Exp3Bandit.defaultEta(nbrArms)
-    val resolvedGamma = gamma ?: (nbrArms * resolvedEta).coerceAtMost(1.0)
+    // Via defaultGamma, not the `K * eta` rule this used to inline. See its KDoc: against the
+    // horizon-free eta above that formula saturates at 1.0 for every arm count, and a gamma of 1.0
+    // makes playDistribution exactly uniform, so every EXP3 built from a spec ignored its weights.
+    val resolvedGamma = gamma ?: Exp3Bandit.defaultGamma(resolvedEta)
     return Exp3Bandit(nbrArms, resolvedEta, resolvedGamma, random)
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
@@ -1,0 +1,34 @@
+package com.eignex.kumulant.bandit
+
+/**
+ * The three preconditions every bandit shares, each stated once.
+ *
+ * They were spelled out inline instead: the arm-count message at eight sites, the bounds message at
+ * eight, and the merge-arity message at seven. That is not merely repetitive - the bounds check was
+ * *missing* from [com.eignex.kumulant.bandit.contextual.RegressionContextualBandit] entirely, on all
+ * four of its arm-indexed entry points, while a comment in `MultiArmedBandit.update` asserted that
+ * "every sibling bandit validates this". Twenty-three hand-copied `require` calls are exactly the
+ * shape in which one of them goes missing and the comments keep claiming otherwise.
+ *
+ * The messages are preserved byte for byte, since they are what the tests match on.
+ */
+
+/** Guards the constructor: a bandit with no arms has nothing to choose between. */
+internal fun requireNbrArms(nbrArms: Int) {
+    require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+}
+
+/**
+ * Guards every entry point that takes an arm index.
+ *
+ * Without it a bad index surfaces as a raw `IndexOutOfBoundsException` from whatever array happens to
+ * be indexed first, rather than the `IllegalArgumentException` the interfaces document.
+ */
+internal fun requireArmIndex(armIndex: Int, nbrArms: Int) {
+    require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+}
+
+/** Guards a merge: two bandits over different arm counts have no correspondence to merge along. */
+internal fun requireMergeSize(size: Int, nbrArms: Int) {
+    require(size == nbrArms) { "merge: other.size=$size does not match nbrArms=$nbrArms" }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
@@ -1,16 +1,8 @@
 package com.eignex.kumulant.bandit
 
 /*
- * The three preconditions every bandit shares, each stated once.
- *
- * They were spelled out inline instead: the arm-count message at eight sites, the bounds message at
- * eight, and the merge-arity message at seven. That is not merely repetitive - the bounds check was
- * *missing* from [com.eignex.kumulant.bandit.contextual.RegressionContextualBandit] entirely, on all
- * four of its arm-indexed entry points, while a comment in `MultiArmedBandit.update` asserted that
- * "every sibling bandit validates this". Twenty-three hand-copied `require` calls are exactly the
- * shape in which one of them goes missing and the comments keep claiming otherwise.
- *
- * The messages are preserved byte for byte, since they are what the tests match on.
+ * The preconditions every bandit shares. Every arm-indexed entry point on every bandit is expected to
+ * call requireArmIndex; ArmIndexContractSweepTest enforces that across the family.
  */
 
 /** Guards the constructor: a bandit with no arms has nothing to choose between. */
@@ -19,10 +11,8 @@ internal fun requireNbrArms(nbrArms: Int) {
 }
 
 /**
- * Guards every entry point that takes an arm index.
- *
- * Without it a bad index surfaces as a raw `IndexOutOfBoundsException` from whatever array happens to
- * be indexed first, rather than the `IllegalArgumentException` the interfaces document.
+ * Guards every entry point that takes an arm index, so a bad index raises the
+ * `IllegalArgumentException` the interfaces document rather than a raw `IndexOutOfBoundsException`.
  */
 internal fun requireArmIndex(armIndex: Int, nbrArms: Int) {
     require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditValidation.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-/**
+/*
  * The three preconditions every bandit shares, each stated once.
  *
  * They were spelled out inline instead: the arm-count message at eight sites, the bounds message at

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
@@ -48,14 +48,8 @@ internal fun DoubleArray.renormaliseExponentialWeights() {
 /**
  * Draw an index from a normalised probability array by inverse CDF.
  *
- * EXP3, EXP4 and Boltzmann each carried this byte for byte, trailing fallback included. The fallback is
- * the part worth having in one place: the loop can fall through when the probabilities sum to slightly
- * under one, which floating-point normalisation routinely produces, and returning the last index rather
- * than failing is the deliberate choice. Three copies is three chances for one of them to `throw`
- * instead, or to test `u < 0.0` and drop a zero-probability arm's turn on the boundary.
- *
- * Ties and zero-probability entries: an entry of exactly `0.0` never wins, since `u` is strictly
- * positive until something subtracts from it.
+ * Falls through to the last index when the probabilities sum to slightly under one, which floating-point
+ * normalisation routinely produces. An entry of exactly `0.0` never wins.
  */
 internal fun Random.sampleFromDistribution(p: DoubleArray): Int {
     var u = nextDouble()
@@ -66,12 +60,5 @@ internal fun Random.sampleFromDistribution(p: DoubleArray): Int {
     return p.size - 1
 }
 
-/**
- * Index of the largest score, resolving ties to the lowest index.
- *
- * Four bandits spelled out the same `bestScore = NEGATIVE_INFINITY` loop. The NaN behaviour is the
- * reason to name it: `NaN > -Infinity` is false, so an arm scoring NaN silently loses rather than
- * poisoning the comparison - and if *every* arm scores NaN the result is arm 0. That is the trap a
- * comment in `UCB1Normal` records as having caused a real bug, documented there and nowhere else.
- */
+/** Index of the highest-scoring arm; see [argMaxOf] for the tie and NaN rules. */
 internal inline fun argmaxArm(nbrArms: Int, score: (Int) -> Double): Int = argMaxOf(nbrArms, score)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
@@ -1,5 +1,8 @@
 package com.eignex.kumulant.bandit
 
+import com.eignex.kumulant.math.argMaxOf
+import kotlin.random.Random
+
 /**
  * Floor applied to the played probability before it divides an importance-weighted reward.
  *
@@ -41,3 +44,34 @@ internal fun DoubleArray.renormaliseExponentialWeights() {
         maxW == 0.0 -> for (i in indices) this[i] = 1.0
     }
 }
+
+/**
+ * Draw an index from a normalised probability array by inverse CDF.
+ *
+ * EXP3, EXP4 and Boltzmann each carried this byte for byte, trailing fallback included. The fallback is
+ * the part worth having in one place: the loop can fall through when the probabilities sum to slightly
+ * under one, which floating-point normalisation routinely produces, and returning the last index rather
+ * than failing is the deliberate choice. Three copies is three chances for one of them to `throw`
+ * instead, or to test `u < 0.0` and drop a zero-probability arm's turn on the boundary.
+ *
+ * Ties and zero-probability entries: an entry of exactly `0.0` never wins, since `u` is strictly
+ * positive until something subtracts from it.
+ */
+internal fun Random.sampleFromDistribution(p: DoubleArray): Int {
+    var u = nextDouble()
+    for (a in p.indices) {
+        u -= p[a]
+        if (u <= 0.0) return a
+    }
+    return p.size - 1
+}
+
+/**
+ * Index of the largest score, resolving ties to the lowest index.
+ *
+ * Four bandits spelled out the same `bestScore = NEGATIVE_INFINITY` loop. The NaN behaviour is the
+ * reason to name it: `NaN > -Infinity` is false, so an arm scoring NaN silently loses rather than
+ * poisoning the comparison - and if *every* arm scores NaN the result is arm 0. That is the trap a
+ * comment in `UCB1Normal` records as having caused a real bug, documented there and nowhere else.
+ */
+internal inline fun argmaxArm(nbrArms: Int, score: (Int) -> Double): Int = argMaxOf(nbrArms, score)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -43,10 +43,8 @@ class TrackedContextualBandit<B : ContextualBandit>(
     val inner: B,
     /** Context vector dimension validated against templates and incoming updates. */
     val contextFeatureSize: Int,
-    // Plain parameters, not `private val`s. All three are read only in `init` and in the property
-    // initialisers just below, both of which run at construction, so retaining them kept a template
-    // regressor alive for the lifetime of every tracked bandit for nothing. `updateArmRewardTemplate`
-    // below and both templates on TrackedUnivariateBandit already had it right.
+    // Plain parameters, not `private val`s: these are read only during construction, so holding them
+    // would keep a template regressor alive for the lifetime of every tracked bandit.
     chooseTemplate: RegressionStat<out Result>? = null,
     updateJointTemplate: RegressionStat<out Result>? = null,
     updateMarginalTemplate: RegressionStat<out Result>? = null,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -43,9 +43,13 @@ class TrackedContextualBandit<B : ContextualBandit>(
     val inner: B,
     /** Context vector dimension validated against templates and incoming updates. */
     val contextFeatureSize: Int,
-    private val chooseTemplate: RegressionStat<out Result>? = null,
-    private val updateJointTemplate: RegressionStat<out Result>? = null,
-    private val updateMarginalTemplate: RegressionStat<out Result>? = null,
+    // Plain parameters, not `private val`s. All three are read only in `init` and in the property
+    // initialisers just below, both of which run at construction, so retaining them kept a template
+    // regressor alive for the lifetime of every tracked bandit for nothing. `updateArmRewardTemplate`
+    // below and both templates on TrackedUnivariateBandit already had it right.
+    chooseTemplate: RegressionStat<out Result>? = null,
+    updateJointTemplate: RegressionStat<out Result>? = null,
+    updateMarginalTemplate: RegressionStat<out Result>? = null,
     updateArmRewardTemplate: PairedStat<out Result>? = null,
     private val nowNanos: () -> Long = { 0L },
 ) : ContextualBandit {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -5,14 +5,16 @@ import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable
 import com.eignex.kumulant.bandit.renormaliseExponentialWeights
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Snapshot of [com.eignex.kumulant.bandit.contextual.Exp4Bandit]'s state: the per-expert exponential weights. The
@@ -106,7 +108,7 @@ class Exp4Bandit(
 ) : ContextualBandit,
     Snapshotable<Exp4State> {
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
         require(experts.isNotEmpty()) { "experts must be non-empty" }
         require(eta > 0.0) { "eta must be positive, got $eta" }
         require(gamma in 0.0..1.0) { "gamma must lie in [0, 1], got $gamma" }
@@ -158,7 +160,7 @@ class Exp4Bandit(
 
     /** Fold a `(context, reward)` observation back into the expert weights. */
     override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)
         val pPlayed = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.bandit.Snapshotable
 import com.eignex.kumulant.bandit.renormaliseExponentialWeights
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireNbrArms
+import com.eignex.kumulant.bandit.sampleFromDistribution
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
@@ -122,12 +123,7 @@ class Exp4Bandit(
     override fun choose(x: VectorView): Int {
         val p = playDistribution(x)
         lastPlayDist = p
-        var u = random.nextDouble()
-        for (a in 0 until nbrArms) {
-            u -= p[a]
-            if (u <= 0.0) return a
-        }
-        return nbrArms - 1
+        return random.sampleFromDistribution(p)
     }
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -9,12 +9,12 @@ import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 
 /**
  * Snapshot of [com.eignex.kumulant.bandit.contextual.Exp4Bandit]'s state: the per-expert exponential weights. The

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -7,13 +7,16 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Per-arm snapshot for [KnnContextualBandit]: the retained history of
@@ -123,7 +126,7 @@ class KnnContextualBandit(
     PerArmBandit<KnnArmResult>,
     ContextualScorable {
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
         require(k > 0) { "k must be positive, got $k" }
         require(maxHistoryPerArm > 0) { "maxHistoryPerArm must be positive, got $maxHistoryPerArm" }
         require(exploration >= 0.0) { "exploration must be non-negative, got $exploration" }
@@ -152,7 +155,7 @@ class KnnContextualBandit(
 
     /** Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus. */
     override fun evaluate(armIndex: Int, x: VectorView): Double {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         val ctx = historyContexts[armIndex]
         if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
         val mean = knnMean(armIndex, x)
@@ -161,7 +164,7 @@ class KnnContextualBandit(
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
     override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         val ctxs = historyContexts[armIndex]
         val rs = historyRewards[armIndex]
         val ws = historyWeights[armIndex]
@@ -178,10 +181,16 @@ class KnnContextualBandit(
     }
 
     /** Live arm history size for [armIndex]. */
-    fun historySize(armIndex: Int): Int = historyContexts[armIndex].size
+    fun historySize(armIndex: Int): Int {
+        requireArmIndex(armIndex, nbrArms)
+        return historyContexts[armIndex].size
+    }
 
     /** Cumulative observation weight folded into arm [armIndex]. */
-    fun armWeight(armIndex: Int): Double = totalWeights[armIndex]
+    fun armWeight(armIndex: Int): Double {
+        requireArmIndex(armIndex, nbrArms)
+        return totalWeights[armIndex]
+    }
 
     override fun snapshot(): List<KnnArmResult> = List(nbrArms) { a ->
         KnnArmResult(
@@ -193,9 +202,7 @@ class KnnContextualBandit(
     }
 
     override fun merge(other: List<KnnArmResult>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (a in 0 until nbrArms) {
             val arm = other[a]
             for (i in arm.contexts.indices) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -7,6 +7,7 @@ import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
+import com.eignex.kumulant.bandit.argmaxArm
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
@@ -140,15 +141,7 @@ class KnnContextualBandit(
 
     /** Argmax over per-arm [evaluate] scores. Ties broken by lowest index. */
     override fun choose(x: VectorView): Int {
-        var bestIdx = 0
-        var bestScore = Double.NEGATIVE_INFINITY
-        for (a in 0 until nbrArms) {
-            val s = evaluate(a, x)
-            if (s > bestScore) {
-                bestScore = s
-                bestIdx = a
-            }
-        }
+        val bestIdx = argmaxArm(nbrArms) { a -> evaluate(a, x) }
         step++
         return bestIdx
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -12,11 +12,11 @@ import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.preview
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 
 /**
  * Per-arm snapshot for [KnnContextualBandit]: the retained history of

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -4,6 +4,9 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.regression.RegressionPosterior
@@ -90,7 +93,7 @@ class RegressionContextualBandit<R : Result>(
     ContextualScorable {
 
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
     }
 
     private val arms: Array<RegressionStat<R>> = Array(nbrArms) { template.create(null) }
@@ -113,10 +116,13 @@ class RegressionContextualBandit<R : Result>(
         return bestIdx
     }
 
-    override fun evaluate(armIndex: Int, x: VectorView): Double =
-        globalMean(x) + posterior.evaluate(arms[armIndex].read(0L), x, random, exploration)
+    override fun evaluate(armIndex: Int, x: VectorView): Double {
+        requireArmIndex(armIndex, nbrArms)
+        return globalMean(x) + posterior.evaluate(arms[armIndex].read(0L), x, random, exploration)
+    }
 
     override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
+        requireArmIndex(armIndex, nbrArms)
         val g = global
         if (g == null) {
             arms[armIndex].update(x, reward, weight)
@@ -129,14 +135,20 @@ class RegressionContextualBandit<R : Result>(
 
     override fun snapshot(): List<R> = arms.map { it.read(0L) }
 
-    override fun armResult(armIndex: Int): R = arms[armIndex].read(0L)
+    override fun armResult(armIndex: Int): R {
+        requireArmIndex(armIndex, nbrArms)
+        return arms[armIndex].read(0L)
+    }
 
     /**
      * Live per-arm regressor. When pooling is on this fits *residuals against the global
      * mean*, so its predictions are deltas, not full predictions; use [evaluate] for
      * the combined score and [globalSnapshot] for the global's state.
      */
-    fun armStat(armIndex: Int): RegressionStat<R> = arms[armIndex]
+    fun armStat(armIndex: Int): RegressionStat<R> {
+        requireArmIndex(armIndex, nbrArms)
+        return arms[armIndex]
+    }
 
     /** Current global pooling snapshot, or `null` if pooling is disabled. */
     fun globalSnapshot(): R? = global?.read(0L)
@@ -145,9 +157,7 @@ class RegressionContextualBandit<R : Result>(
     fun globalStat(): RegressionStat<R>? = global
 
     override fun merge(other: List<R>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (i in 0 until nbrArms) arms[i].merge(other[i])
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -4,6 +4,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
+import com.eignex.kumulant.bandit.argmaxArm
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
@@ -104,16 +105,7 @@ class RegressionContextualBandit<R : Result>(
 
     override fun choose(x: VectorView): Int {
         val gMean = globalMean(x)
-        var bestIdx = 0
-        var bestScore = Double.NEGATIVE_INFINITY
-        for (i in 0 until nbrArms) {
-            val score = gMean + posterior.evaluate(arms[i].read(0L), x, random, exploration)
-            if (score > bestScore) {
-                bestScore = score
-                bestIdx = i
-            }
-        }
-        return bestIdx
+        return argmaxArm(nbrArms) { i -> gMean + posterior.evaluate(arms[i].read(0L), x, random, exploration) }
     }
 
     override fun evaluate(armIndex: Int, x: VectorView): Double {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.bandit.univariate
 
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.BernoulliSumResult
@@ -485,7 +486,7 @@ class Moss(
     priorWeight: Double = 0.02,
 ) : BanditPolicy<WeightedMeanResult> {
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
     }
     override val arm = MeanArm(priorMean, priorWeight)
     private var totalSamples: Double = 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
@@ -2,6 +2,9 @@ package com.eignex.kumulant.bandit.univariate
 
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 import kotlin.math.exp
@@ -64,7 +67,7 @@ class BoltzmannBandit(
 ) : UnivariateBandit,
     PerArmBandit<WeightedMeanResult> {
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
         require(initialTau > 0.0) { "initialTau must be positive, got $initialTau" }
         require(minTau > 0.0) { "minTau must be positive, got $minTau" }
         require(decay >= 0.0) { "decay must be non-negative, got $decay" }
@@ -106,7 +109,7 @@ class BoltzmannBandit(
 
     /** Fold `(arm, reward)` into the per-arm mean. */
     override fun update(armIndex: Int, value: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         stats[armIndex].update(value, 0L, weight)
     }
 
@@ -115,9 +118,7 @@ class BoltzmannBandit(
     override fun snapshot(): List<WeightedMeanResult> = stats.map { it.read(0L) }
 
     override fun merge(other: List<WeightedMeanResult>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (i in 0 until nbrArms) stats[i].merge(other[i])
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
@@ -5,9 +5,10 @@ import com.eignex.kumulant.bandit.UnivariateBandit
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
+import com.eignex.kumulant.bandit.sampleFromDistribution
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
-import kotlin.math.exp
 import kotlin.math.pow
 import kotlin.random.Random
 
@@ -80,31 +81,20 @@ class BoltzmannBandit(
     /** Sample arm from the softmax of per-arm means at the current temperature. */
     override fun choose(): Int {
         val p = playDistribution()
-        var u = random.nextDouble()
-        for (a in 0 until nbrArms) {
-            u -= p[a]
-            if (u <= 0.0) return a
-        }
-        return nbrArms - 1
+        return random.sampleFromDistribution(p)
     }
 
     /** Current play distribution: `softmax(mean / tau(t))`. Also advances the internal step. */
     fun playDistribution(): DoubleArray {
         step++
         val tau = temperature()
-        val means = DoubleArray(nbrArms) { stats[it].read(0L).mean }
-        // Stable softmax: subtract the max before exp.
-        var maxM = means[0]
-        for (m in means) if (m > maxM) maxM = m
-        val out = DoubleArray(nbrArms)
-        var sum = 0.0
-        for (a in 0 until nbrArms) {
-            val e = exp((means[a] - maxM) / tau)
-            out[a] = e
-            sum += e
-        }
-        for (a in 0 until nbrArms) out[a] /= sum
-        return out
+        // Via softmaxInPlace, the shared max-subtracting softmax. This was a fourth hand-rolled copy,
+        // missed when the other three were consolidated. Dividing by tau before the shift rather than
+        // after is the same arithmetic - tau > 0 is enforced at construction, so
+        // `max(means)/tau == max(means/tau)` - and it costs one array instead of two.
+        val logits = DoubleArray(nbrArms) { stats[it].read(0L).mean / tau }
+        logits.softmaxInPlace()
+        return logits
     }
 
     /** Fold `(arm, reward)` into the per-arm mean. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
@@ -88,10 +88,8 @@ class BoltzmannBandit(
     fun playDistribution(): DoubleArray {
         step++
         val tau = temperature()
-        // Via softmaxInPlace, the shared max-subtracting softmax. This was a fourth hand-rolled copy,
-        // missed when the other three were consolidated. Dividing by tau before the shift rather than
-        // after is the same arithmetic - tau > 0 is enforced at construction, so
-        // `max(means)/tau == max(means/tau)` - and it costs one array instead of two.
+        // Dividing by tau before the max-shift is the same arithmetic, since tau > 0 is enforced at
+        // construction and so `max(means)/tau == max(means/tau)`, and it costs one array instead of two.
         val logits = DoubleArray(nbrArms) { stats[it].read(0L).mean / tau }
         logits.softmaxInPlace()
         return logits

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -8,12 +8,12 @@ import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 
 /** Per-arm snapshot for [Exp3Bandit]: the exponential-weight cell for one arm. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -4,13 +4,16 @@ import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.UnivariateBandit
 import com.eignex.kumulant.bandit.renormaliseExponentialWeights
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /** Per-arm snapshot for [Exp3Bandit]: the exponential-weight cell for one arm. */
 @Serializable
@@ -71,7 +74,7 @@ class Exp3Bandit(
 ) : UnivariateBandit,
     PerArmBandit<Exp3ArmResult> {
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
         require(eta > 0.0) { "eta must be positive, got $eta" }
         require(gamma in 0.0..1.0) { "gamma must lie in [0, 1], got $gamma" }
     }
@@ -111,7 +114,7 @@ class Exp3Bandit(
 
     /** Fold a `(arm, reward)` observation into the played arm's weight. */
     override fun update(armIndex: Int, value: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         playDistribution().also { lastPlayDist = it }
         val p = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
         val gain = (value * weight) / p
@@ -130,9 +133,7 @@ class Exp3Bandit(
     override fun snapshot(): List<Exp3ArmResult> = List(nbrArms) { Exp3ArmResult(weights[it]) }
 
     override fun merge(other: List<Exp3ArmResult>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         // No canonical merge for EXP3 weights; multiply elementwise as a coarse pool,
         // then renormalise. Use for "roughly combine two parallel runs", not principled
         // aggregation.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.bandit.renormaliseExponentialWeights
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
+import com.eignex.kumulant.bandit.sampleFromDistribution
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -86,12 +87,7 @@ class Exp3Bandit(
     override fun choose(): Int {
         val p = playDistribution()
         lastPlayDist = p
-        var u = random.nextDouble()
-        for (a in 0 until nbrArms) {
-            u -= p[a]
-            if (u <= 0.0) return a
-        }
-        return nbrArms - 1
+        return random.sampleFromDistribution(p)
     }
 
     /** Current play distribution: weight-normalised softmax blended with uniform [gamma]. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
@@ -5,6 +5,9 @@ package com.eignex.kumulant.bandit.univariate
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.Scorable
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.concurrent.atomics.AtomicLong
@@ -52,7 +55,7 @@ class MultiArmedBandit<R : Result>(
     Scorable {
 
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
     }
 
     private val step = AtomicLong(0L)
@@ -76,23 +79,25 @@ class MultiArmedBandit<R : Result>(
         return bestIdx
     }
 
-    override fun evaluate(armIndex: Int): Double = policy.evaluate(arms[armIndex].read(0L), step.load(), random)
+    override fun evaluate(armIndex: Int): Double {
+        requireArmIndex(armIndex, nbrArms)
+        return policy.evaluate(arms[armIndex].read(0L), step.load(), random)
+    }
 
     override fun update(armIndex: Int, value: Double, weight: Double) {
-        // Every sibling bandit validates this; without it a bad index surfaced as a raw
-        // ArrayIndexOutOfBoundsException rather than the documented message.
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         policy.update(arms[armIndex], value, weight)
     }
 
     override fun snapshot(): List<R> = arms.map { it.read(0L) }
 
-    override fun armResult(armIndex: Int): R = arms[armIndex].read(0L)
+    override fun armResult(armIndex: Int): R {
+        requireArmIndex(armIndex, nbrArms)
+        return arms[armIndex].read(0L)
+    }
 
     override fun merge(other: List<R>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (i in 0 until nbrArms) {
             val oldSnap = arms[i].read(0L)
             policy.removeArm(oldSnap)
@@ -120,5 +125,8 @@ class MultiArmedBandit<R : Result>(
      * [BanditPolicy.update] (use [MultiArmedBandit.update] for that); the returned reference
      * is intended for read-side and composition, not for bypassing the policy.
      */
-    fun armStat(armIndex: Int): SeriesStat<R> = arms[armIndex]
+    fun armStat(armIndex: Int): SeriesStat<R> {
+        requireArmIndex(armIndex, nbrArms)
+        return arms[armIndex]
+    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
@@ -5,6 +5,7 @@ package com.eignex.kumulant.bandit.univariate
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.Scorable
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.argmaxArm
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
@@ -67,16 +68,7 @@ class MultiArmedBandit<R : Result>(
 
     override fun choose(): Int {
         val t = step.addAndFetch(1L) - 1L
-        var bestIdx = 0
-        var bestScore = Double.NEGATIVE_INFINITY
-        for (i in 0 until nbrArms) {
-            val score = policy.evaluate(arms[i].read(0L), t, random)
-            if (score > bestScore) {
-                bestScore = score
-                bestIdx = i
-            }
-        }
-        return bestIdx
+        return argmaxArm(nbrArms) { i -> policy.evaluate(arms[i].read(0L), t, random) }
     }
 
     override fun evaluate(armIndex: Int): Double {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
@@ -3,11 +3,14 @@ package com.eignex.kumulant.bandit.univariate
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.Scorable
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
+import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.isInertWeight
+import kotlin.random.Random
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.random.Random
 
 /**
  * Per-arm state snapshot for [RouletteWheelBandit]. Exposes the current weight plus the
@@ -82,7 +85,7 @@ class RouletteWheelBandit(
     Scorable {
 
     init {
-        require(nbrArms > 0) { "nbrArms must be positive, got $nbrArms" }
+        requireNbrArms(nbrArms)
         require(reactionFactor in 0.0..1.0) { "reactionFactor must be in [0, 1], got $reactionFactor" }
         require(segmentLength > 0) { "segmentLength must be positive, got $segmentLength" }
         require(minWeight > 0.0) { "minWeight must be positive, got $minWeight" }
@@ -107,10 +110,13 @@ class RouletteWheelBandit(
 
     /** Returns the arm's current weight. Used by `choose` is computed inline; this is
      *  the [Scorable] view exposed for inspection / debugging. */
-    override fun evaluate(armIndex: Int): Double = weights[armIndex]
+    override fun evaluate(armIndex: Int): Double {
+        requireArmIndex(armIndex, nbrArms)
+        return weights[armIndex]
+    }
 
     override fun update(armIndex: Int, value: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         // A zero weight contributes nothing to the score, but the counter and the segment clock
         // used to advance anyway, so it diluted the arm's average toward zero and could trip a
         // rebalance. Zero weight means "ignore this observation" library-wide.
@@ -147,9 +153,7 @@ class RouletteWheelBandit(
      * for "roughly combine two parallel runs" rather than for principled aggregation.
      */
     override fun merge(other: List<RouletteWheelArmResult>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (i in 0 until nbrArms) {
             weights[i] = ((weights[i] + other[i].weight) / 2.0).coerceAtLeast(minWeight)
             accumulatedScores[i] += other[i].accumulatedScore

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
@@ -8,9 +8,9 @@ import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.isInertWeight
-import kotlin.random.Random
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.random.Random
 
 /**
  * Per-arm state snapshot for [RouletteWheelBandit]. Exposes the current weight plus the

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
@@ -2,6 +2,8 @@ package com.eignex.kumulant.bandit.univariate
 
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.requireArmIndex
+import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.random.Random
@@ -96,7 +98,7 @@ class TopTwoThompsonBandit<R : Result>(
     }
 
     override fun update(armIndex: Int, value: Double, weight: Double) {
-        require(armIndex in 0 until nbrArms) { "armIndex out of bounds: $armIndex" }
+        requireArmIndex(armIndex, nbrArms)
         policy.update(stats[armIndex], value, weight)
     }
 
@@ -110,9 +112,7 @@ class TopTwoThompsonBandit<R : Result>(
     }
 
     override fun merge(other: List<R>) {
-        require(other.size == nbrArms) {
-            "merge: other.size=${other.size} does not match nbrArms=$nbrArms"
-        }
+        requireMergeSize(other.size, nbrArms)
         for (i in 0 until nbrArms) stats[i].merge(other[i])
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.bandit.univariate
 
 import com.eignex.kumulant.bandit.PerArmBandit
 import com.eignex.kumulant.bandit.UnivariateBandit
+import com.eignex.kumulant.bandit.argmaxArm
 import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.core.Result
@@ -85,16 +86,7 @@ class TopTwoThompsonBandit<R : Result>(
     /** Single posterior sample per arm; return the argmax. */
     fun sampleArgmax(): Int {
         val t = step++
-        var bestIdx = 0
-        var bestScore = Double.NEGATIVE_INFINITY
-        for (a in 0 until nbrArms) {
-            val s = policy.evaluate(stats[a].read(0L), t, random)
-            if (s > bestScore) {
-                bestScore = s
-                bestIdx = a
-            }
-        }
-        return bestIdx
+        return argmaxArm(nbrArms) { a -> policy.evaluate(stats[a].read(0L), t, random) }
     }
 
     override fun update(armIndex: Int, value: Double, weight: Double) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/UnivariateBanditSpec.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/UnivariateBanditSpec.kt
@@ -67,7 +67,7 @@ data class Exp3Spec(
     val nbrArms: Int,
     /** Learning rate on per-arm gain updates; `null` selects `sqrt(ln(K)/K)`. */
     val eta: Double? = null,
-    /** Exploration mix probability; `null` selects `min(K * eta, 1)`. */
+    /** Exploration mix probability; `null` selects `min(eta, 1)`. */
     val gamma: Double? = null,
 ) : UnivariateBanditSpec
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -25,3 +25,34 @@ import com.eignex.koblas.VectorView
 internal inline fun VectorView.requireFeatureSize(expected: Int) {
     require(size == expected) { "x.size=$size, expected $expected" }
 }
+
+/**
+ * Reject a non-positive feature count at construction.
+ *
+ * Sixteen sites spelled this out, in *two* spellings: the GLM stats said `"featureSize must be positive"`
+ * and the tree stats appended `", got $featureSize"`. Standardised on the with-value form, since a
+ * message naming the offending number is strictly more useful and no test matched either one.
+ */
+internal fun requirePositiveFeatureSize(featureSize: Int) {
+    require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
+}
+
+/** Reject a class count below two. One class is not a classification problem. Nine identical sites. */
+internal fun requireAtLeastTwoClasses(numClasses: Int) {
+    require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+}
+
+/** Reject a non-positive bin count. Six identical sites across the score and calibration families. */
+internal fun requirePositiveBins(numBins: Int) {
+    require(numBins > 0) { "numBins must be > 0; got $numBins" }
+}
+
+/**
+ * Reject a merge between two models of different arity.
+ *
+ * Distinct from [requireFeatureSize], which guards an incoming observation: this guards an incoming
+ * *snapshot*, where the mismatch means the two models were never the same model. Three identical sites.
+ */
+internal fun requireMergeFeatureSize(incoming: Int, own: Int) {
+    require(incoming == own) { "merge: featureSize mismatch $incoming vs $own" }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -14,9 +14,7 @@ import com.eignex.koblas.VectorView
  * stays greppable and so the assertion in `RegressionOpsTest` keeps meaning what it meant. The one
  * site left spelling it out is `HalfSpaceTreesStat.update`, whose receiver is named `vector` and whose
  * message says so.
- *
- * `VectorizedStat.update` was a second such site, with a third wording again, until it was migrated
- * here - so treat the count above as something to re-check rather than trust.
+
  *
  * @param expected the model's feature count.
  * @throws IllegalArgumentException if [VectorView.size] differs from [expected].
@@ -26,23 +24,17 @@ internal inline fun VectorView.requireFeatureSize(expected: Int) {
     require(size == expected) { "x.size=$size, expected $expected" }
 }
 
-/**
- * Reject a non-positive feature count at construction.
- *
- * Sixteen sites spelled this out, in *two* spellings: the GLM stats said `"featureSize must be positive"`
- * and the tree stats appended `", got $featureSize"`. Standardised on the with-value form, since a
- * message naming the offending number is strictly more useful and no test matched either one.
- */
+/** Reject a non-positive feature count at construction. */
 internal fun requirePositiveFeatureSize(featureSize: Int) {
     require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
 }
 
-/** Reject a class count below two. One class is not a classification problem. Nine identical sites. */
+/** Reject a class count below two: one class is not a classification problem. */
 internal fun requireAtLeastTwoClasses(numClasses: Int) {
     require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
 }
 
-/** Reject a non-positive bin count. Six identical sites across the score and calibration families. */
+/** Reject a non-positive bin count. */
 internal fun requirePositiveBins(numBins: Int) {
     require(numBins > 0) { "numBins must be > 0; got $numBins" }
 }
@@ -51,7 +43,7 @@ internal fun requirePositiveBins(numBins: Int) {
  * Reject a merge between two models of different arity.
  *
  * Distinct from [requireFeatureSize], which guards an incoming observation: this guards an incoming
- * *snapshot*, where the mismatch means the two models were never the same model. Three identical sites.
+ * *snapshot*, where a mismatch means the two were never the same model.
  */
 internal fun requireMergeFeatureSize(incoming: Int, own: Int) {
     require(incoming == own) { "merge: featureSize mismatch $incoming vs $own" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -15,6 +15,9 @@ import com.eignex.koblas.VectorView
  * site left spelling it out is `HalfSpaceTreesStat.update`, whose receiver is named `vector` and whose
  * message says so.
  *
+ * `VectorizedStat.update` was a second such site, with a third wording again, until it was migrated
+ * here - so treat the count above as something to re-check rather than trust.
+ *
  * @param expected the model's feature count.
  * @throws IllegalArgumentException if [VectorView.size] differs from [expected].
  */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/ArgMax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/ArgMax.kt
@@ -3,19 +3,8 @@ package com.eignex.kumulant.math
 /**
  * Index of the largest of [n] scores, resolving ties to the lowest index.
  *
- * Eight sites open-coded this: four bandits over arms, and four models over class labels. They were not
- * quite the same loop, and the difference was in NaN handling.
- *
- * The bandits seeded `best` at `-Infinity`; the models seeded it at `score(0)`. Since every comparison
- * against NaN is false, seeding from `score(0)` means a NaN *first* score wins outright - nothing can
- * ever beat it - so one poisoned class label decided every later prediction. Seeding at `-Infinity`
- * makes a NaN score lose instead, and only an all-NaN set falls through to index 0.
- *
- * This unifies on `-Infinity`, which changes what a poisoned model predicts: previously whichever class
- * happened to go NaN first, now the best of the classes that are still finite. Both are permitted - a
- * non-finite value is allowed to poison a stat and only guaranteed not to throw - but a model that keeps
- * answering from its surviving coordinates is the more useful of the two, and having one convention
- * rather than two is the point.
+ * A NaN score always loses, because the running best starts at `-Infinity` and every comparison against
+ * NaN is false. An all-NaN set therefore yields index 0.
  */
 internal inline fun argMaxOf(n: Int, score: (Int) -> Double): Int {
     var bestIdx = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/ArgMax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/ArgMax.kt
@@ -1,0 +1,31 @@
+package com.eignex.kumulant.math
+
+/**
+ * Index of the largest of [n] scores, resolving ties to the lowest index.
+ *
+ * Eight sites open-coded this: four bandits over arms, and four models over class labels. They were not
+ * quite the same loop, and the difference was in NaN handling.
+ *
+ * The bandits seeded `best` at `-Infinity`; the models seeded it at `score(0)`. Since every comparison
+ * against NaN is false, seeding from `score(0)` means a NaN *first* score wins outright - nothing can
+ * ever beat it - so one poisoned class label decided every later prediction. Seeding at `-Infinity`
+ * makes a NaN score lose instead, and only an all-NaN set falls through to index 0.
+ *
+ * This unifies on `-Infinity`, which changes what a poisoned model predicts: previously whichever class
+ * happened to go NaN first, now the best of the classes that are still finite. Both are permitted - a
+ * non-finite value is allowed to poison a stat and only guaranteed not to throw - but a model that keeps
+ * answering from its surviving coordinates is the more useful of the two, and having one convention
+ * rather than two is the point.
+ */
+internal inline fun argMaxOf(n: Int, score: (Int) -> Double): Int {
+    var bestIdx = 0
+    var bestScore = Double.NEGATIVE_INFINITY
+    for (i in 0 until n) {
+        val s = score(i)
+        if (s > bestScore) {
+            bestScore = s
+            bestIdx = i
+        }
+    }
+    return bestIdx
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
@@ -188,13 +188,10 @@ fun Random.nextBeta(alpha: Double, beta: Double): Double {
     val a = nextGamma(alpha)
     val b = nextGamma(beta)
     val s = a + b
-    return if (s > 0.0) {
-        a / s
-    } else if (a > 0.0) {
-        1.0
-    } else {
-        0.0
-    }
+    // nextGamma is non-negative on every path, so `s <= 0.0` forces `a == b == 0.0` and the old
+    // `else if (a > 0.0) 1.0` branch could not be reached. A NaN `a` also lands here, since both
+    // comparisons are false against NaN, and zero is the right answer there too.
+    return if (s > 0.0) a / s else 0.0
 }
 
 /** Knuth's Poisson sampler at lambda=1; returns 0/1/2/... with mass `e^{-1} / k!`. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
@@ -188,9 +188,8 @@ fun Random.nextBeta(alpha: Double, beta: Double): Double {
     val a = nextGamma(alpha)
     val b = nextGamma(beta)
     val s = a + b
-    // nextGamma is non-negative on every path, so `s <= 0.0` forces `a == b == 0.0` and the old
-    // `else if (a > 0.0) 1.0` branch could not be reached. A NaN `a` also lands here, since both
-    // comparisons are false against NaN, and zero is the right answer there too.
+    // nextGamma is non-negative on every path, so `s <= 0.0` means both draws were zero. A NaN draw
+    // lands here too, since comparisons against NaN are false, and zero is the right answer for both.
     return if (s > 0.0) a / s else 0.0
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
@@ -41,12 +41,8 @@ internal fun DoubleArray.softmaxInPlace(): Boolean {
 /**
  * Floor and ceiling applied to a probability before taking its logarithm.
  *
- * `ln(0)` is `-Infinity`, which poisons a running mean permanently, so every log-loss-shaped score has to
- * clamp first. The value was declared twice under two names - `LOG_LOSS_EPS` in the score family and
- * `SOFTMAX_EPS` in the softmax regressor - for the same job, plus a third time in prose in a KDoc.
- *
- * `1e-15` rather than something smaller: `ln(1e-15)` is about -34.5, a large but finite penalty, while a
- * clamp near the `2.2e-16` double epsilon would lose the distinction between the clamp and `1.0` at the
- * upper end, where the interesting quantity is `1 - p`.
+ * `ln(0)` is `-Infinity`, which poisons a running mean permanently, so every log-loss-shaped score clamps
+ * first. `1e-15` gives a large but finite penalty at about -34.5, while staying far enough from the
+ * `2.2e-16` double epsilon that `1 - p` is still distinguishable from zero at the upper end.
  */
 internal const val PROBABILITY_FLOOR: Double = 1e-15

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
@@ -37,3 +37,16 @@ internal fun DoubleArray.softmaxInPlace(): Boolean {
     for (i in indices) this[i] *= invZ
     return true
 }
+
+/**
+ * Floor and ceiling applied to a probability before taking its logarithm.
+ *
+ * `ln(0)` is `-Infinity`, which poisons a running mean permanently, so every log-loss-shaped score has to
+ * clamp first. The value was declared twice under two names - `LOG_LOSS_EPS` in the score family and
+ * `SOFTMAX_EPS` in the softmax regressor - for the same job, plus a third time in prose in a KDoc.
+ *
+ * `1e-15` rather than something smaller: `ln(1e-15)` is about -34.5, a large but finite penalty, while a
+ * clamp near the `2.2e-16` double epsilon would lose the distinction between the clamp and `1.0` at the
+ * upper end, where the interesting quantity is `1 - p`.
+ */
+internal const val PROBABILITY_FLOOR: Double = 1e-15

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/AxisBindings.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/AxisBindings.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.core.*
+import com.eignex.kumulant.stream.NANOS_PER_SECOND
 
 /** Lift a paired stat into a series stat that feeds its x from the event timestamp (seconds). */
 internal fun <R : Result> PairedStat<R>.withTimeAsX(): SeriesStat<R> = WithTimeAsXStat(this)
@@ -20,7 +21,7 @@ internal class WithTimeAsXStat<R : Result>(private val delegate: PairedStat<R>) 
     Stat<R> by delegate {
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         delegate.update(
-            x = timestampNanos / 1e9,
+            x = timestampNanos / NANOS_PER_SECOND,
             y = value,
             timestampNanos,
             weight,
@@ -37,7 +38,7 @@ internal class WithTimeAsYStat<R : Result>(private val delegate: PairedStat<R>) 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         delegate.update(
             x = value,
-            y = timestampNanos / 1e9,
+            y = timestampNanos / NANOS_PER_SECOND,
             timestampNanos,
             weight,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -49,7 +49,7 @@ internal class FeedbackSeriesStat<P : Result, I : Result>(
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         primary.update(value, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
-        inner.update(project.eval(value, 0.0, EMPTY_VECTOR, snapshot), timestampNanos, weight)
+        inner.update(project.eval(value, primary = snapshot), timestampNanos, weight)
     }
 
     override fun reset() {
@@ -59,10 +59,6 @@ internal class FeedbackSeriesStat<P : Result, I : Result>(
 
     override fun create(concurrency: Concurrency?): SeriesStat<I> =
         FeedbackSeriesStat(inner.create(concurrency), primary.create(concurrency), project)
-
-    companion object {
-        private val EMPTY_VECTOR = DoubleArray(0)
-    }
 }
 
 /**
@@ -89,7 +85,7 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
         primary.update(vector, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(vector.size) { i ->
-            project.eval(vector[i], 0.0, EMPTY_VECTOR, IndexedResult(snapshot.results[i], i))
+            project.eval(vector[i], primary = IndexedResult(snapshot.results[i], i))
         }
         inner.update(transformed, timestampNanos, weight)
     }
@@ -101,10 +97,6 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
 
     override fun create(concurrency: Concurrency?): VectorStat<I> =
         FeedbackVectorStat(inner.create(concurrency), primary.create(concurrency), project)
-
-    companion object {
-        private val EMPTY_VECTOR = DoubleArray(0)
-    }
 }
 
 /**
@@ -132,7 +124,7 @@ internal class FeedbackRegressionStat<P : Result, R : Result>(
         primary.update(x, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(x.size) { i ->
-            project.eval(x[i], 0.0, EMPTY_VECTOR, IndexedResult(snapshot.results[i], i))
+            project.eval(x[i], primary = IndexedResult(snapshot.results[i], i))
         }
         inner.update(transformed, y, timestampNanos, weight)
     }
@@ -144,10 +136,6 @@ internal class FeedbackRegressionStat<P : Result, R : Result>(
 
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
         FeedbackRegressionStat(inner.create(concurrency), primary.create(concurrency), project)
-
-    companion object {
-        private val EMPTY_VECTOR = DoubleArray(0)
-    }
 }
 
 /**
@@ -176,8 +164,8 @@ internal class FeedbackPairedStat<P : Result, R : Result>(
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         primaryX.update(x, timestampNanos, weight)
         primaryY.update(y, timestampNanos, weight)
-        val tx = project.eval(x, 0.0, EMPTY_VECTOR, IndexedResult(primaryX.read(timestampNanos), 0))
-        val ty = project.eval(y, 0.0, EMPTY_VECTOR, IndexedResult(primaryY.read(timestampNanos), 1))
+        val tx = project.eval(x, primary = IndexedResult(primaryX.read(timestampNanos), 0))
+        val ty = project.eval(y, primary = IndexedResult(primaryY.read(timestampNanos), 1))
         inner.update(tx, ty, timestampNanos, weight)
     }
 
@@ -193,8 +181,4 @@ internal class FeedbackPairedStat<P : Result, R : Result>(
         primaryY.create(concurrency),
         project,
     )
-
-    companion object {
-        private val EMPTY_VECTOR = DoubleArray(0)
-    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
@@ -1,0 +1,53 @@
+package com.eignex.kumulant.operation
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stream.monotonicMode
+import kotlin.random.Random
+
+/**
+ * Counts updates and lets every `every`-th one through.
+ *
+ * Five wrappers - the four in [Sampling] plus the regression one - carried this identically: the same
+ * `init` check, the same counter, the same `% every == 0L` test, and the same five-line comment on why
+ * `reset` has to clear the phase as well as the delegate. That comment is the reason to have one gate:
+ * `Stat.reset` promises the equivalent of a fresh stat, `by delegate` forwards `reset` straight past a
+ * counter the wrapper owns, and a wrapper that forgets to clear it forwards on its first update instead
+ * of its `every`-th. Five copies of a subtlety is five chances to omit it.
+ *
+ * The counter goes through [monotonicMode] rather than a raw `AtomicLong`, which is the other thing the
+ * copies got wrong. Every other stateful wrapper in this package resolves its cells from the delegate's
+ * [Concurrency]; these five were unconditionally atomic, so a throttled stat under [Concurrency.None]
+ * paid an atomic read-modify-write per update where a lagged stat next to it paid a plain increment.
+ * Correctness was never at stake - always-atomic is strictly safer - only the cost the concurrency
+ * contract exists to let a caller decline.
+ */
+internal class ThrottleGate(private val every: Int, concurrency: Concurrency) {
+    init {
+        checkEvery(every)
+    }
+
+    private val tick = concurrency.monotonicMode().newLong(0L)
+
+    /** True when this update is the one to forward. */
+    fun pass(): Boolean = tick.addAndGet(1L) % every == 0L
+
+    /** Clears the phase, so the next update is counted as the first. */
+    fun reset() = tick.store(0L)
+}
+
+/**
+ * Lets a Bernoulli-sampled fraction of updates through.
+ *
+ * Five wrappers spelled out `if (random.nextDouble() < rate)` behind the same `init` check. Less
+ * substance than [ThrottleGate], but the predicate is worth pinning in one place: `<` rather than `<=`
+ * is what makes `rate = 0.0` reject everything, and five copies is five chances for one to admit an
+ * update the caller asked to drop entirely.
+ */
+internal class SampleGate(private val rate: Double, private val random: Random) {
+    init {
+        checkRate(rate)
+    }
+
+    /** True when this update survives the sampling draw. */
+    fun pass(): Boolean = random.nextDouble() < rate
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
@@ -7,19 +7,12 @@ import kotlin.random.Random
 /**
  * Counts updates and lets every `every`-th one through.
  *
- * Five wrappers - the four in [Sampling] plus the regression one - carried this identically: the same
- * `init` check, the same counter, the same `% every == 0L` test, and the same five-line comment on why
- * `reset` has to clear the phase as well as the delegate. That comment is the reason to have one gate:
- * `Stat.reset` promises the equivalent of a fresh stat, `by delegate` forwards `reset` straight past a
- * counter the wrapper owns, and a wrapper that forgets to clear it forwards on its first update instead
- * of its `every`-th. Five copies of a subtlety is five chances to omit it.
+ * A wrapper holding one of these must call [reset] from its own `reset`: `Stat.reset` promises the
+ * equivalent of a fresh stat, and `by delegate` forwards `reset` straight past the gate, leaving a reset
+ * stat to forward on its first update rather than its `every`-th.
  *
- * The counter goes through [monotonicMode] rather than a raw `AtomicLong`, which is the other thing the
- * copies got wrong. Every other stateful wrapper in this package resolves its cells from the delegate's
- * [Concurrency]; these five were unconditionally atomic, so a throttled stat under [Concurrency.None]
- * paid an atomic read-modify-write per update where a lagged stat next to it paid a plain increment.
- * Correctness was never at stake - always-atomic is strictly safer - only the cost the concurrency
- * contract exists to let a caller decline.
+ * The counter resolves through [monotonicMode] so a gate under [Concurrency.None] costs a plain
+ * increment rather than an atomic read-modify-write.
  */
 internal class ThrottleGate(private val every: Int, concurrency: Concurrency) {
     init {
@@ -38,10 +31,7 @@ internal class ThrottleGate(private val every: Int, concurrency: Concurrency) {
 /**
  * Lets a Bernoulli-sampled fraction of updates through.
  *
- * Five wrappers spelled out `if (random.nextDouble() < rate)` behind the same `init` check. Less
- * substance than [ThrottleGate], but the predicate is worth pinning in one place: `<` rather than `<=`
- * is what makes `rate = 0.0` reject everything, and five copies is five chances for one to admit an
- * update the caller asked to drop entirely.
+ * The predicate is `<` rather than `<=`, which is what makes `rate = 0.0` reject everything.
  */
 internal class SampleGate(private val rate: Double, private val random: Random) {
     init {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.DenseVector
@@ -10,8 +8,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.requireFeatureSize
-import kotlin.concurrent.atomics.AtomicLong
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import kotlin.random.Random
 
 // Decorator surface for [RegressionStat], mirroring the live ops on the other modalities.
@@ -145,20 +142,13 @@ internal class WeightByRegressionStat<R : Result>(
 internal class ThrottleRegressionStat<R : Result>(private val delegate: RegressionStat<R>, private val every: Int) :
     RegressionStat<R>,
     Stat<R> by delegate {
-    init {
-        checkEvery(every)
-    }
     override val featureSize: Int = delegate.featureSize
-    private val tick = AtomicLong(0L)
+    private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        if (tick.addAndFetch(1L) % every == 0L) delegate.update(x, y, timestampNanos, weight)
+        if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun reset() {
-        // Reset the phase too, not just the delegate: Stat.reset promises the equivalent of a fresh
-        // stat, and `by delegate` forwarded reset straight past this counter, so a reset stat
-        // forwarded on its first update instead of its `every`-th. The sibling wrappers
-        // (LagSeriesStat, DiffSeriesStat, HysteresisSeriesStat, ResampleByTimeStat) all do this.
-        tick.store(0L)
+        gate.reset()
         delegate.reset()
     }
 
@@ -172,12 +162,10 @@ internal class SampleRegressionStat<R : Result>(
     private val random: Random,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
-    init {
-        checkRate(rate)
-    }
+    private val gate = SampleGate(rate, random)
     override val featureSize: Int = delegate.featureSize
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        if (random.nextDouble() < rate) delegate.update(x, y, timestampNanos, weight)
+        if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
         SampleRegressionStat(delegate.create(concurrency), rate, random)
@@ -190,7 +178,7 @@ internal class FoldRegressionStat<R : Result>(
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     init {
-        require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
+        requirePositiveFeatureSize(featureSize)
     }
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.VectorView
@@ -10,8 +8,6 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
-import kotlin.concurrent.atomics.AtomicLong
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.random.Random
 
 // Throttle / sample adapters. Each wraps an inner stat, intercepts at the update
@@ -65,19 +61,12 @@ internal fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate 
 internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val every: Int) :
     SeriesStat<R>,
     Stat<R> by delegate {
-    init {
-        checkEvery(every)
-    }
-    private val tick = AtomicLong(0L)
+    private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (tick.addAndFetch(1L) % every == 0L) delegate.update(value, timestampNanos, weight)
+        if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun reset() {
-        // Reset the phase too, not just the delegate: Stat.reset promises the equivalent of a fresh
-        // stat, and `by delegate` forwarded reset straight past this counter, so a reset stat
-        // forwarded on its first update instead of its `every`-th. The sibling wrappers
-        // (LagSeriesStat, DiffSeriesStat, HysteresisSeriesStat, ResampleByTimeStat) all do this.
-        tick.store(0L)
+        gate.reset()
         delegate.reset()
     }
 
@@ -88,19 +77,12 @@ internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R
 internal class ThrottlePairedStat<R : Result>(private val delegate: PairedStat<R>, private val every: Int) :
     PairedStat<R>,
     Stat<R> by delegate {
-    init {
-        checkEvery(every)
-    }
-    private val tick = AtomicLong(0L)
+    private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        if (tick.addAndFetch(1L) % every == 0L) delegate.update(x, y, timestampNanos, weight)
+        if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun reset() {
-        // Reset the phase too, not just the delegate: Stat.reset promises the equivalent of a fresh
-        // stat, and `by delegate` forwarded reset straight past this counter, so a reset stat
-        // forwarded on its first update instead of its `every`-th. The sibling wrappers
-        // (LagSeriesStat, DiffSeriesStat, HysteresisSeriesStat, ResampleByTimeStat) all do this.
-        tick.store(0L)
+        gate.reset()
         delegate.reset()
     }
 
@@ -111,19 +93,12 @@ internal class ThrottlePairedStat<R : Result>(private val delegate: PairedStat<R
 internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R>, private val every: Int) :
     VectorStat<R>,
     Stat<R> by delegate {
-    init {
-        checkEvery(every)
-    }
-    private val tick = AtomicLong(0L)
+    private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
-        if (tick.addAndFetch(1L) % every == 0L) delegate.update(vector, timestampNanos, weight)
+        if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
     override fun reset() {
-        // Reset the phase too, not just the delegate: Stat.reset promises the equivalent of a fresh
-        // stat, and `by delegate` forwarded reset straight past this counter, so a reset stat
-        // forwarded on its first update instead of its `every`-th. The sibling wrappers
-        // (LagSeriesStat, DiffSeriesStat, HysteresisSeriesStat, ResampleByTimeStat) all do this.
-        tick.store(0L)
+        gate.reset()
         delegate.reset()
     }
 
@@ -134,19 +109,12 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
 internal class ThrottleDiscreteStat<R : Result>(private val delegate: DiscreteStat<R>, private val every: Int) :
     DiscreteStat<R>,
     Stat<R> by delegate {
-    init {
-        checkEvery(every)
-    }
-    private val tick = AtomicLong(0L)
+    private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (tick.addAndFetch(1L) % every == 0L) delegate.update(value, timestampNanos, weight)
+        if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun reset() {
-        // Reset the phase too, not just the delegate: Stat.reset promises the equivalent of a fresh
-        // stat, and `by delegate` forwarded reset straight past this counter, so a reset stat
-        // forwarded on its first update instead of its `every`-th. The sibling wrappers
-        // (LagSeriesStat, DiffSeriesStat, HysteresisSeriesStat, ResampleByTimeStat) all do this.
-        tick.store(0L)
+        gate.reset()
         delegate.reset()
     }
 
@@ -163,11 +131,9 @@ internal class SampleSeriesStat<R : Result>(
     private val random: Random,
 ) : SeriesStat<R>,
     Stat<R> by delegate {
-    init {
-        checkRate(rate)
-    }
+    private val gate = SampleGate(rate, random)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (random.nextDouble() < rate) delegate.update(value, timestampNanos, weight)
+        if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
         SampleSeriesStat(delegate.create(concurrency), rate, random)
@@ -179,11 +145,9 @@ internal class SamplePairedStat<R : Result>(
     private val random: Random,
 ) : PairedStat<R>,
     Stat<R> by delegate {
-    init {
-        checkRate(rate)
-    }
+    private val gate = SampleGate(rate, random)
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        if (random.nextDouble() < rate) delegate.update(x, y, timestampNanos, weight)
+        if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): PairedStat<R> =
         SamplePairedStat(delegate.create(concurrency), rate, random)
@@ -195,11 +159,9 @@ internal class SampleVectorStat<R : Result>(
     private val random: Random,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    init {
-        checkRate(rate)
-    }
+    private val gate = SampleGate(rate, random)
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
-        if (random.nextDouble() < rate) delegate.update(vector, timestampNanos, weight)
+        if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
         SampleVectorStat(delegate.create(concurrency), rate, random)
@@ -211,11 +173,9 @@ internal class SampleDiscreteStat<R : Result>(
     private val random: Random,
 ) : DiscreteStat<R>,
     Stat<R> by delegate {
-    init {
-        checkRate(rate)
-    }
+    private val gate = SampleGate(rate, random)
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        if (random.nextDouble() < rate) delegate.update(value, timestampNanos, weight)
+        if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): DiscreteStat<R> =
         SampleDiscreteStat(delegate.create(concurrency), rate, random)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Scalers.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Scalers.kt
@@ -22,6 +22,8 @@ import com.eignex.kumulant.schema.expr.plus
 import com.eignex.kumulant.schema.expr.times
 import com.eignex.kumulant.stat.summary.RangeStat
 import com.eignex.kumulant.stat.summary.VarianceStat
+import com.eignex.kumulant.stream.DEFAULT_TARGET_HIGH
+import com.eignex.kumulant.stream.DEFAULT_TARGET_LOW
 
 // Standard streaming feature scalers built on top of `withFeedback`. Each scaler couples the
 // inner stat with a small running-statistics primary so the projected input is rescaled per
@@ -57,8 +59,8 @@ internal fun <R : Result> SeriesStat<R>.standardScaler(concurrency: Concurrency 
  * update or constant stream) the scaler emits [targetLow].
  */
 internal fun <R : Result> SeriesStat<R>.minMaxScaler(
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
     concurrency: Concurrency = this.concurrency,
 ): SeriesStat<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
@@ -90,8 +92,8 @@ internal fun <I : Result> VectorStat<I>.standardScaleFeatures(
 @Suppress("UNCHECKED_CAST")
 internal fun <I : Result> VectorStat<I>.minMaxScaleFeatures(
     dimensions: Int,
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
     concurrency: Concurrency = this.concurrency,
 ): VectorStat<I> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
@@ -121,8 +123,8 @@ internal fun <R : Result> RegressionStat<R>.standardScaleFeatures(
  */
 @Suppress("UNCHECKED_CAST")
 internal fun <R : Result> RegressionStat<R>.minMaxScaleFeatures(
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
     concurrency: Concurrency = this.concurrency,
 ): RegressionStat<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
@@ -145,8 +147,8 @@ internal fun <R : Result> PairedStat<R>.standardScaler(concurrency: Concurrency 
  * degenerate.
  */
 internal fun <R : Result> PairedStat<R>.minMaxScaler(
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
     concurrency: Concurrency = this.concurrency,
 ): PairedStat<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.stream.NANOS_PER_SECOND
 import com.eignex.kumulant.stream.firstWriterMode
 import com.eignex.kumulant.stream.monotonicMode
 
@@ -123,8 +124,4 @@ internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat
     }
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> = DerivativeSeriesStat(delegate.create(concurrency))
-
-    companion object {
-        private const val NANOS_PER_SECOND: Double = 1_000_000_000.0
-    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -52,9 +52,6 @@ internal class VectorizedStat<R : Result>(
         VectorizedStat(dimensions, template.create(concurrency), skipZeros)
 
     override fun merge(values: ResultList<R>) {
-        // Had no message at all, which on a wire-reachable path - every `Vectorized` spec and all four
-        // `*ScaleFeatures` scalers materialise through here - meant an arity mismatch surfaced as a bare
-        // "Failed requirement." with nothing naming the two numbers involved.
         require(values.results.size == dimensions) {
             "merge: results.size=${values.results.size}, expected $dimensions"
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.VectorStat
+import com.eignex.kumulant.core.requireFeatureSize
 
 /**
  * Fans each vector observation out to one [SeriesStat] per dimension.
@@ -35,9 +36,7 @@ internal class VectorizedStat<R : Result>(
     override val concurrency: Concurrency get() = template.concurrency
 
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
-        require(vector.size == dimensions) {
-            "Vector size ${vector.size} does not match expected dimensions $dimensions"
-        }
+        vector.requireFeatureSize(dimensions)
         if (skipZeros) {
             vector.forEachStored { i, v -> stats[i].update(v, timestampNanos, weight) }
         } else {
@@ -53,7 +52,12 @@ internal class VectorizedStat<R : Result>(
         VectorizedStat(dimensions, template.create(concurrency), skipZeros)
 
     override fun merge(values: ResultList<R>) {
-        require(values.results.size == dimensions)
+        // Had no message at all, which on a wire-reachable path - every `Vectorized` spec and all four
+        // `*ScaleFeatures` scalers materialise through here - meant an arity mismatch surfaced as a bare
+        // "Failed requirement." with nothing naming the two numbers involved.
+        require(values.results.size == dimensions) {
+            "merge: results.size=${values.results.size}, expected $dimensions"
+        }
         for (i in 0 until dimensions) {
             stats[i].merge(values.results[i])
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -45,10 +45,8 @@ internal inline fun Double.orInert(replacement: Double): Double = if (isInertWei
 internal class WithWeightStat<R : Result>(private val delegate: SeriesStat<R>, private val weight: Double) :
     SeriesStat<R>,
     Stat<R> by delegate {
-    private fun overrideOf(callerWeight: Double) = callerWeight.orInert(weight)
-
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        delegate.update(value, timestampNanos, overrideOf(weight))
+        delegate.update(value, timestampNanos, weight.orInert(this.weight))
     }
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> = WithWeightStat(delegate.create(concurrency), weight)
@@ -58,10 +56,8 @@ internal class WithWeightStat<R : Result>(private val delegate: SeriesStat<R>, p
 internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat<R>, private val weight: Double) :
     PairedStat<R>,
     Stat<R> by delegate {
-    private fun overrideOf(callerWeight: Double) = callerWeight.orInert(weight)
-
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        delegate.update(x, y, timestampNanos, overrideOf(weight))
+        delegate.update(x, y, timestampNanos, weight.orInert(this.weight))
     }
 
     override fun create(concurrency: Concurrency?): PairedStat<R> =
@@ -72,10 +68,8 @@ internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat
 internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat<R>, private val weight: Double) :
     VectorStat<R>,
     Stat<R> by delegate {
-    private fun overrideOf(callerWeight: Double) = callerWeight.orInert(weight)
-
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
-        delegate.update(vector, timestampNanos, overrideOf(weight))
+        delegate.update(vector, timestampNanos, weight.orInert(this.weight))
     }
 
     override fun create(concurrency: Concurrency?): VectorStat<R> =
@@ -86,10 +80,8 @@ internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat
 internal class WithWeightDiscreteStat<R : Result>(private val delegate: DiscreteStat<R>, private val weight: Double) :
     DiscreteStat<R>,
     Stat<R> by delegate {
-    private fun overrideOf(callerWeight: Double) = callerWeight.orInert(weight)
-
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        delegate.update(value, timestampNanos, overrideOf(weight))
+        delegate.update(value, timestampNanos, weight.orInert(this.weight))
     }
 
     override fun create(concurrency: Concurrency?): DiscreteStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
+import com.eignex.kumulant.stream.DEFAULT_WINDOW_SLICES
 import com.eignex.kumulant.stream.SliceRing
 import kotlin.time.Duration
 
@@ -20,7 +21,7 @@ import kotlin.time.Duration
  */
 internal fun <R : Result> SeriesStat<R>.windowed(
     duration: Duration,
-    slices: Int = 10,
+    slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
 ): SeriesStat<R> = if (this is BandSeriesStat<*>) {
     // A band cannot be merged, and windowedRead merges, so window the band's inner stat instead and
@@ -34,21 +35,21 @@ internal fun <R : Result> SeriesStat<R>.windowed(
 /** Paired-stat counterpart of [SeriesStat.windowed]. */
 internal fun <R : Result> PairedStat<R>.windowed(
     duration: Duration,
-    slices: Int = 10,
+    slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
 ): PairedStat<R> = WindowedPairedStat(duration, slices, this, concurrency)
 
 /** Vector-stat counterpart of [SeriesStat.windowed]. */
 internal fun <R : Result> VectorStat<R>.windowed(
     duration: Duration,
-    slices: Int = 10,
+    slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
 ): VectorStat<R> = WindowedVectorStat(duration, slices, this, concurrency)
 
 /** Discrete-stat counterpart of [SeriesStat.windowed]. */
 internal fun <R : Result> DiscreteStat<R>.windowed(
     duration: Duration,
-    slices: Int = 10,
+    slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
 ): DiscreteStat<R> = WindowedDiscreteStat(duration, slices, this, concurrency)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/samples/DocSamples.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/samples/DocSamples.kt
@@ -1,6 +1,4 @@
-// The samples are referenced only from KDoc @sample directives, which the compiler does not see as
-// usages. UnusedPrivateMember and UNUSED_PARAMETER were also suppressed here and applied to nothing:
-// every declaration in the file is internal and none takes a parameter.
+// Referenced only from KDoc @sample directives, which the compiler does not see as usages.
 @file:Suppress("unused")
 
 package com.eignex.kumulant.samples

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/samples/DocSamples.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/samples/DocSamples.kt
@@ -1,4 +1,7 @@
-@file:Suppress("UnusedPrivateMember", "unused", "UNUSED_PARAMETER")
+// The samples are referenced only from KDoc @sample directives, which the compiler does not see as
+// usages. UnusedPrivateMember and UNUSED_PARAMETER were also suppressed here and applied to nothing:
+// every declaration in the file is internal and none takes a parameter.
+@file:Suppress("unused")
 
 package com.eignex.kumulant.samples
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -4,6 +4,8 @@ import com.eignex.kumulant.core.HasCenterScale
 import com.eignex.kumulant.core.HasMinMax
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.stream.DEFAULT_TARGET_HIGH
+import com.eignex.kumulant.stream.DEFAULT_TARGET_LOW
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.abs
@@ -457,9 +459,9 @@ data object Standardize : ScalarExpr {
 @SerialName("MinMax")
 data class MinMax(
     /** Lower bound of the output range. */
-    val targetLow: Double = 0.0,
+    val targetLow: Double = DEFAULT_TARGET_LOW,
     /** Upper bound of the output range. */
-    val targetHigh: Double = 1.0,
+    val targetHigh: Double = DEFAULT_TARGET_HIGH,
 ) : ScalarExpr {
     init {
         require(targetHigh > targetLow) { "MinMax targetHigh ($targetHigh) must be > targetLow ($targetLow)" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -21,14 +21,9 @@ private val EMPTY_VECTOR = DoubleArray(0)
 /**
  * Narrow a feedback primary to the trait a node needs, unwrapping the per-element indirection first.
  *
- * Six nodes repeated the unwrap and the check verbatim, and the wording had already drifted: `Center`,
- * `Scale`, `Low` and `High` say "feedback primary" while `Standardize` and `MinMax` say just "primary".
- * That divergence is the copy-paste fingerprint, and it is exactly what a caller greps for when a
- * pipeline fails to find its primary.
- *
- * The [IndexedResult] unwrap is the load-bearing half: a vectorised feedback stat hands each coordinate
- * its own primary boxed with the coordinate's index, so a node that checked the box rather than its
- * contents would reject every element-wise pipeline.
+ * The [IndexedResult] unwrap is load-bearing: a vectorised feedback stat hands each coordinate its own
+ * primary boxed with the coordinate's index, so a node that checked the box rather than its contents
+ * would reject every element-wise pipeline.
  */
 private inline fun <reified T> Result?.feedbackPrimary(node: String): T {
     val unwrapped = if (this is IndexedResult) inner else this

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -17,6 +17,26 @@ import kotlin.math.sqrt
 private val EMPTY_VECTOR = DoubleArray(0)
 
 /**
+ * Narrow a feedback primary to the trait a node needs, unwrapping the per-element indirection first.
+ *
+ * Six nodes repeated the unwrap and the check verbatim, and the wording had already drifted: `Center`,
+ * `Scale`, `Low` and `High` say "feedback primary" while `Standardize` and `MinMax` say just "primary".
+ * That divergence is the copy-paste fingerprint, and it is exactly what a caller greps for when a
+ * pipeline fails to find its primary.
+ *
+ * The [IndexedResult] unwrap is the load-bearing half: a vectorised feedback stat hands each coordinate
+ * its own primary boxed with the coordinate's index, so a node that checked the box rather than its
+ * contents would reject every element-wise pipeline.
+ */
+private inline fun <reified T> Result?.feedbackPrimary(node: String): T {
+    val unwrapped = if (this is IndexedResult) inner else this
+    check(unwrapped is T) {
+        "$node requires a ${T::class.simpleName} feedback primary; got ${unwrapped?.let { it::class.simpleName }}"
+    }
+    return unwrapped
+}
+
+/**
  * Wire-serialisable AST for scalar expressions over the per-update input
  * environment. The library uses these wherever a stat needs to apply a
  * caller-supplied projection / weight / threshold expression that has to
@@ -88,10 +108,7 @@ data object Y : ScalarExpr {
 @SerialName("Center")
 data object Center : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasCenterScale) {
-            "Center requires a HasCenterScale feedback primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasCenterScale>("Center")
         return unwrapped.center
     }
 }
@@ -105,10 +122,7 @@ data object Center : ScalarExpr {
 @SerialName("Scale")
 data object Scale : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasCenterScale) {
-            "Scale requires a HasCenterScale feedback primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasCenterScale>("Scale")
         return unwrapped.scale
     }
 }
@@ -122,10 +136,7 @@ data object Scale : ScalarExpr {
 @SerialName("Low")
 data object Low : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasMinMax) {
-            "Low requires a HasMinMax feedback primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasMinMax>("Low")
         return unwrapped.min
     }
 }
@@ -139,10 +150,7 @@ data object Low : ScalarExpr {
 @SerialName("High")
 data object High : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasMinMax) {
-            "High requires a HasMinMax feedback primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasMinMax>("High")
         return unwrapped.max
     }
 }
@@ -434,10 +442,7 @@ data class In(
 @SerialName("Standardize")
 data object Standardize : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasCenterScale) {
-            "Standardize requires a HasCenterScale primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasCenterScale>("Standardize")
         val scale = unwrapped.scale
         return if (scale > 0.0) (x - unwrapped.center) / scale else 0.0
     }
@@ -461,10 +466,7 @@ data class MinMax(
     }
 
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double {
-        val unwrapped = if (primary is IndexedResult) primary.inner else primary
-        check(unwrapped is HasMinMax) {
-            "MinMax requires a HasMinMax primary; got ${unwrapped?.let { it::class.simpleName }}"
-        }
+        val unwrapped = primary.feedbackPrimary<HasMinMax>("MinMax")
         val lo = unwrapped.min
         val hi = unwrapped.max
         val span = hi - lo

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
@@ -7,6 +7,9 @@ import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.*
 import com.eignex.kumulant.schema.expr.*
 import com.eignex.kumulant.schema.spec.*
+import com.eignex.kumulant.stream.DEFAULT_TARGET_HIGH
+import com.eignex.kumulant.stream.DEFAULT_TARGET_LOW
+import com.eignex.kumulant.stream.DEFAULT_WINDOW_SLICES
 
 // Composition operators for the wire specs in [com.eignex.kumulant.schema].
 // Each returns a spec of the same modality, building the internal wrapper
@@ -70,20 +73,28 @@ fun <R : Result> PairedStatSpec<R>.withTimeAsX(): SeriesStatSpec<R> = WithTimeAs
 fun <R : Result> PairedStatSpec<R>.withTimeAsY(): SeriesStatSpec<R> = WithTimeAsY(this) as SeriesStatSpec<R>
 
 /** Wrap this series spec in a sliding time window of [durationMillis] split into [slices] buckets. */
-fun <R : Result> SeriesStatSpec<R>.windowed(durationMillis: Long, slices: Int = 10): SeriesStatSpec<R> =
-    WindowedSeries(this, durationMillis, slices) as SeriesStatSpec<R>
+fun <R : Result> SeriesStatSpec<R>.windowed(
+    durationMillis: Long,
+    slices: Int = DEFAULT_WINDOW_SLICES,
+): SeriesStatSpec<R> = WindowedSeries(this, durationMillis, slices) as SeriesStatSpec<R>
 
 /** Wrap this paired spec in a sliding time window of [durationMillis] split into [slices] buckets. */
-fun <R : Result> PairedStatSpec<R>.windowed(durationMillis: Long, slices: Int = 10): PairedStatSpec<R> =
-    WindowedPaired(this, durationMillis, slices) as PairedStatSpec<R>
+fun <R : Result> PairedStatSpec<R>.windowed(
+    durationMillis: Long,
+    slices: Int = DEFAULT_WINDOW_SLICES,
+): PairedStatSpec<R> = WindowedPaired(this, durationMillis, slices) as PairedStatSpec<R>
 
 /** Wrap this vector spec in a sliding time window of [durationMillis] split into [slices] buckets. */
-fun <R : Result> VectorStatSpec<R>.windowed(durationMillis: Long, slices: Int = 10): VectorStatSpec<R> =
-    WindowedVector(this, durationMillis, slices) as VectorStatSpec<R>
+fun <R : Result> VectorStatSpec<R>.windowed(
+    durationMillis: Long,
+    slices: Int = DEFAULT_WINDOW_SLICES,
+): VectorStatSpec<R> = WindowedVector(this, durationMillis, slices) as VectorStatSpec<R>
 
 /** Wrap this discrete spec in a sliding time window of [durationMillis] split into [slices] buckets. */
-fun <R : Result> DiscreteStatSpec<R>.windowed(durationMillis: Long, slices: Int = 10): DiscreteStatSpec<R> =
-    WindowedDiscrete(this, durationMillis, slices) as DiscreteStatSpec<R>
+fun <R : Result> DiscreteStatSpec<R>.windowed(
+    durationMillis: Long,
+    slices: Int = DEFAULT_WINDOW_SLICES,
+): DiscreteStatSpec<R> = WindowedDiscrete(this, durationMillis, slices) as DiscreteStatSpec<R>
 
 /** Lift a series spec to a vector spec by replicating it across every coordinate of an N-dim input. */
 fun <R : Result> SeriesStatSpec<R>.vectorized(
@@ -217,8 +228,8 @@ fun <R : Result> VectorStatSpec<R>.standardScaleFeatures(dimensions: Int): Vecto
 /** Element-wise min-max scale a vector spec against a hidden per-coordinate [Range] primary. */
 fun <R : Result> VectorStatSpec<R>.minMaxScaleFeatures(
     dimensions: Int,
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
 ): VectorStatSpec<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
     return MinMaxScalerVector(this, dimensions, targetLow, targetHigh) as VectorStatSpec<R>
@@ -228,7 +239,10 @@ fun <R : Result> VectorStatSpec<R>.minMaxScaleFeatures(
 fun <R : Result> PairedStatSpec<R>.standardScaler(): PairedStatSpec<R> = StandardScalerPaired(this) as PairedStatSpec<R>
 
 /** Min-max scale both axes of a paired spec against per-axis [Range] primaries. */
-fun <R : Result> PairedStatSpec<R>.minMaxScaler(targetLow: Double = 0.0, targetHigh: Double = 1.0): PairedStatSpec<R> {
+fun <R : Result> PairedStatSpec<R>.minMaxScaler(
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
+): PairedStatSpec<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
     return MinMaxScalerPaired(this, targetLow, targetHigh) as PairedStatSpec<R>
 }
@@ -239,8 +253,8 @@ fun <R : Result> RegressionStatSpec<R>.standardScaleFeatures(): RegressionStatSp
 
 /** Element-wise min-max scale a regression spec's feature vector. */
 fun <R : Result> RegressionStatSpec<R>.minMaxScaleFeatures(
-    targetLow: Double = 0.0,
-    targetHigh: Double = 1.0,
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
 ): RegressionStatSpec<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
     return MinMaxScalerRegression(this, targetLow, targetHigh) as RegressionStatSpec<R>
@@ -258,7 +272,10 @@ fun <R : Result> SeriesStatSpec<R>.standardScaler(): SeriesStatSpec<R> = Standar
  * `targetLow = -1.0, targetHigh = 1.0` for a `[-1, 1]` mapping. Emits [targetLow] while
  * the running range is still degenerate.
  */
-fun <R : Result> SeriesStatSpec<R>.minMaxScaler(targetLow: Double = 0.0, targetHigh: Double = 1.0): SeriesStatSpec<R> {
+fun <R : Result> SeriesStatSpec<R>.minMaxScaler(
+    targetLow: Double = DEFAULT_TARGET_LOW,
+    targetHigh: Double = DEFAULT_TARGET_HIGH,
+): SeriesStatSpec<R> {
     require(targetHigh > targetLow) { "targetHigh ($targetHigh) must be > targetLow ($targetLow)" }
     return MinMaxScalerSeries(this, targetLow, targetHigh) as SeriesStatSpec<R>
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
@@ -7,7 +7,6 @@ import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.*
 import com.eignex.kumulant.schema.expr.*
 import com.eignex.kumulant.schema.spec.*
-import com.eignex.kumulant.schema.spec.ResampleAggregator
 
 // Composition operators for the wire specs in [com.eignex.kumulant.schema].
 // Each returns a spec of the same modality, building the internal wrapper

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -33,7 +33,19 @@ internal sealed class AbstractListStats<R : Result, S : Stat<out R>>(
         requireUniqueNames(entries, typeName)
     }
 
-    final override val concurrency: Concurrency get() = concurrencyOverride ?: Concurrency.None
+    /**
+     * The weakest guarantee any entry offers, matching [AbstractStatGroup.concurrency].
+     *
+     * This reported [Concurrency.None] whenever no override was passed, which was simply untrue for a
+     * list of `Strict` entries - and this property is what a caller introspects to decide whether reads
+     * need external synchronisation. `AbstractStatGroup` was fixed; the sibling class holding the same
+     * kind of children kept the old answer, so `StatGroup(schema)` and `ListStats(schema)` over the
+     * very same schema disagreed about what they guaranteed.
+     *
+     * Computed once rather than per access: the entries are fixed at construction.
+     */
+    final override val concurrency: Concurrency =
+        concurrencyOverride ?: entries.minOfOrNull { (_, stat) -> stat.concurrency } ?: Concurrency.None
 
     final override fun read(timestampNanos: Long): ResultList<R> =
         ResultList(entries.map { it.first }, entries.map { it.second.read(timestampNanos) })

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -259,10 +259,4 @@ internal class RegressionListStats<R : Result>(
     }
 }
 
-/** Auto-named [RegressionListStats]: each stat keyed by its class `simpleName`. */
-internal fun <R : Result> regressionListStats(
-    vararg stats: RegressionStat<out R>,
-    concurrency: Concurrency? = null,
-): RegressionListStats<R> = RegressionListStats(stats.map { autoName(it) to it }, concurrency)
-
 private fun autoName(stat: Any): String = stat::class.simpleName ?: "Stat"

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -699,10 +699,7 @@ fun <R : Result> RegressionStatSpec<R>.materialize(concurrency: Concurrency = Co
 /**
  * Narrow a wrapper spec's inner spec to the modality the wrapper needs.
  *
- * Five of these existed, one per modality, with identical bodies - and the regression one sat a hundred
- * and twenty lines away from its four siblings rather than beside them. The five names are kept because
- * they read better at the ~50 call sites; only the repeated body is gone. `S::class.simpleName` derives
- * the type name the message used to spell out, so the messages are unchanged.
+ * The five per-modality aliases below exist because they read better at the call sites.
  *
  * @param S the modality the wrapper requires of its inner spec.
  * @param inner the inner spec to narrow.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -343,7 +343,6 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
         is BandSeries -> {
             // The runtime check happens at the first read; the cast is safe iff the inner stat's
             // Result implements HasCenterScale, which is part of BandSeries's documented contract.
-            @Suppress("UNCHECKED_CAST")
             val centerScaleInner = requireSeries(inner, "BandSeries").materialize(concurrency)
                 as SeriesStat<HasCenterScale>
             centerScaleInner.band(k)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -382,7 +382,7 @@ fun <R : Result> PairedStatSpec<R>.materialize(concurrency: Concurrency = Concur
 
         is ConfusionMatrix -> ConfusionMatrixStat(numClasses, concurrency)
 
-        Accuracy -> AccuracyStat(concurrency)
+        is Accuracy -> AccuracyStat(numClasses, concurrency)
 
         is WithWeightPaired ->
             requirePaired(inner, "WithWeightPaired").materialize(concurrency).withWeight(weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -334,10 +334,10 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
         }
 
         is StandardScalerSeries ->
-            requireSeries(inner, "StandardScaler").materialize(concurrency).standardScaler(concurrency)
+            requireSeries(inner, "StandardScalerSeries").materialize(concurrency).standardScaler(concurrency)
 
         is MinMaxScalerSeries ->
-            requireSeries(inner, "MinMaxScaler").materialize(concurrency)
+            requireSeries(inner, "MinMaxScalerSeries").materialize(concurrency)
                 .minMaxScaler(targetLow, targetHigh, concurrency)
 
         is BandSeries -> {
@@ -583,13 +583,6 @@ fun StatSpec.materialize(concurrency: Concurrency = Concurrency.None): Stat<*> =
     is RegressionStatSpec<*> -> materialize(concurrency)
 }
 
-private fun requireRegression(inner: StatSpec, op: String): RegressionStatSpec<*> {
-    require(inner is RegressionStatSpec<*>) {
-        "$op expects a RegressionStatSpec inner; got ${inner::class.simpleName}"
-    }
-    return inner
-}
-
 /**
  * Construct a live [RegressionStat] from a [RegressionStatSpec]. See [SeriesStatSpec.materialize].
  */
@@ -703,30 +696,29 @@ fun <R : Result> RegressionStatSpec<R>.materialize(concurrency: Concurrency = Co
     return out as RegressionStat<R>
 }
 
-private fun requireSeries(inner: StatSpec, op: String): SeriesStatSpec<*> {
-    require(inner is SeriesStatSpec<*>) {
-        "$op expects a SeriesStatSpec inner; got ${inner::class.simpleName}"
-    }
+/**
+ * Narrow a wrapper spec's inner spec to the modality the wrapper needs.
+ *
+ * Five of these existed, one per modality, with identical bodies - and the regression one sat a hundred
+ * and twenty lines away from its four siblings rather than beside them. The five names are kept because
+ * they read better at the ~50 call sites; only the repeated body is gone. `S::class.simpleName` derives
+ * the type name the message used to spell out, so the messages are unchanged.
+ *
+ * @param S the modality the wrapper requires of its inner spec.
+ * @param inner the inner spec to narrow.
+ * @param op the wrapper's own name, for the message.
+ */
+private inline fun <reified S : StatSpec> requireInner(inner: StatSpec, op: String): S {
+    require(inner is S) { "$op expects a ${S::class.simpleName} inner; got ${inner::class.simpleName}" }
     return inner
 }
 
-private fun requirePaired(inner: StatSpec, op: String): PairedStatSpec<*> {
-    require(inner is PairedStatSpec<*>) {
-        "$op expects a PairedStatSpec inner; got ${inner::class.simpleName}"
-    }
-    return inner
-}
+private fun requireSeries(inner: StatSpec, op: String): SeriesStatSpec<*> = requireInner(inner, op)
 
-private fun requireVector(inner: StatSpec, op: String): VectorStatSpec<*> {
-    require(inner is VectorStatSpec<*>) {
-        "$op expects a VectorStatSpec inner; got ${inner::class.simpleName}"
-    }
-    return inner
-}
+private fun requirePaired(inner: StatSpec, op: String): PairedStatSpec<*> = requireInner(inner, op)
 
-private fun requireDiscrete(inner: StatSpec, op: String): DiscreteStatSpec<*> {
-    require(inner is DiscreteStatSpec<*>) {
-        "$op expects a DiscreteStatSpec inner; got ${inner::class.simpleName}"
-    }
-    return inner
-}
+private fun requireVector(inner: StatSpec, op: String): VectorStatSpec<*> = requireInner(inner, op)
+
+private fun requireDiscrete(inner: StatSpec, op: String): DiscreteStatSpec<*> = requireInner(inner, op)
+
+private fun requireRegression(inner: StatSpec, op: String): RegressionStatSpec<*> = requireInner(inner, op)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
@@ -98,9 +98,6 @@ internal fun regressionSpecs(schema: StatSchema): List<BoundStat<*, out Regressi
 internal fun <S : Stat<*>> toSpec(key: StatKey<*>, stat: S): BoundStat<*, out S, *> =
     BoundStat(key as StatKey<Result>, stat as Stat<Result>) as BoundStat<*, out S, *>
 
-internal inline fun <reified S : Stat<*>> filterSpecs(specs: List<BoundStat<*, *, *>>): List<BoundStat<*, out S, *>> =
-    specs.mapNotNull { (key, stat) -> if (stat is S) toSpec(key, stat) else null }
-
 @Suppress("UNCHECKED_CAST")
 internal fun mergeEntry(values: GroupResult, key: StatKey<*>, stat: Stat<*>) {
     val result = values.results[key.name] ?: return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
@@ -67,9 +67,6 @@ fun StatSchemaDef.materializeDiscrete(
     bindDiscrete(name, config.materialize(concurrency))
 }
 
-// All five of these are `toSpec(StatKey(name), stat)` spelled out longhand - same package, same cast,
-// same suppression. Delegating drops five copies of the unchecked cast along with the five annotations
-// justifying it, and leaves one place where the erasure argument has to hold.
 private fun bind(name: String, stat: Stat<*>): BoundStat<*, *, *> = toSpec(StatKey<Result>(name), stat)
 
 private fun bindSeries(name: String, stat: SeriesStat<*>): BoundStat<*, out SeriesStat<*>, *> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
@@ -67,22 +67,19 @@ fun StatSchemaDef.materializeDiscrete(
     bindDiscrete(name, config.materialize(concurrency))
 }
 
-@Suppress("UNCHECKED_CAST")
-private fun bind(name: String, stat: Stat<*>): BoundStat<*, *, *> =
-    BoundStat(StatKey<Result>(name), stat as Stat<Result>) as BoundStat<*, *, *>
+// All five of these are `toSpec(StatKey(name), stat)` spelled out longhand - same package, same cast,
+// same suppression. Delegating drops five copies of the unchecked cast along with the five annotations
+// justifying it, and leaves one place where the erasure argument has to hold.
+private fun bind(name: String, stat: Stat<*>): BoundStat<*, *, *> = toSpec(StatKey<Result>(name), stat)
 
-@Suppress("UNCHECKED_CAST")
 private fun bindSeries(name: String, stat: SeriesStat<*>): BoundStat<*, out SeriesStat<*>, *> =
-    BoundStat(StatKey<Result>(name), stat as SeriesStat<Result>) as BoundStat<*, out SeriesStat<*>, *>
+    toSpec(StatKey<Result>(name), stat)
 
-@Suppress("UNCHECKED_CAST")
 private fun bindPaired(name: String, stat: PairedStat<*>): BoundStat<*, out PairedStat<*>, *> =
-    BoundStat(StatKey<Result>(name), stat as PairedStat<Result>) as BoundStat<*, out PairedStat<*>, *>
+    toSpec(StatKey<Result>(name), stat)
 
-@Suppress("UNCHECKED_CAST")
 private fun bindVector(name: String, stat: VectorStat<*>): BoundStat<*, out VectorStat<*>, *> =
-    BoundStat(StatKey<Result>(name), stat as VectorStat<Result>) as BoundStat<*, out VectorStat<*>, *>
+    toSpec(StatKey<Result>(name), stat)
 
-@Suppress("UNCHECKED_CAST")
 private fun bindDiscrete(name: String, stat: DiscreteStat<*>): BoundStat<*, out DiscreteStat<*>, *> =
-    BoundStat(StatKey<Result>(name), stat as DiscreteStat<Result>) as BoundStat<*, out DiscreteStat<*>, *>
+    toSpec(StatKey<Result>(name), stat)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
@@ -1,12 +1,9 @@
-@file:Suppress("UNCHECKED_CAST")
-
 package com.eignex.kumulant.schema.spec
 
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.BandResult
 import com.eignex.kumulant.schema.expr.*
-import com.eignex.kumulant.schema.spec.ResampleAggregator
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
@@ -4,6 +4,9 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.schema.BandResult
 import com.eignex.kumulant.schema.expr.*
+import com.eignex.kumulant.stream.DEFAULT_TARGET_HIGH
+import com.eignex.kumulant.stream.DEFAULT_TARGET_LOW
+import com.eignex.kumulant.stream.DEFAULT_WINDOW_SLICES
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -183,7 +186,7 @@ internal data class WindowedSeries(
     /** Total window span in milliseconds. */
     val durationMillis: Long,
     /** Number of equal-length buckets inside the window. */
-    val slices: Int = 10,
+    val slices: Int = DEFAULT_WINDOW_SLICES,
 ) : SeriesStatSpec<Result>
 
 /** Wire spec for `PairedStat.windowed(durationMillis, slices)`: sliding time window with [slices] buckets. */
@@ -195,7 +198,7 @@ internal data class WindowedPaired(
     /** Total window span in milliseconds. */
     val durationMillis: Long,
     /** Number of equal-length buckets inside the window. */
-    val slices: Int = 10,
+    val slices: Int = DEFAULT_WINDOW_SLICES,
 ) : PairedStatSpec<Result>
 
 /** Wire spec for `VectorStat.windowed(durationMillis, slices)`: sliding time window with [slices] buckets. */
@@ -207,7 +210,7 @@ internal data class WindowedVector(
     /** Total window span in milliseconds. */
     val durationMillis: Long,
     /** Number of equal-length buckets inside the window. */
-    val slices: Int = 10,
+    val slices: Int = DEFAULT_WINDOW_SLICES,
 ) : VectorStatSpec<Result>
 
 /** Wire spec for `DiscreteStat.windowed(durationMillis, slices)`: sliding time window with [slices] buckets. */
@@ -219,7 +222,7 @@ internal data class WindowedDiscrete(
     /** Total window span in milliseconds. */
     val durationMillis: Long,
     /** Number of equal-length buckets inside the window. */
-    val slices: Int = 10,
+    val slices: Int = DEFAULT_WINDOW_SLICES,
 ) : DiscreteStatSpec<Result>
 
 /** Wire spec for `SeriesStat.vectorized(dimensions)`: replicates a series stat across [dimensions] coordinates. */
@@ -617,9 +620,9 @@ internal data class MinMaxScalerVector(
     /** Number of vector coordinates. */
     val dimensions: Int,
     /** Lower bound of each coordinate's output range. */
-    val targetLow: Double = 0.0,
+    val targetLow: Double = DEFAULT_TARGET_LOW,
     /** Upper bound of each coordinate's output range. */
-    val targetHigh: Double = 1.0,
+    val targetHigh: Double = DEFAULT_TARGET_HIGH,
 ) : VectorStatSpec<Result>
 
 /**
@@ -645,9 +648,9 @@ internal data class MinMaxScalerRegression(
     /** Inner regression spec receiving the rescaled feature vector. */
     val inner: StatSpec,
     /** Lower bound of each coordinate's output range. */
-    val targetLow: Double = 0.0,
+    val targetLow: Double = DEFAULT_TARGET_LOW,
     /** Upper bound of each coordinate's output range. */
-    val targetHigh: Double = 1.0,
+    val targetHigh: Double = DEFAULT_TARGET_HIGH,
 ) : RegressionStatSpec<Result>
 
 /**
@@ -671,9 +674,9 @@ internal data class MinMaxScalerPaired(
     /** Inner paired spec receiving the rescaled pair. */
     val inner: StatSpec,
     /** Lower bound of each axis's output range. */
-    val targetLow: Double = 0.0,
+    val targetLow: Double = DEFAULT_TARGET_LOW,
     /** Upper bound of each axis's output range. */
-    val targetHigh: Double = 1.0,
+    val targetHigh: Double = DEFAULT_TARGET_HIGH,
 ) : PairedStatSpec<Result>
 
 /**
@@ -700,9 +703,9 @@ internal data class MinMaxScalerSeries(
     /** Inner spec receiving the rescaled value. */
     val inner: StatSpec,
     /** Lower bound of the output range. */
-    val targetLow: Double = 0.0,
+    val targetLow: Double = DEFAULT_TARGET_LOW,
     /** Upper bound of the output range. */
-    val targetHigh: Double = 1.0,
+    val targetHigh: Double = DEFAULT_TARGET_HIGH,
 ) : SeriesStatSpec<Result>
 
 /** Wire spec for `SeriesStat.sample(rate, random)`: forwards each update with probability [rate]. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
@@ -416,10 +416,9 @@ data class ConfusionMatrix(
 /**
  * Spec for `AccuracyStat`: weighted classification accuracy over (predictedClass, trueClass).
  *
- * Was a `data object`. It gained [numClasses] because the stat did: accuracy is only comparable with
- * `ConfusionMatrix` over the same stream if both agree on which labels name a class, and that agreement
- * needs a bound. A payload authored against the old shape will fail to decode, which is the intended
- * outcome - the alternative is silently defaulting a bound and scoring labels the author never declared.
+ * [numClasses] is required rather than defaulted: accuracy is only comparable with `ConfusionMatrix` over
+ * the same stream if both bound the labels the same way, and defaulting a bound would silently score
+ * labels the author never declared.
  */
 @Serializable
 @SerialName("Accuracy")

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
@@ -413,10 +413,20 @@ data class ConfusionMatrix(
     val numClasses: Int,
 ) : PairedStatSpec<ConfusionMatrixResult>
 
-/** Spec for `AccuracyStat`: weighted classification accuracy over (predictedClass, trueClass). */
+/**
+ * Spec for `AccuracyStat`: weighted classification accuracy over (predictedClass, trueClass).
+ *
+ * Was a `data object`. It gained [numClasses] because the stat did: accuracy is only comparable with
+ * `ConfusionMatrix` over the same stream if both agree on which labels name a class, and that agreement
+ * needs a bound. A payload authored against the old shape will fail to decode, which is the intended
+ * outcome - the alternative is silently defaulting a bound and scoring labels the author never declared.
+ */
 @Serializable
 @SerialName("Accuracy")
-data object Accuracy : PairedStatSpec<WeightedMeanResult>
+data class Accuracy(
+    /** Number of classes; class indices are `[0, numClasses)`. */
+    val numClasses: Int,
+) : PairedStatSpec<WeightedMeanResult>
 
 /** Spec for `HyperLogLogStat`: cardinality sketch with controllable [precision]. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
@@ -65,7 +66,7 @@ data class HalfSpaceTreesResult(
     private val numLeaves: Int get() = 1 shl height
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(numTrees > 0) { "numTrees must be positive" }
         require(height > 0) { "height must be positive" }
         require(featureIndices.size == numTrees * numInternal) {
@@ -154,7 +155,7 @@ class HalfSpaceTreesStat(
 ) : VectorStat<HalfSpaceTreesResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(featureRanges.size == featureSize) {
             "featureRanges must have length $featureSize; got ${featureRanges.size}"
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -90,21 +90,10 @@ data class HalfSpaceTreesResult(
         var total = 0.0
         val depthFactor = 1 shl height
         for (t in 0 until numTrees) {
-            val leafIdx = routeToLeaf(t, x)
+            val leafIdx = routeToLeaf(featureIndices, thresholds, height, numInternal, t, x)
             total += referenceMass[t * numLeaves + leafIdx] * depthFactor
         }
         return total
-    }
-
-    private fun routeToLeaf(treeIdx: Int, x: VectorView): Int {
-        val treeOffset = treeIdx * numInternal
-        var node = 0
-        repeat(height) {
-            val featureIdx = featureIndices[treeOffset + node]
-            val threshold = thresholds[treeOffset + node]
-            node = if (x[featureIdx] < threshold) 2 * node + 1 else 2 * node + 2
-        }
-        return node - numInternal
     }
 
     override fun equals(other: Any?): Boolean = other is HalfSpaceTreesResult &&
@@ -221,7 +210,7 @@ class HalfSpaceTreesStat(
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }
         if (weight.isNotPositiveWeight()) return
         for (t in 0 until numTrees) {
-            val leafIdx = routeToLeaf(t, vector)
+            val leafIdx = routeToLeaf(featureIndices, thresholds, height, numInternal, t, vector)
             latestMass.add(t * numLeaves + leafIdx, weight)
         }
         totalWeightsCell.add(weight)
@@ -237,17 +226,6 @@ class HalfSpaceTreesStat(
             referenceMass.store(i, latest)
             latestMass.store(i, 0.0)
         }
-    }
-
-    private fun routeToLeaf(treeIdx: Int, x: VectorView): Int {
-        val treeOffset = treeIdx * numInternal
-        var node = 0
-        repeat(height) {
-            val featureIdx = featureIndices[treeOffset + node]
-            val threshold = thresholds[treeOffset + node]
-            node = if (x[featureIdx] < threshold) 2 * node + 1 else 2 * node + 2
-        }
-        return node - numInternal
     }
 
     override fun read(timestampNanos: Long): HalfSpaceTreesResult = HalfSpaceTreesResult(
@@ -317,4 +295,31 @@ class HalfSpaceTreesStat(
         /** 2^30 leaves is already far past anything useful and keeps `1 shl height` positive. */
         const val MAX_HEIGHT = 30
     }
+}
+
+/**
+ * Walk [x] down one tree to its leaf, returning the leaf's index within that tree.
+ *
+ * The result class and the stat carried this identically - same text, same variable names - over
+ * identically-named fields. Scoring routes through the result's copy and updating through the stat's,
+ * so the two had to agree exactly or a mass bucket would be credited on update and read back from a
+ * different one, which shows up as a score that drifts for no visible reason. The `2n+1 / 2n+2`
+ * heap layout and the `- numInternal` rebase to leaf-space are the parts that must not diverge.
+ */
+private fun routeToLeaf(
+    featureIndices: IntArray,
+    thresholds: DoubleArray,
+    height: Int,
+    numInternal: Int,
+    treeIdx: Int,
+    x: VectorView,
+): Int {
+    val treeOffset = treeIdx * numInternal
+    var node = 0
+    repeat(height) {
+        val featureIdx = featureIndices[treeOffset + node]
+        val threshold = thresholds[treeOffset + node]
+        node = if (x[featureIdx] < threshold) 2 * node + 1 else 2 * node + 2
+    }
+    return node - numInternal
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -103,9 +103,8 @@ class IsotonicCalibratorStat(
 
     override fun read(timestampNanos: Long): IsotonicCalibratorResult {
         val r = inner.read(timestampNanos)
-        val raw = DoubleArray(numBins) {
-            if (r.totalWeights[it] > 0.0) r.sumOutcome[it] / r.totalWeights[it] else Double.NaN
-        }
+        // ReliabilityResult already derives this, with the same zero-weight NaN convention.
+        val raw = r.outcomeRate
         val weights = r.totalWeights
         val midpoints = DoubleArray(numBins) { (it + 0.5) / numBins }
         val monotone = pav(raw, weights)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.calibration
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.requirePositiveBins
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,7 +31,7 @@ data class IsotonicCalibratorResult(
 ) : HasObservationCount {
 
     init {
-        require(numBins > 0) { "numBins must be > 0; got $numBins" }
+        requirePositiveBins(numBins)
         require(binMidpoints.size == numBins && probabilities.size == numBins) {
             "binMidpoints and probabilities must have length $numBins"
         }
@@ -93,7 +94,7 @@ class IsotonicCalibratorStat(
 ) : PairedStat<IsotonicCalibratorResult> {
 
     init {
-        require(numBins > 0) { "numBins must be > 0; got $numBins" }
+        requirePositiveBins(numBins)
     }
 
     private val inner = ReliabilityStat(numBins, concurrency)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
@@ -10,9 +10,9 @@ import com.eignex.kumulant.stat.regression.glm.ConstantRate
 import com.eignex.kumulant.stat.regression.glm.Link
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import com.eignex.kumulant.stat.regression.glm.sigmoid
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.exp
 
 /**
  * Snapshot from [PlattCalibratorStat]: the learned sigmoid parameters and a
@@ -32,10 +32,7 @@ data class PlattCalibratorResult(
 ) : HasObservationCount {
 
     /** Calibrated probability for raw score [x] via `sigmoid(slope * x + intercept)`. */
-    fun calibrate(x: Double): Double {
-        val eta = slope * x + intercept
-        return if (eta >= 0.0) 1.0 / (1.0 + exp(-eta)) else exp(eta) / (1.0 + exp(eta))
-    }
+    fun calibrate(x: Double): Double = sigmoid(slope * x + intercept)
 }
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requirePositiveBins
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
@@ -106,7 +107,7 @@ class ReliabilityStat(val numBins: Int, override val concurrency: Concurrency = 
     PairedStat<ReliabilityResult> {
 
     init {
-        require(numBins > 0) { "numBins must be > 0; got $numBins" }
+        requirePositiveBins(numBins)
     }
 
     private val mode = concurrency.additiveMode()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
+import com.eignex.kumulant.stat.sketch.requireSameHasher
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.casMax
@@ -136,9 +137,7 @@ class HyperLogLogStat(
     }
 
     override fun merge(values: HyperLogLogResult) {
-        require(values.hasher == hasherRef) {
-            "Cannot merge HyperLogLogStat hashed with ${values.hasher} into one hashed with $hasherRef"
-        }
+        requireSameHasher("HyperLogLogStat", values.hasher, hasherRef)
         // Shape before array length. `m` is derived from `precision`, so checking the register count
         // first made the precision message unreachable: a payload from a differently-sized sketch was
         // reported as the wrong number of registers rather than as the wrong precision, which is the

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -138,11 +138,9 @@ class HyperLogLogStat(
 
     override fun merge(values: HyperLogLogResult) {
         requireSameHasher("HyperLogLogStat", values.hasher, hasherRef)
-        // Shape before array length. `m` is derived from `precision`, so checking the register count
-        // first made the precision message unreachable: a payload from a differently-sized sketch was
-        // reported as the wrong number of registers rather than as the wrong precision, which is the
-        // thing the caller actually got wrong. BloomFilterStat and CountMinSketchStat already order it
-        // this way; these three did not.
+        // Shape before array length: `m` is derived from `precision`, so checking the register count
+        // first would report a differently-sized sketch as the wrong register count rather than the
+        // wrong precision, which is what the caller actually got wrong.
         require(values.precision == precision) {
             "Cannot merge HyperLogLogStat with precision ${values.precision} into $precision"
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/HyperLogLogStat.kt
@@ -139,11 +139,16 @@ class HyperLogLogStat(
         require(values.hasher == hasherRef) {
             "Cannot merge HyperLogLogStat hashed with ${values.hasher} into one hashed with $hasherRef"
         }
-        require(values.registers.size == m) {
-            "Cannot merge HyperLogLogStat: expected $m registers, got ${values.registers.size}"
-        }
+        // Shape before array length. `m` is derived from `precision`, so checking the register count
+        // first made the precision message unreachable: a payload from a differently-sized sketch was
+        // reported as the wrong number of registers rather than as the wrong precision, which is the
+        // thing the caller actually got wrong. BloomFilterStat and CountMinSketchStat already order it
+        // this way; these three did not.
         require(values.precision == precision) {
             "Cannot merge HyperLogLogStat with precision ${values.precision} into $precision"
+        }
+        require(values.registers.size == m) {
+            "Cannot merge HyperLogLogStat: expected $m registers, got ${values.registers.size}"
         }
         for (i in 0 until m) {
             val incoming = values.registers[i].toLong()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -129,11 +129,13 @@ class LinearCountingStat(
         require(values.hasher == hasherRef) {
             "Cannot merge LinearCountingStat hashed with ${values.hasher} into one hashed with $hasherRef"
         }
-        require(values.words.size == wordCount) {
-            "Cannot merge LinearCountingStat: expected $wordCount words, got ${values.words.size}"
-        }
+        // Shape before array length; see HyperLogLogStat.merge. `wordCount` is `bits / 64`, so the
+        // bits message was unreachable for any self-consistent payload.
         require(values.bits == bits) {
             "Cannot merge LinearCountingStat with bits=${values.bits} into $bits"
+        }
+        require(values.words.size == wordCount) {
+            "Cannot merge LinearCountingStat: expected $wordCount words, got ${values.words.size}"
         }
         for (i in 0 until wordCount) {
             val incoming = values.words[i]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.preview
 import com.eignex.kumulant.math.HasherRef
 import com.eignex.kumulant.math.LongHasher
 import com.eignex.kumulant.math.SplitMix64
+import com.eignex.kumulant.stat.sketch.requireSameHasher
 import com.eignex.kumulant.stream.StreamLong
 import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.casOr
@@ -126,9 +127,7 @@ class LinearCountingStat(
     }
 
     override fun merge(values: LinearCountingResult) {
-        require(values.hasher == hasherRef) {
-            "Cannot merge LinearCountingStat hashed with ${values.hasher} into one hashed with $hasherRef"
-        }
+        requireSameHasher("LinearCountingStat", values.hasher, hasherRef)
         // Shape before array length; see HyperLogLogStat.merge. `wordCount` is `bits / 64`, so the
         // bits message was unreachable for any self-consistent payload.
         require(values.bits == bits) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStat.kt
@@ -128,8 +128,7 @@ class LinearCountingStat(
 
     override fun merge(values: LinearCountingResult) {
         requireSameHasher("LinearCountingStat", values.hasher, hasherRef)
-        // Shape before array length; see HyperLogLogStat.merge. `wordCount` is `bits / 64`, so the
-        // bits message was unreachable for any self-consistent payload.
+        // Shape before array length; see HyperLogLogStat.merge. `wordCount` is `bits / 64`.
         require(values.bits == bits) {
             "Cannot merge LinearCountingStat with bits=${values.bits} into $bits"
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
@@ -5,10 +5,10 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.monotonicMode
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /** Snapshot from a two-sided [CusumStat] change-point detector. */
 @Serializable
@@ -76,6 +76,14 @@ class CusumStat(
     private val cusumPos = streamMode.newDouble(0.0)
     private val cusumNeg = streamMode.newDouble(0.0)
 
+    /**
+     * Whether anything has landed yet, which the two cells cannot tell us on their own.
+     *
+     * `cusumPos` clamps at zero and `cusumNeg` at zero from below, so "no observation yet" and "the
+     * drift has walked back to zero" are the same pair of numbers. [merge] has to distinguish them.
+     */
+    private val initialized = streamMode.newLong(0L)
+
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         val deviation = value - target
@@ -89,24 +97,33 @@ class CusumStat(
             val next = min(0.0, prev + deviation + referenceValue)
             if (cusumNeg.compareAndSet(prev, next)) break
         }
+        initialized.store(1L)
     }
 
     override fun merge(values: CusumResult) {
+        // Adopt the snapshot verbatim while empty, matching RecursiveVarianceStat.merge, HoltStat.merge
+        // and SeasonalSmoothingStat.merge. Averaging against a fresh stat's 0.0 halved the incoming
+        // drift, and halving the drift is not a rounding matter here: `alarmUp` compares the cumulative
+        // sum against `threshold`, so a coordinator that merged a worker's snapshot needed twice the
+        // real shift before it would fire. The baselines were merged exactly, which hid it further.
+        val empty = initialized.load() == 0L
         while (true) {
             val prev = cusumPos.load()
-            val next = 0.5 * (prev + values.cusumPositive)
+            val next = if (empty) values.cusumPositive else 0.5 * (prev + values.cusumPositive)
             if (cusumPos.compareAndSet(prev, next)) break
         }
         while (true) {
             val prev = cusumNeg.load()
-            val next = 0.5 * (prev + values.cusumNegative)
+            val next = if (empty) values.cusumNegative else 0.5 * (prev + values.cusumNegative)
             if (cusumNeg.compareAndSet(prev, next)) break
         }
+        initialized.store(1L)
     }
 
     override fun reset() {
         cusumPos.store(0.0)
         cusumNeg.store(0.0)
+        initialized.store(0L)
     }
 
     override fun read(timestampNanos: Long): CusumResult {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
@@ -5,10 +5,10 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.monotonicMode
-import kotlin.math.max
-import kotlin.math.min
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.math.max
+import kotlin.math.min
 
 /** Snapshot from a two-sided [CusumStat] change-point detector. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
@@ -102,10 +102,8 @@ class CusumStat(
 
     override fun merge(values: CusumResult) {
         // Adopt the snapshot verbatim while empty, matching RecursiveVarianceStat.merge, HoltStat.merge
-        // and SeasonalSmoothingStat.merge. Averaging against a fresh stat's 0.0 halved the incoming
-        // drift, and halving the drift is not a rounding matter here: `alarmUp` compares the cumulative
-        // sum against `threshold`, so a coordinator that merged a worker's snapshot needed twice the
-        // real shift before it would fire. The baselines were merged exactly, which hid it further.
+        // and SeasonalSmoothingStat.merge. Averaging against a fresh stat's zero would halve the incoming
+        // drift, and `alarmUp` thresholds on that sum directly, so the alarm would need twice the shift.
         val empty = initialized.load() == 0L
         while (true) {
             val prev = cusumPos.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
@@ -117,10 +117,8 @@ class PageHinkleyStat(
             (mean.load() * localCount + values.mean * incomingCount) / combinedCount.toDouble()
         count.store(combinedCount)
         mean.store(combinedMean)
-        // Adopt verbatim while empty. The mean above already does this implicitly - a `localCount` of
-        // zero weights it out - but the drift cells did not, so a fresh coordinator merging a worker's
-        // snapshot halved exactly the two quantities `alarmUp`/`alarmDown` threshold against while
-        // taking the mean and both extremes exactly. Same defect RecursiveVarianceStat.merge records.
+        // Adopt verbatim while empty, as the count-weighted mean above already does implicitly. Halving
+        // these would halve exactly the two quantities `alarmUp`/`alarmDown` threshold against.
         val empty = localCount == 0L
         cumPos.store(if (empty) values.cumulativePositive else 0.5 * (cumPos.load() + values.cumulativePositive))
         cumNeg.store(if (empty) values.cumulativeNegative else 0.5 * (cumNeg.load() + values.cumulativeNegative))

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
@@ -7,10 +7,10 @@ import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /** Snapshot from a [PageHinkleyStat] change-point detector. */
 @Serializable
@@ -117,8 +117,13 @@ class PageHinkleyStat(
             (mean.load() * localCount + values.mean * incomingCount) / combinedCount.toDouble()
         count.store(combinedCount)
         mean.store(combinedMean)
-        cumPos.store(0.5 * (cumPos.load() + values.cumulativePositive))
-        cumNeg.store(0.5 * (cumNeg.load() + values.cumulativeNegative))
+        // Adopt verbatim while empty. The mean above already does this implicitly - a `localCount` of
+        // zero weights it out - but the drift cells did not, so a fresh coordinator merging a worker's
+        // snapshot halved exactly the two quantities `alarmUp`/`alarmDown` threshold against while
+        // taking the mean and both extremes exactly. Same defect RecursiveVarianceStat.merge records.
+        val empty = localCount == 0L
+        cumPos.store(if (empty) values.cumulativePositive else 0.5 * (cumPos.load() + values.cumulativePositive))
+        cumNeg.store(if (empty) values.cumulativeNegative else 0.5 * (cumNeg.load() + values.cumulativeNegative))
         minPos.store(min(minPos.load(), values.minPositive))
         maxNeg.store(max(maxNeg.load(), values.maxNegative))
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
@@ -7,10 +7,10 @@ import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
-import kotlin.math.max
-import kotlin.math.min
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.math.max
+import kotlin.math.min
 
 /** Snapshot from a [PageHinkleyStat] change-point detector. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayWeighting.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayWeighting.kt
@@ -69,3 +69,22 @@ fun halfLife(halfLife: Duration): DecayWeighting.HalfLife = DecayWeighting.HalfL
 
 /** Shorthand for [DecayWeighting.Alpha] - usable as a shared weighting across stats. */
 fun alpha(alpha: Double): DecayWeighting.Alpha = DecayWeighting.Alpha(alpha)
+
+/**
+ * Divide a biased accumulator by its [DecayWeighting.correction], reporting an unmoved accumulator as
+ * zero.
+ *
+ * Three getters across [EwmaMeanStat] and [EwmaVarianceStat] spelled this out. The zero branch is
+ * reachable only for `alpha == 0.0` - no smoothing at all - where the accumulator has never left zero and
+ * the ratio is 0/0; reporting the accumulator beats reporting NaN. `EwmaMeanStat` records that the two
+ * stats "used to disagree here", and the fix was applied by copying rather than by extracting, which
+ * left the mean version carrying an extra `w == 0.0` guard the variance version does without. That guard
+ * was redundant either way, since `correction(0.0)` is already `0.0`.
+ *
+ * An extension rather than an interface member: [DecayWeighting] is public API, and this is a convenience
+ * for three internal call sites, not something the sealed hierarchy should publish.
+ */
+internal fun DecayWeighting.debias(biased: Double, totalWeight: Double): Double {
+    val correction = correction(totalWeight)
+    return if (correction == 0.0) 0.0 else biased / correction
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayWeighting.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayWeighting.kt
@@ -74,15 +74,11 @@ fun alpha(alpha: Double): DecayWeighting.Alpha = DecayWeighting.Alpha(alpha)
  * Divide a biased accumulator by its [DecayWeighting.correction], reporting an unmoved accumulator as
  * zero.
  *
- * Three getters across [EwmaMeanStat] and [EwmaVarianceStat] spelled this out. The zero branch is
- * reachable only for `alpha == 0.0` - no smoothing at all - where the accumulator has never left zero and
- * the ratio is 0/0; reporting the accumulator beats reporting NaN. `EwmaMeanStat` records that the two
- * stats "used to disagree here", and the fix was applied by copying rather than by extracting, which
- * left the mean version carrying an extra `w == 0.0` guard the variance version does without. That guard
- * was redundant either way, since `correction(0.0)` is already `0.0`.
+ * The zero branch is reachable only for `alpha == 0.0` - no smoothing at all - where the accumulator has
+ * never left zero and the ratio is 0/0. Reporting the accumulator beats reporting NaN.
  *
- * An extension rather than an interface member: [DecayWeighting] is public API, and this is a convenience
- * for three internal call sites, not something the sealed hierarchy should publish.
+ * An extension rather than an interface member, so the public [DecayWeighting] hierarchy does not publish
+ * a convenience for internal callers.
  */
 internal fun DecayWeighting.debias(biased: Double, totalWeight: Double): Double {
     val correction = correction(totalWeight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
@@ -51,14 +51,7 @@ class EwmaMeanStat(
 
     private val mean: Double
         get() {
-            val biased = biasedMean.load()
-            val w = totalWeights.load()
-            if (w == 0.0) return 0.0
-            val correction = weighting.correction(w)
-            // Reachable only for `alpha == 0.0`, i.e. no smoothing at all, where `biasedMean` has
-            // never moved off zero and the ratio is 0/0. Report the unmoved accumulator rather than
-            // NaN, matching EwmaVarianceStat on the same state; the two used to disagree here.
-            return if (correction == 0.0) 0.0 else biased / correction
+            return weighting.debias(biasedMean.load(), totalWeights.load())
         }
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
@@ -49,16 +49,12 @@ class EwmaVarianceStat(
 
     private val mean: Double
         get() {
-            val biased = biasedMean.load()
-            val correction = weighting.correction(totalWeights.load())
-            return if (correction == 0.0) 0.0 else biased / correction
+            return weighting.debias(biasedMean.load(), totalWeights.load())
         }
 
     private val variance: Double
         get() {
-            val biasedVar = biasedM2.load()
-            val correction = weighting.correction(totalWeights.load())
-            return if (correction == 0.0) 0.0 else biasedVar / correction
+            return weighting.debias(biasedM2.load(), totalWeights.load())
         }
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/DampedTrend.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/DampedTrend.kt
@@ -5,13 +5,8 @@ import kotlin.math.pow
 /**
  * The damped-trend multiplier `phi + phi^2 + ... + phi^steps`, in closed form.
  *
- * [HoltStat] and [SeasonalSmoothingStat] each carried this, along with the `phi == 1.0` special case
- * where the series degenerates to `steps` and the closed form would divide by zero.
- *
- * The closed form is not an optimisation detail to be rediscovered: `HoltStat` records that the loop it
- * replaced made `forecast(Int.MAX_VALUE)` stall for seconds. A second copy is a second place for that to
- * come back, and the two had already drifted in shape - Holt returned early on `phi == 1.0` while the
- * seasonal version folded the case into the sum - which is how a fix lands on one and not the other.
+ * Closed form rather than a loop so `forecast(Int.MAX_VALUE)` is O(1). At `phi == 1.0` the series
+ * degenerates to `steps` and the closed form would divide by zero, hence the special case.
  */
 internal fun dampedTrendSum(phi: Double, steps: Int): Double =
     if (phi == 1.0) steps.toDouble() else phi * (1.0 - phi.pow(steps.toDouble())) / (1.0 - phi)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/DampedTrend.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/DampedTrend.kt
@@ -1,0 +1,27 @@
+package com.eignex.kumulant.stat.forecast
+
+import kotlin.math.pow
+
+/**
+ * The damped-trend multiplier `phi + phi^2 + ... + phi^steps`, in closed form.
+ *
+ * [HoltStat] and [SeasonalSmoothingStat] each carried this, along with the `phi == 1.0` special case
+ * where the series degenerates to `steps` and the closed form would divide by zero.
+ *
+ * The closed form is not an optimisation detail to be rediscovered: `HoltStat` records that the loop it
+ * replaced made `forecast(Int.MAX_VALUE)` stall for seconds. A second copy is a second place for that to
+ * come back, and the two had already drifted in shape - Holt returned early on `phi == 1.0` while the
+ * seasonal version folded the case into the sum - which is how a fix lands on one and not the other.
+ */
+internal fun dampedTrendSum(phi: Double, steps: Int): Double =
+    if (phi == 1.0) steps.toDouble() else phi * (1.0 - phi.pow(steps.toDouble())) / (1.0 - phi)
+
+/** Guards the damping factor. Zero is excluded: it would erase the trend term rather than damp it. */
+internal fun requirePhi(phi: Double) {
+    require(phi > 0.0 && phi <= 1.0) { "phi must be in (0, 1], got $phi" }
+}
+
+/** Guards a forecast horizon. Zero is allowed and means "the current level". */
+internal fun requireForecastSteps(steps: Int) {
+    require(steps >= 0) { "forecast steps must be >= 0, got $steps" }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/HoltStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/HoltStat.kt
@@ -10,7 +10,6 @@ import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.pow
 
 /**
  * Snapshot from a [HoltStat]: the current level and trend plus the damping factor.
@@ -33,13 +32,9 @@ data class HoltResult(
      * `phi == 1.0` it collapses to `level + steps * trend`.
      */
     fun forecast(steps: Int): Double {
-        require(steps >= 0) { "forecast steps must be >= 0, got $steps" }
+        requireForecastSteps(steps)
         if (steps == 0) return level
-        if (phi == 1.0) return level + steps.toDouble() * trend
-        // Closed form of the geometric series, as the comment always claimed: looping `steps` times
-        // made forecast(Int.MAX_VALUE) stall for seconds for no gain in accuracy.
-        val sum = phi * (1.0 - phi.pow(steps.toDouble())) / (1.0 - phi)
-        return level + sum * trend
+        return level + dampedTrendSum(phi, steps) * trend
     }
 }
 
@@ -90,7 +85,7 @@ class HoltStat(
     ) : this(DecayWeighting.Alpha(alpha), DecayWeighting.Alpha(beta), phi, concurrency)
 
     init {
-        require(phi > 0.0 && phi <= 1.0) { "phi must be in (0, 1], got $phi" }
+        requirePhi(phi)
     }
 
     /** Level smoothing factor; larger weights recent samples more. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -147,13 +147,7 @@ class SeasonalSmoothingStat(
     private val level = streamMode.newDouble(0.0)
     private val trend = streamMode.newDouble(0.0)
 
-    /**
-     * The seasonal identity: 1.0 multiplicatively, 0.0 additively.
-     *
-     * Was a `streamMode.newDouble` cell - an atomic or striped allocation holding a value fixed at
-     * construction - read exactly once, on the line below. `reset` then recomputed the same expression
-     * rather than reading it, so the identity was written twice sixty lines apart.
-     */
+    /** The seasonal identity: 1.0 multiplicatively, 0.0 additively. Used by the initialiser and `reset`. */
     private val seasonIdentity: Double = if (mode == SeasonalMode.Multiplicative) 1.0 else 0.0
     private val seasons = streamMode.newDoubleArray(period) { seasonIdentity }
     private val slot = streamMode.newLong(0L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -148,8 +148,16 @@ class SeasonalSmoothingStat(
     private val initialized = streamMode.newLong(0L)
     private val level = streamMode.newDouble(0.0)
     private val trend = streamMode.newDouble(0.0)
-    private val seasonInit = streamMode.newDouble(if (mode == SeasonalMode.Multiplicative) 1.0 else 0.0)
-    private val seasons = streamMode.newDoubleArray(period) { seasonInit.load() }
+
+    /**
+     * The seasonal identity: 1.0 multiplicatively, 0.0 additively.
+     *
+     * Was a `streamMode.newDouble` cell - an atomic or striped allocation holding a value fixed at
+     * construction - read exactly once, on the line below. `reset` then recomputed the same expression
+     * rather than reading it, so the identity was written twice sixty lines apart.
+     */
+    private val seasonIdentity: Double = if (mode == SeasonalMode.Multiplicative) 1.0 else 0.0
+    private val seasons = streamMode.newDoubleArray(period) { seasonIdentity }
     private val slot = streamMode.newLong(0L)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
@@ -216,7 +224,7 @@ class SeasonalSmoothingStat(
         level.store(0.0)
         trend.store(0.0)
         slot.store(0L)
-        val identity = if (mode == SeasonalMode.Multiplicative) 1.0 else 0.0
+        val identity = seasonIdentity
         for (i in 0 until period) seasons.store(i, identity)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -10,7 +10,6 @@ import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.pow
 
 /** Additive vs multiplicative seasonal coupling. */
 @Serializable
@@ -48,10 +47,9 @@ data class SeasonalSmoothingResult(
      * wraps around the [seasons] vector.
      */
     fun forecast(steps: Int): Double {
-        require(steps >= 0) { "forecast steps must be >= 0, got $steps" }
+        requireForecastSteps(steps)
         if (steps == 0) return level
-        val sum = if (phi == 1.0) steps.toDouble() else phi * (1.0 - phi.pow(steps.toDouble())) / (1.0 - phi)
-        val trendPart = level + sum * trend
+        val trendPart = level + dampedTrendSum(phi, steps) * trend
         val seasonIndex = ((currentSlot + steps - 1) % period + period) % period
         val seasonFactor = seasons[seasonIndex]
         return when (mode) {
@@ -131,7 +129,7 @@ class SeasonalSmoothingStat(
 
     init {
         require(period >= 2) { "period must be >= 2, got $period" }
-        require(phi > 0.0 && phi <= 1.0) { "phi must be in (0, 1], got $phi" }
+        requirePhi(phi)
     }
 
     /** Level smoothing factor. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -116,7 +116,7 @@ class DDSketchStat(
     )
 
     override fun merge(values: SketchResult) {
-        require(abs(this.gamma - values.gamma) < 1e-9) {
+        require(abs(this.gamma - values.gamma) < PARAMETER_MATCH_TOLERANCE) {
             "Cannot merge DDSketches with different relative error targets"
         }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -164,7 +164,8 @@ class DDSketchStat(
             // sketch that genuinely observed zeros, so an untouched sketch used to render as a
             // p99 of 0.0 - which reads as excellent latency rather than as no data. AucStat
             // already returned NaN in the same situation. Callers who want to branch rather
-            // than propagate NaN can check [SketchResult.isEmpty].
+            // than propagate NaN can check `isEmpty` on the result, which every HasObservationCount
+            // gets as an extension.
             computedQuantiles.fill(Double.NaN)
             return SketchResult(
                 probabilities = probabilities,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -164,8 +164,7 @@ class DDSketchStat(
             // sketch that genuinely observed zeros, so an untouched sketch used to render as a
             // p99 of 0.0 - which reads as excellent latency rather than as no data. AucStat
             // already returned NaN in the same situation. Callers who want to branch rather
-            // than propagate NaN can check `isEmpty` on the result, which every HasObservationCount
-            // gets as an extension.
+            // than propagate NaN can check `isEmpty` on the result.
             computedQuantiles.fill(Double.NaN)
             return SketchResult(
                 probabilities = probabilities,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
@@ -72,7 +72,6 @@ class HdrHistogramStat(
             emptyArray(),
         ),
     )
-    private val totalWeights = mode.newDouble(0.0)
 
     private fun createState(internalHighest: Long, oldCounts: Array<StreamDouble>): State {
         // Ensure the internal highest is at least 2 to prevent bitwise math collapse
@@ -129,8 +128,6 @@ class HdrHistogramStat(
         // Scale the incoming floating-point value to an internal integer
         val internalValue = (value * multiplier).toLong()
 
-        totalWeights.add(weight)
-
         while (true) {
             val state = stateRef.load()
 
@@ -161,7 +158,6 @@ class HdrHistogramStat(
     }
 
     override fun reset() {
-        totalWeights.store(0.0)
         while (true) {
             val state = stateRef.load()
             val fresh = createState(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
@@ -122,7 +122,7 @@ class LinearHistogramStat(
         if (abs(span - binWidth) > binWidth * 1e-12) return false
         val ratio = (lo - lowerBound) / binWidth
         val rounded = round(ratio)
-        return abs(ratio - rounded) < 1e-9 && rounded >= 0.0 && rounded < binCount
+        return abs(ratio - rounded) < BIN_ALIGNMENT_TOLERANCE && rounded >= 0.0 && rounded < binCount
     }
 
     override fun reset() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
@@ -52,14 +52,21 @@ class LinearHistogramStat(
     private val binWidth: Double = (upperBound - lowerBound) / binCount
 
     private val mode = concurrency.additiveMode()
-    private val totalWeights = mode.newDouble(0.0)
     private val underflow = mode.newDouble(0.0)
     private val overflow = mode.newDouble(0.0)
     private val bins = ArrayBins(mode)
 
+    /**
+     * The bin a value falls in, clamped to the array.
+     *
+     * Written out twice, in `update` and in `merge`. The two have to agree exactly or a merged bucket
+     * lands somewhere a directly-observed value of the same magnitude would not, which shows up as a
+     * histogram that disagrees with itself depending on how the observations arrived.
+     */
+    private fun binOf(value: Double): Int = ((value - lowerBound) / binWidth).toInt().coerceIn(0, binCount - 1)
+
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isNotPositiveWeight()) return
-        totalWeights.add(weight)
 
         when {
             value < lowerBound -> underflow.add(weight)
@@ -67,8 +74,7 @@ class LinearHistogramStat(
             value >= upperBound -> overflow.add(weight)
 
             else -> {
-                val idx = ((value - lowerBound) / binWidth).toInt().coerceIn(0, binCount - 1)
-                bins.add(idx, weight)
+                bins.add(binOf(value), weight)
             }
         }
     }
@@ -88,19 +94,15 @@ class LinearHistogramStat(
             val hi = values.upperBounds[i]
             when {
                 !lo.isFinite() && hi == lowerBound -> {
-                    totalWeights.add(w)
                     underflow.add(w)
                 }
 
                 lo == upperBound && !hi.isFinite() -> {
-                    totalWeights.add(w)
                     overflow.add(w)
                 }
 
                 lo.isFinite() && hi.isFinite() && matchesLayout(lo, hi) -> {
-                    totalWeights.add(w)
-                    val idx = ((lo - lowerBound) / binWidth).toInt().coerceIn(0, binCount - 1)
-                    bins.add(idx, w)
+                    bins.add(binOf(lo), w)
                 }
 
                 else -> {
@@ -124,7 +126,6 @@ class LinearHistogramStat(
     }
 
     override fun reset() {
-        totalWeights.store(0.0)
         underflow.store(0.0)
         overflow.store(0.0)
         bins.clear()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -143,21 +143,16 @@ fun SketchResult.toSparseHistogram(): SparseHistogramResult {
 /**
  * How close two sketch parameters must be before a merge is allowed.
  *
- * [DDSketchStat] compares relative-error targets and [TDigestStat] compares compressions, both against a
- * bare `1e-9`. The comparison is approximate rather than exact because these are `Double`s that may have
- * round-tripped through a wire format, so a sketch merged with a re-decoded copy of itself must still be
- * accepted. It is not a numerical tolerance on the *estimate* - a genuinely different parameter means
- * incompatible bucket layouts and no error bound at all, so anything past this is refused outright.
- *
- * Named because `1e-9` appears in this package with three unrelated meanings: this, the bin-alignment
- * check in [LinearHistogramStat], and [DDSketchStat]'s default `minIndexableValue`.
+ * Approximate rather than exact because these are `Double`s that may have round-tripped through a wire
+ * format, so a sketch must still merge with a re-decoded copy of itself. Not a tolerance on the estimate:
+ * a genuinely different parameter means incompatible bucket layouts, and anything past this is refused.
  */
 internal const val PARAMETER_MATCH_TOLERANCE: Double = 1e-9
 
 /**
  * How closely an incoming bucket edge must land on a bin boundary to be merged into that bin.
  *
- * Distinct from [PARAMETER_MATCH_TOLERANCE] despite the same value: this one is a tolerance on where a
- * bucket edge sits after division, not on whether two configurations match.
+ * Distinct from [PARAMETER_MATCH_TOLERANCE] despite sharing its value: this bounds where an edge sits
+ * after division, not whether two configurations match.
  */
 internal const val BIN_ALIGNMENT_TOLERANCE: Double = 1e-9

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -139,3 +139,25 @@ fun SketchResult.toSparseHistogram(): SparseHistogramResult {
         weights = weights,
     )
 }
+
+/**
+ * How close two sketch parameters must be before a merge is allowed.
+ *
+ * [DDSketchStat] compares relative-error targets and [TDigestStat] compares compressions, both against a
+ * bare `1e-9`. The comparison is approximate rather than exact because these are `Double`s that may have
+ * round-tripped through a wire format, so a sketch merged with a re-decoded copy of itself must still be
+ * accepted. It is not a numerical tolerance on the *estimate* - a genuinely different parameter means
+ * incompatible bucket layouts and no error bound at all, so anything past this is refused outright.
+ *
+ * Named because `1e-9` appears in this package with three unrelated meanings: this, the bin-alignment
+ * check in [LinearHistogramStat], and [DDSketchStat]'s default `minIndexableValue`.
+ */
+internal const val PARAMETER_MATCH_TOLERANCE: Double = 1e-9
+
+/**
+ * How closely an incoming bucket edge must land on a bin boundary to be merged into that bin.
+ *
+ * Distinct from [PARAMETER_MATCH_TOLERANCE] despite the same value: this one is a tolerance on where a
+ * bucket edge sits after division, not on whether two configurations match.
+ */
+internal const val BIN_ALIGNMENT_TOLERANCE: Double = 1e-9

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -376,7 +376,7 @@ class TDigestStat(
     )
 
     override fun merge(values: TDigestResult) {
-        require(abs(compression - values.compression) < 1e-9) {
+        require(abs(compression - values.compression) < PARAMETER_MATCH_TOLERANCE) {
             "Cannot merge TDigests with different compression"
         }
         outerLock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -424,8 +424,7 @@ class TDigestStat(
                 // NaN per quantile rather than 0.0, matching DDSketchStat and AucStat. A
                 // zero-filled array cannot be told apart from a digest that genuinely observed
                 // zeros, so an untouched digest reported a p99 of 0.0 and read as healthy.
-                // `isEmpty` on the result is the check for callers who would rather branch; it is an
-                // extension on HasObservationCount, not a member, so it cannot be linked as one.
+                // `isEmpty` on the result is the check for callers who would rather branch.
                 computed.fill(Double.NaN)
                 return@guarded TDigestResult(
                     probabilities,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -424,7 +424,8 @@ class TDigestStat(
                 // NaN per quantile rather than 0.0, matching DDSketchStat and AucStat. A
                 // zero-filled array cannot be told apart from a digest that genuinely observed
                 // zeros, so an untouched digest reported a p99 of 0.0 and read as healthy.
-                // [TDigestResult.isEmpty] is the check for callers who would rather branch.
+                // `isEmpty` on the result is the check for callers who would rather branch; it is an
+                // extension on HasObservationCount, not a member, so it cannot be linked as one.
                 computed.fill(Double.NaN)
                 return@guarded TDigestResult(
                     probabilities,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
@@ -5,11 +5,12 @@ import com.eignex.kumulant.core.HasRate
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.operation.mapResult
+import com.eignex.kumulant.stat.decay.DecayWeighting
 import com.eignex.kumulant.stat.decay.DecayingSumResult
 import com.eignex.kumulant.stat.decay.DecayingSumStat
+import com.eignex.kumulant.stream.NANOS_PER_SECOND
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.ln
 import kotlin.time.Duration
 
 /** Exponentially time-decayed rate snapshot. */
@@ -42,7 +43,16 @@ data class DecayingRateResult(
 class DecayingRateStat(val halfLife: Duration, override val concurrency: Concurrency = Concurrency.None) :
     SeriesStat<DecayingRateResult> by decayingRateDelegate(halfLife, concurrency)
 
-private fun rateScale(halfLife: Duration): Double = (ln(2.0) / halfLife.inWholeNanoseconds.toDouble()) * 1e9
+/**
+ * Per-second rate scale for a half-life, via [DecayWeighting.HalfLife].
+ *
+ * This recomputed `ln(2) / halfLife` itself rather than reading the one place that already derives it,
+ * and the copy had no validation: `inWholeNanoseconds` truncates, so a sub-nanosecond half-life gave an
+ * infinite scale instead of the documented error. It only ever looked correct because the
+ * `DecayingSumStat` constructed on the next line happens to throw first - an ordering the compiler does
+ * not enforce and nothing recorded.
+ */
+private fun rateScale(halfLife: Duration): Double = DecayWeighting.HalfLife(halfLife).alpha * NANOS_PER_SECOND
 
 private fun decayingRateDelegate(halfLife: Duration, concurrency: Concurrency): SeriesStat<DecayingRateResult> {
     val scale = rateScale(halfLife)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasRate
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.stream.NANOS_PER_SECOND
 import com.eignex.kumulant.stream.additiveMode
 import com.eignex.kumulant.stream.firstWriterMode
 import kotlinx.serialization.SerialName
@@ -21,7 +22,7 @@ data class RateResult(val startTimestampNanos: Long, val totalValue: Double, val
             // Subtract in Double, not Long: a large-magnitude negative start against a positive read
             // timestamp overflows the Long subtraction, and the guard below then read the wrapped
             // value as a non-positive duration and silently returned 0.0.
-            val durationSeconds = (timestampNanos.toDouble() - startTimestampNanos.toDouble()) / 1e9
+            val durationSeconds = (timestampNanos.toDouble() - startTimestampNanos.toDouble()) / NANOS_PER_SECOND
             if (!(durationSeconds > 0.0)) return 0.0
             return totalValue / durationSeconds
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -8,7 +8,9 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.stream.StreamDouble
@@ -127,8 +129,8 @@ class GaussianNaiveBayesStat(
 ) : RegressionStat<GaussianNaiveBayesResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
-        require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+        requirePositiveFeatureSize(featureSize)
+        requireAtLeastTwoClasses(numClasses)
         require(varianceFloor > 0.0) { "varianceFloor must be positive; got $varianceFloor" }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
@@ -87,18 +88,7 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: VectorView): Int {
-        var best = 0
-        var bestL = logPosterior(x, 0)
-        for (k in 1 until numClasses) {
-            val l = logPosterior(x, k)
-            if (l > bestL) {
-                bestL = l
-                best = k
-            }
-        }
-        return best
-    }
+    fun predict(x: VectorView): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
 
     private companion object {
         const val SMALL_PROB: Double = 1e-300

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/Optimizer.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/Optimizer.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.StreamDoubleArray
@@ -89,7 +90,7 @@ class AdagradOptimizer(
 ) : Optimizer {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(epsilon > 0.0) { "epsilon must be positive" }
     }
 
@@ -134,7 +135,7 @@ class RmspropOptimizer(
 ) : Optimizer {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(rho in 0.0..1.0) { "rho must be in [0, 1]; got $rho" }
         require(epsilon > 0.0) { "epsilon must be positive" }
     }
@@ -182,7 +183,7 @@ class AdamOptimizer(
 ) : Optimizer {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(beta1 in 0.0..1.0) { "beta1 must be in [0, 1]; got $beta1" }
         require(beta2 in 0.0..1.0) { "beta2 must be in [0, 1]; got $beta2" }
         require(epsilon > 0.0) { "epsilon must be positive" }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -12,6 +12,7 @@ import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
+import com.eignex.kumulant.math.PROBABILITY_FLOOR
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
@@ -157,7 +158,7 @@ class SoftmaxRegressionStat(
             // Probabilities live in etas[] from here on. A false return means every exponential
             // underflowed, so there is no distribution to take a gradient against.
             if (!etas.softmaxInPlace()) return@guarded
-            val logProbC = ln(etas[c].coerceAtLeast(SOFTMAX_EPS))
+            val logProbC = ln(etas[c].coerceAtLeast(PROBABILITY_FLOOR))
             crossEntropyCell.add(-logProbC * weight)
 
             biasOpt.advance()
@@ -227,8 +228,4 @@ class SoftmaxRegressionStat(
 
     override fun create(concurrency: Concurrency?) =
         SoftmaxRegressionStat(featureSize, numClasses, optimizer, biasOptimizer, concurrency ?: this.concurrency)
-
-    private companion object {
-        const val SOFTMAX_EPS = 1e-15
-    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -10,6 +10,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -70,18 +71,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: VectorView): Int {
-        var best = 0
-        var bestEta = logit(x, 0)
-        for (k in 1 until numClasses) {
-            val e = logit(x, k)
-            if (e > bestEta) {
-                bestEta = e
-                best = k
-            }
-        }
-        return best
-    }
+    fun predict(x: VectorView): Int = argMaxOf(numClasses) { k -> logit(x, k) }
 }
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -9,7 +9,9 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isNotPositiveWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.softmaxInPlace
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
@@ -107,8 +109,8 @@ class SoftmaxRegressionStat(
 ) : RegressionStat<SoftmaxRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
-        require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+        requirePositiveFeatureSize(featureSize)
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val mode = concurrency.welfordMode()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -160,7 +160,22 @@ class BayesianRegressionStat(
             val wc = weight * curvature
             val z = covariance.matVec(x)
             val denom = sqrt(1.0 + wc * (x dot z))
-            if (denom == 0.0) return@guarded
+            // Non-finite as well as zero. Testing only `denom == 0.0` guarded a case that cannot arise
+            // and let through the two that can:
+            //
+            //  - `xT S x` is non-negative for a positive-definite `S` and `wc` is non-negative
+            //    (`weight > 0` is enforced above, and every `Link.curvature` is non-negative), so
+            //    `denom >= 1`. Reaching exactly zero needs `wc * xT S x == -1.0`, i.e. an `S` already
+            //    outside the cone - and in that regime the argument goes *negative*, so `sqrt` returns
+            //    NaN and `NaN == 0.0` is false.
+            //  - `Link.Log.curvature` is `exp(eta)`, which overflows to `+Infinity` for a large linear
+            //    predictor. Then `wc` is infinite, `denom` is infinite, and the scale below is
+            //    `Infinity / Infinity`, i.e. NaN. This one needs no instability at all.
+            //
+            // Either way the NaN reached `scale(z, ...)` and then `ger`, poisoning the covariance
+            // permanently - and a covariance of NaN yields NaN predictions with no way for a caller to
+            // tell the model is dead. Skipping the observation keeps the posterior usable.
+            if (!denom.isFinite() || denom == 0.0) return@guarded
             scale(z, sqrt(wc) / denom)
 
             // Downdate the Cholesky factor; repair on instability. The downdate leaves the factor

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -21,6 +21,8 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requireMergeFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.choleskyDowndateInPlace
 import com.eignex.kumulant.math.zeroUpperTriangle
 import com.eignex.kumulant.stream.guarded
@@ -88,7 +90,7 @@ class BayesianRegressionStat(
 ) : RegressionStat<CovarianceRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(priorVariance > 0.0) { "priorVariance must be positive, got $priorVariance" }
         require(priorMean == null || priorMean.size == featureSize) {
             "priorMean.size=${priorMean?.size}, expected $featureSize"
@@ -225,9 +227,7 @@ class BayesianRegressionStat(
      * the intercept as a scalar Gaussian with zero prior mean.
      */
     override fun merge(values: CovarianceRegressionResult) {
-        require(values.featureSize == featureSize) {
-            "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
-        }
+        requireMergeFeatureSize(values.featureSize, featureSize)
         lock.guarded {
             val n = featureSize
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -169,14 +169,14 @@ class BayesianRegressionStat(
             // factor, and the two never agree again.
             var norm = covarianceL.choleskyDowndateInPlace(z)
             if (norm >= 1.0) {
-                for (i in 0 until featureSize) covariance[i, i] = covariance[i, i] + 1e-5
+                for (i in 0 until featureSize) covariance[i, i] = covariance[i, i] + COVARIANCE_RIDGE
                 val Lnew = covariance.cholesky(CholeskyPolicy.Regularize()).l
                 for (i in 0 until featureSize) {
                     for (j in 0..i) covarianceL[i, j] = Lnew[i, j]
                 }
                 norm = covarianceL.choleskyDowndateInPlace(z)
                 while (norm >= 1.0) {
-                    scale(z, 1.0 / (norm + 1e-5))
+                    scale(z, 1.0 / (norm + DOWNDATE_SHRINK))
                     norm = covarianceL.choleskyDowndateInPlace(z)
                 }
             }
@@ -381,3 +381,15 @@ data class PopulationPrior(
     /** Number of per-instance posteriors that contributed to this prior. */
     val instanceCount: Int,
 )
+
+/**
+ * Ridge added to the covariance diagonal when a downdate pushes it out of the positive-definite cone.
+ *
+ * Written as a bare `1e-5` twelve lines from an unrelated bare `1e-5` ([DOWNDATE_SHRINK]), so a reader had
+ * no way to tell whether the coincidence was meaningful. It is not: these damp different quantities and
+ * either could be retuned alone.
+ */
+private const val COVARIANCE_RIDGE: Double = 1e-5
+
+/** Floor on the downdate vector's norm, so a near-zero direction cannot blow the step up. */
+private const val DOWNDATE_SHRINK: Double = 1e-5

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -160,21 +160,11 @@ class BayesianRegressionStat(
             val wc = weight * curvature
             val z = covariance.matVec(x)
             val denom = sqrt(1.0 + wc * (x dot z))
-            // Non-finite as well as zero. Testing only `denom == 0.0` guarded a case that cannot arise
-            // and let through the two that can:
-            //
-            //  - `xT S x` is non-negative for a positive-definite `S` and `wc` is non-negative
-            //    (`weight > 0` is enforced above, and every `Link.curvature` is non-negative), so
-            //    `denom >= 1`. Reaching exactly zero needs `wc * xT S x == -1.0`, i.e. an `S` already
-            //    outside the cone - and in that regime the argument goes *negative*, so `sqrt` returns
-            //    NaN and `NaN == 0.0` is false.
-            //  - `Link.Log.curvature` is `exp(eta)`, which overflows to `+Infinity` for a large linear
-            //    predictor. Then `wc` is infinite, `denom` is infinite, and the scale below is
-            //    `Infinity / Infinity`, i.e. NaN. This one needs no instability at all.
-            //
-            // Either way the NaN reached `scale(z, ...)` and then `ger`, poisoning the covariance
-            // permanently - and a covariance of NaN yields NaN predictions with no way for a caller to
-            // tell the model is dead. Skipping the observation keeps the posterior usable.
+            // Non-finite as well as zero. Two paths reach a NaN denominator: an `S` outside the
+            // positive-definite cone makes the argument negative, and `Link.Log.curvature` is
+            // `exp(eta)`, which overflows so that the scale below is `Infinity / Infinity`. Either NaN
+            // would reach `ger` and poison the covariance permanently, taking every later prediction
+            // with it. Skipping the observation keeps the posterior usable.
             if (!denom.isFinite() || denom == 0.0) return@guarded
             scale(z, sqrt(wc) / denom)
 
@@ -400,9 +390,8 @@ data class PopulationPrior(
 /**
  * Ridge added to the covariance diagonal when a downdate pushes it out of the positive-definite cone.
  *
- * Written as a bare `1e-5` twelve lines from an unrelated bare `1e-5` ([DOWNDATE_SHRINK]), so a reader had
- * no way to tell whether the coincidence was meaningful. It is not: these damp different quantities and
- * either could be retuned alone.
+ * Shares a value with [DOWNDATE_SHRINK] but not a purpose: the two damp different quantities and either
+ * can be retuned alone.
  */
 private const val COVARIANCE_RIDGE: Double = 1e-5
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -8,6 +8,8 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requireMergeFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
@@ -70,7 +72,7 @@ class DiagonalRegressionStat(
 ) : RegressionStat<DiagonalRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(priorPrecision > 0.0) { "priorPrecision must be positive, got $priorPrecision" }
     }
 
@@ -141,9 +143,7 @@ class DiagonalRegressionStat(
      * with the diagonal model.
      */
     override fun merge(values: DiagonalRegressionResult) {
-        require(values.featureSize == featureSize) {
-            "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
-        }
+        requireMergeFeatureSize(values.featureSize, featureSize)
         lock.guarded {
             val otherWeights = values.weights.toDoubleArray()
             val otherPrecision = values.precision.toDoubleArray()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.regression.glm
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 
 /**
  * Manager for a population of [BayesianRegressionStat] instances that share an
@@ -40,7 +41,7 @@ class HierarchicalBayesianRegression(
     initialPriorCovariance: DenseMatrix? = null,
 ) {
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
     }
 
     private val tracked = mutableListOf<BayesianRegressionStat>()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -45,6 +45,8 @@ import com.eignex.kumulant.stream.welfordMode
  * **Concurrency:** Welford-coupled per-slot atomic under [Concurrency.Relaxed]
  * (HOGWILD-style asynchronous SGD), serialised under [Concurrency.Strict] /
  * [Concurrency.HighWrite].
+ *
+ * @sample com.eignex.kumulant.samples.regressionUpdate
  */
 class StochasticRegressionStat(
     override val featureSize: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -7,6 +7,8 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requireMergeFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.OptimizerSpec
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -62,7 +64,7 @@ class StochasticRegressionStat(
 ) : RegressionStat<StochasticRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive" }
+        requirePositiveFeatureSize(featureSize)
         require(penalty == Penalty.None || (optimizer is Sgd && biasOptimizer is Sgd)) {
             "Penalty.L1 / Penalty.L2 require Sgd optimizers; got optimizer=${optimizer::class.simpleName}"
         }
@@ -240,9 +242,7 @@ class StochasticRegressionStat(
      * so this is an approximation; for principled merges use [BayesianRegressionStat].
      */
     override fun merge(values: StochasticRegressionResult) {
-        require(values.featureSize == featureSize) {
-            "merge: featureSize mismatch ${values.featureSize} vs $featureSize"
-        }
+        requireMergeFeatureSize(values.featureSize, featureSize)
         lock.guarded {
             val w1 = totalWeightsCell.load()
             val w2 = values.totalWeights

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
@@ -46,17 +47,7 @@ data class ClassCountsResult(
     }
 
     /** Argmax class index; ties resolve to the lowest index. */
-    fun predict(): Int {
-        var best = 0
-        var bestCount = counts[0]
-        for (k in 1 until numClasses) {
-            if (counts[k] > bestCount) {
-                bestCount = counts[k]
-                best = k
-            }
-        }
-        return best
-    }
+    fun predict(): Int = argMaxOf(numClasses) { k -> counts[k] }
 
     /** Shannon entropy of the empirical class distribution, in nats. Zero on an empty leaf. */
     val entropy: Double get() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric.kt
@@ -21,28 +21,20 @@ sealed interface ClassificationSplitMetric {
 @Serializable
 @SerialName("GiniReduction")
 data object GiniReduction : ClassificationSplitMetric {
-    override fun score(total: ClassCountsResult, pos: ClassCountsResult, neg: ClassCountsResult): Double {
-        val wPos = pos.totalWeights
-        val wNeg = neg.totalWeights
-        val w = wPos + wNeg
-        if (w <= 0.0) return 0.0
-        val weighted = (wPos / w) * pos.gini + (wNeg / w) * neg.gini
-        return total.gini - weighted
-    }
+    override fun score(total: ClassCountsResult, pos: ClassCountsResult, neg: ClassCountsResult): Double =
+        impurityReduction(total, pos, neg) {
+            it.gini
+        }
 }
 
 /** Information-gain split criterion: parent entropy minus weighted children entropy. */
 @Serializable
 @SerialName("InformationGain")
 data object InformationGain : ClassificationSplitMetric {
-    override fun score(total: ClassCountsResult, pos: ClassCountsResult, neg: ClassCountsResult): Double {
-        val wPos = pos.totalWeights
-        val wNeg = neg.totalWeights
-        val w = wPos + wNeg
-        if (w <= 0.0) return 0.0
-        val weighted = (wPos / w) * pos.entropy + (wNeg / w) * neg.entropy
-        return total.entropy - weighted
-    }
+    override fun score(total: ClassCountsResult, pos: ClassCountsResult, neg: ClassCountsResult): Double =
+        impurityReduction(total, pos, neg) {
+            it.entropy
+        }
 }
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -131,7 +131,7 @@ class ClassificationTree(
             return a
         }
         if (a is ClassificationLeafNode && b is TreeClassificationSplitResult) {
-            val cloned = cloneFromResult(b, depth = 0) as ClassificationSplitNode
+            val cloned = cloneFromResult(b) as ClassificationSplitNode
             foldIntoCarryover(cloned, a.arm.read(0L))
             return cloned
         }
@@ -151,7 +151,18 @@ class ClassificationTree(
         }
     }
 
-    private fun cloneFromResult(node: TreeClassificationNodeResult, depth: Int): ClassificationNode {
+    /**
+     * Rebuild a live subtree from a snapshot.
+     *
+     * Carried a `depth` parameter that was threaded through every recursive call and read by none of them.
+     * Removed rather than left in place, because as written it read as a live depth cap and was not one.
+     *
+     * Whether it should be one is a separate question this does not settle: `newLeaf` refuses to grow past
+     * `config.maxDepth`, and nothing here refuses to clone past it. In practice a snapshot comes from a tree
+     * that already honoured its own `maxDepth`, so the two only diverge when the configs differ - which is a
+     * behaviour decision rather than a cleanup.
+     */
+    private fun cloneFromResult(node: TreeClassificationNodeResult): ClassificationNode {
         nbrNodes.addAndFetch(1)
         return when (node) {
             is TreeClassificationLeafResult -> {
@@ -161,8 +172,8 @@ class ClassificationTree(
             }
 
             is TreeClassificationSplitResult -> {
-                val pos = cloneFromResult(node.pos, depth + 1)
-                val neg = cloneFromResult(node.neg, depth + 1)
+                val pos = cloneFromResult(node.pos)
+                val neg = cloneFromResult(node.neg)
                 val childSum = mergeCC(node.pos.value, node.neg.value)
                 val residual = subtractCC(node.value, childSum)
                 val carry = if (residual.totalWeights > 0.0) leafArmFactory().also { it.merge(residual) } else null

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -5,6 +5,7 @@ package com.eignex.kumulant.stat.regression.tree
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.stream.Mutex
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
@@ -32,7 +33,7 @@ class ClassificationTree(
     randomSeed: Int = 0,
 ) {
     init {
-        require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val random = Random(randomSeed)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
@@ -11,14 +11,14 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ClassificationTreeConfig(
-    override val delta: Double = 0.05,
-    override val deltaDecay: Double = 0.9,
-    override val tau: Double = 0.05,
-    override val minSamplesSplit: Double = 30.0,
-    override val minSamplesLeaf: Double = 5.0,
-    override val splitPeriod: Int = 10,
-    override val maxDepth: Int = 16,
-    override val maxNodes: Int = 1024,
+    override val delta: Double = HoeffdingDefaults.DELTA,
+    override val deltaDecay: Double = HoeffdingDefaults.DELTA_DECAY,
+    override val tau: Double = HoeffdingDefaults.TAU,
+    override val minSamplesSplit: Double = HoeffdingDefaults.MIN_SAMPLES_SPLIT,
+    override val minSamplesLeaf: Double = HoeffdingDefaults.MIN_SAMPLES_LEAF,
+    override val splitPeriod: Int = HoeffdingDefaults.SPLIT_PERIOD,
+    override val maxDepth: Int = HoeffdingDefaults.MAX_DEPTH,
+    override val maxNodes: Int = HoeffdingDefaults.MAX_NODES,
     /** Split criterion; ranks candidates by the class impurity they remove. */
     val metric: ClassificationSplitMetric = GiniReduction,
     override val mtry: Int? = null,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -6,7 +6,9 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import kotlin.random.Random
 
 /**
@@ -32,8 +34,8 @@ class DecisionTreeClassifierStat(
 ) : RegressionStat<TreeClassificationResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
-        require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+        requirePositiveFeatureSize(featureSize)
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val seedRng = Random(randomSeed)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.random.Random
@@ -62,7 +63,7 @@ class DecisionTreeRegressionStat(
 ) : RegressionStat<TreeRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
+        requirePositiveFeatureSize(featureSize)
     }
 
     private val seedRng = Random(randomSeed)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
@@ -67,3 +67,41 @@ interface HoeffdingTreeConfig {
      */
     val mtry: Int?
 }
+
+/**
+ * The growth defaults both VFDT trees use.
+ *
+ * [HoeffdingTreeConfig] is an interface, so it can describe these fields but cannot carry their values -
+ * and so [RegressionTreeConfig] and [ClassificationTreeConfig] each declared all nine numbers. A tuning
+ * change to one tree silently left the other behind, and `TreeInternalsTest` already asserts that
+ * `shouldSplit` agrees between the two default configs, which means the test suite depended on that
+ * duplication being kept in sync by hand.
+ *
+ * Referencing a `const` from a constructor default is not an ABI change: the value is compiled into the
+ * synthetic defaults method exactly as the literal was.
+ */
+internal object HoeffdingDefaults {
+    /** See [HoeffdingTreeConfig.delta]. */
+    const val DELTA: Double = 0.05
+
+    /** See [HoeffdingTreeConfig.deltaDecay]. */
+    const val DELTA_DECAY: Double = 0.9
+
+    /** See [HoeffdingTreeConfig.tau]. */
+    const val TAU: Double = 0.05
+
+    /** See [HoeffdingTreeConfig.minSamplesSplit]. */
+    const val MIN_SAMPLES_SPLIT: Double = 30.0
+
+    /** See [HoeffdingTreeConfig.minSamplesLeaf]. */
+    const val MIN_SAMPLES_LEAF: Double = 5.0
+
+    /** See [HoeffdingTreeConfig.splitPeriod]. */
+    const val SPLIT_PERIOD: Int = 10
+
+    /** See [HoeffdingTreeConfig.maxDepth]. */
+    const val MAX_DEPTH: Int = 16
+
+    /** See [HoeffdingTreeConfig.maxNodes]. */
+    const val MAX_NODES: Int = 1024
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
@@ -71,14 +71,9 @@ interface HoeffdingTreeConfig {
 /**
  * The growth defaults both VFDT trees use.
  *
- * [HoeffdingTreeConfig] is an interface, so it can describe these fields but cannot carry their values -
- * and so [RegressionTreeConfig] and [ClassificationTreeConfig] each declared all nine numbers. A tuning
- * change to one tree silently left the other behind, and `TreeInternalsTest` already asserts that
- * `shouldSplit` agrees between the two default configs, which means the test suite depended on that
- * duplication being kept in sync by hand.
- *
- * Referencing a `const` from a constructor default is not an ABI change: the value is compiled into the
- * synthetic defaults method exactly as the literal was.
+ * [HoeffdingTreeConfig] is an interface and cannot carry values, so [RegressionTreeConfig] and
+ * [ClassificationTreeConfig] both default from here. `TreeInternalsTest` asserts `shouldSplit` agrees
+ * between the two default configs, which only holds while they share these.
  */
 internal object HoeffdingDefaults {
     /** See [HoeffdingTreeConfig.delta]. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -7,7 +7,9 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
@@ -37,8 +39,8 @@ class RandomForestClassifierStat(
 ) : RegressionStat<ForestClassificationResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
-        require(numClasses >= 2) { "numClasses must be >= 2; got $numClasses" }
+        requirePositiveFeatureSize(featureSize)
+        requireAtLeastTwoClasses(numClasses)
         require(nbrTrees > 0) { "nbrTrees must be positive, got $nbrTrees" }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -144,9 +145,7 @@ data class ForestClassificationResult(
     /** Argmax over [probabilities]. */
     fun predict(x: VectorView): Int {
         val p = probabilities(x)
-        var best = 0
-        for (k in 1 until numClasses) if (p[k] > p[best]) best = k
-        return best
+        return argMaxOf(numClasses) { k -> p[k] }
     }
 
     /** Sum of per-tree root totalWeights. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -135,22 +135,23 @@ data class ForestRegressionResult(
     /** Merge the leaves that [x] routes to across every tree into a single weighted-
      *  variance aggregate. Useful for ensembled scoring. */
     fun findLeafMerged(x: VectorView): WeightedVarianceResult {
-        var totalW = 0.0
-        var mean = 0.0
-        var sst = 0.0
+        // Via mergeWVR, which is the same Chan recurrence this used to inline and the one every other
+        // aggregate path in the tree package already goes through.
+        //
+        // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, and the difference is not
+        // cosmetic: mergeWVR short-circuits only on an exactly-zero weight, so a leaf left with negative
+        // total weight by an over-reaching downdate would be folded in, and against a positive sibling
+        // of equal magnitude the combined weight is zero - a division producing NaN for the whole
+        // forest. Dropping such a leaf loses information; folding it in loses the answer. Deciding
+        // which of those is right for corrupted state is a separate question from removing the
+        // duplicated recurrence, so this preserves the existing behaviour exactly.
+        var acc = WeightedVarianceResult(0.0, 0.0, 0.0)
         for (t in trees) {
             val leaf = t.findLeaf(x)
-            val w2 = leaf.totalWeights
-            if (w2 <= 0.0) continue
-            val w1 = totalW
-            val nextW = w1 + w2
-            val delta = leaf.mean - mean
-            mean += delta * (w2 / nextW)
-            sst += leaf.variance * w2 + (delta * delta) * (w1 * w2 / nextW)
-            totalW = nextW
+            if (leaf.totalWeights <= 0.0) continue
+            acc = mergeWVR(acc, leaf)
         }
-        val variance = if (totalW > 0.0) sst / totalW else 0.0
-        return WeightedVarianceResult(totalW, mean, variance)
+        return acc
     }
 
     /** Mean of [findLeafMerged]. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -136,16 +136,10 @@ data class ForestRegressionResult(
     /** Merge the leaves that [x] routes to across every tree into a single weighted-
      *  variance aggregate. Useful for ensembled scoring. */
     fun findLeafMerged(x: VectorView): WeightedVarianceResult {
-        // Via mergeWVR, which is the same Chan recurrence this used to inline and the one every other
-        // aggregate path in the tree package already goes through.
-        //
-        // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, and the difference is not
-        // cosmetic: mergeWVR short-circuits only on an exactly-zero weight, so a leaf left with negative
-        // total weight by an over-reaching downdate would be folded in, and against a positive sibling
-        // of equal magnitude the combined weight is zero - a division producing NaN for the whole
-        // forest. Dropping such a leaf loses information; folding it in loses the answer. Deciding
-        // which of those is right for corrupted state is a separate question from removing the
-        // duplicated recurrence, so this preserves the existing behaviour exactly.
+        // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, which short-circuits only
+        // on an exactly-zero weight: a leaf left with negative total weight by an over-reaching
+        // downdate would otherwise be folded in, and against a positive sibling of equal magnitude the
+        // combined weight is zero, producing NaN for the whole forest.
         var acc = WeightedVarianceResult(0.0, 0.0, 0.0)
         for (t in trees) {
             val leaf = t.findLeaf(x)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.nextPoissonOne
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -57,7 +58,7 @@ class RandomForestRegressionStat(
 ) : RegressionStat<ForestRegressionResult> {
 
     init {
-        require(featureSize > 0) { "featureSize must be positive, got $featureSize" }
+        requirePositiveFeatureSize(featureSize)
         require(nbrTrees > 0) { "nbrTrees must be positive, got $nbrTrees" }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeConfig.kt
@@ -11,14 +11,14 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RegressionTreeConfig(
-    override val delta: Double = 0.05,
-    override val deltaDecay: Double = 0.9,
-    override val tau: Double = 0.05,
-    override val minSamplesSplit: Double = 30.0,
-    override val minSamplesLeaf: Double = 5.0,
-    override val splitPeriod: Int = 10,
-    override val maxDepth: Int = 16,
-    override val maxNodes: Int = 1024,
+    override val delta: Double = HoeffdingDefaults.DELTA,
+    override val deltaDecay: Double = HoeffdingDefaults.DELTA_DECAY,
+    override val tau: Double = HoeffdingDefaults.TAU,
+    override val minSamplesSplit: Double = HoeffdingDefaults.MIN_SAMPLES_SPLIT,
+    override val minSamplesLeaf: Double = HoeffdingDefaults.MIN_SAMPLES_LEAF,
+    override val splitPeriod: Int = HoeffdingDefaults.SPLIT_PERIOD,
+    override val maxDepth: Int = HoeffdingDefaults.MAX_DEPTH,
+    override val maxNodes: Int = HoeffdingDefaults.MAX_NODES,
     /** Split criterion; ranks candidates by the variance they remove. */
     val metric: SplitMetric = VarianceReduction,
     override val mtry: Int? = null,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/SplitMetric.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/SplitMetric.kt
@@ -27,14 +27,7 @@ data object VarianceReduction : SplitMetric {
         total: WeightedVarianceResult,
         pos: WeightedVarianceResult,
         neg: WeightedVarianceResult,
-    ): Double {
-        val wPos = pos.totalWeights
-        val wNeg = neg.totalWeights
-        val w = wPos + wNeg
-        if (w <= 0.0) return 0.0
-        val weighted = (wPos / w) * pos.variance + (wNeg / w) * neg.variance
-        return total.variance - weighted
-    }
+    ): Double = impurityReduction(total, pos, neg) { it.variance }
 }
 
 /** Result of evaluating all candidate splits at a leaf: best score, runner-up, best index. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -147,3 +147,27 @@ internal fun shouldSplit(ranked: SplitInfo, totalWeight: Double, depth: Int, con
     val eps = hoeffdingBound(config.delta, totalWeight, depth, config.deltaDecay)
     return ranked.top1 - ranked.top2 > eps || eps < config.tau
 }
+
+/**
+ * Parent impurity minus the weight-averaged impurity of the two children.
+ *
+ * All three split criteria kumulant ships are this one expression over a different impurity measure:
+ * [VarianceReduction] over `variance`, [GiniReduction] over `gini`, [InformationGain] over `entropy`.
+ * The five lines were written out three times, including the `w <= 0.0` guard that keeps an empty split
+ * scoring zero rather than NaN - the part a fourth criterion would be most likely to get wrong.
+ *
+ * The `data object`s stay exactly as they are, so no serial name or public signature moves.
+ */
+internal inline fun <R : HasObservationCount> impurityReduction(
+    total: R,
+    pos: R,
+    neg: R,
+    impurity: (R) -> Double,
+): Double {
+    val wPos = pos.totalWeights
+    val wNeg = neg.totalWeights
+    val w = wPos + wNeg
+    if (w <= 0.0) return 0.0
+    val weighted = (wPos / w) * impurity(pos) + (wNeg / w) * impurity(neg)
+    return impurity(total) - weighted
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -151,12 +151,9 @@ internal fun shouldSplit(ranked: SplitInfo, totalWeight: Double, depth: Int, con
 /**
  * Parent impurity minus the weight-averaged impurity of the two children.
  *
- * All three split criteria kumulant ships are this one expression over a different impurity measure:
- * [VarianceReduction] over `variance`, [GiniReduction] over `gini`, [InformationGain] over `entropy`.
- * The five lines were written out three times, including the `w <= 0.0` guard that keeps an empty split
- * scoring zero rather than NaN - the part a fourth criterion would be most likely to get wrong.
- *
- * The `data object`s stay exactly as they are, so no serial name or public signature moves.
+ * Every split criterion kumulant ships is this expression over a different impurity measure:
+ * [VarianceReduction] over `variance`, [GiniReduction] over `gini`, [InformationGain] over `entropy`. The
+ * `w <= 0.0` guard is what keeps an empty split scoring zero rather than NaN.
  */
 internal inline fun <R : HasObservationCount> impurityReduction(
     total: R,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -129,7 +129,7 @@ private fun RegressionTree<VectorView>.mergeNodeWithResult(
         return a
     }
     if (a is RegressionLeafNode && b is TreeSplitResult) {
-        val cloned = cloneFromResult(b, depth = 0) as RegressionSplitNode
+        val cloned = cloneFromResult(b) as RegressionSplitNode
         foldIntoCarryover(cloned, a.arm.read(0L))
         return cloned
     }
@@ -138,7 +138,18 @@ private fun RegressionTree<VectorView>.mergeNodeWithResult(
     return a
 }
 
-private fun RegressionTree<VectorView>.cloneFromResult(node: TreeNodeResult, depth: Int): RegressionNode<VectorView> {
+/**
+ * Rebuild a live subtree from a snapshot.
+ *
+ * Carried a `depth` parameter that was threaded through every recursive call and read by none of them.
+ * Removed rather than left in place, because as written it read as a live depth cap and was not one.
+ *
+ * Whether it should be one is a separate question this does not settle: `newLeaf` refuses to grow past
+ * `config.maxDepth`, and nothing here refuses to clone past it. In practice a snapshot comes from a tree
+ * that already honoured its own `maxDepth`, so the two only diverge when the configs differ - which is a
+ * behaviour decision rather than a cleanup.
+ */
+private fun RegressionTree<VectorView>.cloneFromResult(node: TreeNodeResult): RegressionNode<VectorView> {
     nbrNodes.addAndFetch(1)
     return when (node) {
         is TreeLeafResult -> {
@@ -148,8 +159,8 @@ private fun RegressionTree<VectorView>.cloneFromResult(node: TreeNodeResult, dep
         }
 
         is TreeSplitResult -> {
-            val pos = cloneFromResult(node.pos, depth + 1)
-            val neg = cloneFromResult(node.neg, depth + 1)
+            val pos = cloneFromResult(node.pos)
+            val neg = cloneFromResult(node.neg)
             // Re-establish any orphan aggregate the snapshot encodes by comparing the
             // recorded value against the sum of the cloned children's aggregates.
             val childSum = mergeWVR(node.pos.value, node.neg.value)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
@@ -2,38 +2,60 @@ package com.eignex.kumulant.stat.score
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 
 /**
- * Streaming classification accuracy: paired `(predictedClass, trueClass)`
- * aggregated as the weighted mean of `1[predicted == truth]`. Classes are
- * compared on `toLong()` so floating-point class indices round-trip safely.
+ * Streaming classification accuracy: paired `(predictedClass, trueClass)` aggregated as the weighted
+ * mean of `1[predicted == truth]`.
  *
- * For the full P/R/F1 surface and a per-class breakdown reach for
- * [ConfusionMatrixStat]; this stat is the O(1)-memory shortcut when only the
- * scalar accuracy is needed.
+ * Labels are resolved by [asClassLabel], the same rule [ConfusionMatrixStat] applies, so a pair either
+ * names two classes in `[0, numClasses)` or is ignored entirely.
  *
- * **Memory:** O(1); backed by a [MeanStat].
+ * That agreement is the reason [numClasses] is required here. This stat used to compare labels on
+ * `toLong()`, which truncates: it scored `1.5` and `1.9` as a matching class 1, and being unbounded it
+ * accepted any label at all. [ConfusionMatrixStat] on the identical stream rejected both observations
+ * outright. The two are documented as computing the same number - [ConfusionMatrixResult.accuracy] exists
+ * so a caller can cross-check them - and they disagreed about which observations even counted, which made
+ * that cross-check meaningless on any stream with a non-integral or out-of-range label.
+ *
+ * For the full P/R/F1 surface and a per-class breakdown reach for [ConfusionMatrixStat]; this stat is the
+ * O(1)-memory shortcut when only the scalar accuracy is needed.
+ *
+ * **Memory:** O(1); backed by a [MeanStat]. This is what it buys over [ConfusionMatrixStat], whose state
+ * is `numClasses^2` cells; [numClasses] is used only to bound the labels, never to allocate.
  *
  * **Update:** O(1) per paired observation.
  *
  * **Concurrency:** Inherits [MeanStat]'s concurrency model.
  */
-class AccuracyStat(override val concurrency: Concurrency = Concurrency.None) : PairedStat<WeightedMeanResult> {
+class AccuracyStat(
+    /** Number of classes; class indices are `[0, numClasses)`. Pairs naming anything else are ignored. */
+    val numClasses: Int,
+    override val concurrency: Concurrency = Concurrency.None,
+) : PairedStat<WeightedMeanResult> {
+
+    init {
+        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+    }
 
     private val inner = MeanStat(concurrency)
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        // NaN.toLong() is 0, so a NaN label compared equal to a genuine class 0 and was scored as a
-        // correct prediction. The same truncation trap ConfusionMatrixStat guards. See Stat.
-        if (x.isNaN() || y.isNaN()) return
-        val match = if (x.toLong() == y.toLong()) 1.0 else 0.0
+        // No separate NaN guard: asClassLabel already rejects NaN, because `NaN.toInt()` is 0 and
+        // `0.0 == NaN` is false, so the round-trip check fails. ConfusionMatrixStat carried a redundant
+        // one for the same reason.
+        val predicted = x.asClassLabel(numClasses)
+        val truth = y.asClassLabel(numClasses)
+        if (predicted < 0 || truth < 0) return
+
+        val match = if (predicted == truth) 1.0 else 0.0
         inner.update(match, timestampNanos, weight)
     }
 
     override fun read(timestampNanos: Long) = inner.read(timestampNanos)
     override fun merge(values: WeightedMeanResult) = inner.merge(values)
     override fun reset() = inner.reset()
-    override fun create(concurrency: Concurrency?) = AccuracyStat(concurrency ?: this.concurrency)
+    override fun create(concurrency: Concurrency?) = AccuracyStat(numClasses, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
@@ -13,18 +13,14 @@ import com.eignex.kumulant.stat.summary.WeightedMeanResult
  * Labels are resolved by [asClassLabel], the same rule [ConfusionMatrixStat] applies, so a pair either
  * names two classes in `[0, numClasses)` or is ignored entirely.
  *
- * That agreement is the reason [numClasses] is required here. This stat used to compare labels on
- * `toLong()`, which truncates: it scored `1.5` and `1.9` as a matching class 1, and being unbounded it
- * accepted any label at all. [ConfusionMatrixStat] on the identical stream rejected both observations
- * outright. The two are documented as computing the same number - [ConfusionMatrixResult.accuracy] exists
- * so a caller can cross-check them - and they disagreed about which observations even counted, which made
- * that cross-check meaningless on any stream with a non-integral or out-of-range label.
+ * That agreement is why [numClasses] is required: [ConfusionMatrixResult.accuracy] exists so a caller can
+ * cross-check the two, which only means anything if both bound the labels identically.
  *
  * For the full P/R/F1 surface and a per-class breakdown reach for [ConfusionMatrixStat]; this stat is the
  * O(1)-memory shortcut when only the scalar accuracy is needed.
  *
- * **Memory:** O(1); backed by a [MeanStat]. This is what it buys over [ConfusionMatrixStat], whose state
- * is `numClasses^2` cells; [numClasses] is used only to bound the labels, never to allocate.
+ * **Memory:** O(1); backed by a [MeanStat]. [numClasses] only bounds the labels, it never allocates -
+ * that is the saving over [ConfusionMatrixStat]'s `numClasses^2` cells.
  *
  * **Update:** O(1) per paired observation.
  *

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requirePositiveBins
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
@@ -114,7 +115,7 @@ class AucStat(
 ) : PairedStat<AucResult> {
 
     init {
-        require(numBins > 0) { "numBins must be > 0; got $numBins" }
+        requirePositiveBins(numBins)
         require(upperBound > lowerBound) { "upperBound must be > lowerBound" }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -172,11 +172,8 @@ class ConfusionMatrixStat(
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        // Via asClassLabel, which is this exact policy already extracted: round-trip through Double to
-        // reject a truncating label, then bound the index. The separate NaN guard this replaces could
-        // not fire - `NaN.toInt()` is 0 and `0.0 == NaN` is false, so the round-trip check already
-        // rejected it - and AccuracyStat now shares the helper, which is what makes the two agree about
-        // which observations count rather than only about how they are counted.
+        // asClassLabel rejects a NaN via its own round-trip, so no separate NaN guard is needed.
+        // AccuracyStat shares it, which is what makes the two agree on which observations count.
         val p = x.asClassLabel(numClasses)
         val t = y.asClassLabel(numClasses)
         if (p < 0 || t < 0) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.score
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.additiveMode
@@ -171,14 +172,14 @@ class ConfusionMatrixStat(
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        if (x.isNaN() || y.isNaN()) return
-        val p = x.toInt()
-        val t = y.toInt()
-        // toInt() truncates toward zero, so anything in (-1, 0) became class 0 and then passed the
-        // range check - scoring an out-of-range prediction as a correct class-0 one. The KDoc
-        // promises out-of-range pairs are ignored, so require the label to be the integer it claims.
-        if (p.toDouble() != x || t.toDouble() != y) return
-        if (p !in 0 until numClasses || t !in 0 until numClasses) return
+        // Via asClassLabel, which is this exact policy already extracted: round-trip through Double to
+        // reject a truncating label, then bound the index. The separate NaN guard this replaces could
+        // not fire - `NaN.toInt()` is 0 and `0.0 == NaN` is false, so the round-trip check already
+        // rejected it - and AccuracyStat now shares the helper, which is what makes the two agree about
+        // which observations count rather than only about how they are counted.
+        val p = x.asClassLabel(numClasses)
+        val t = y.asClassLabel(numClasses)
+        if (p < 0 || t < 0) return
         cells[p * numClasses + t].add(weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/Loss.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/Loss.kt
@@ -2,12 +2,11 @@ package com.eignex.kumulant.stat.score
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.math.PROBABILITY_FLOOR
 import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 import kotlin.math.abs
 import kotlin.math.ln
-
-private const val LOG_LOSS_EPS: Double = 1e-15
 
 /**
  * Streaming mean squared error: paired `(prediction, truth)` aggregated as the
@@ -86,7 +85,7 @@ class LogLossStat(override val concurrency: Concurrency = Concurrency.None) : Pa
     private val inner = MeanStat(concurrency)
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        val p = x.coerceIn(LOG_LOSS_EPS, 1.0 - LOG_LOSS_EPS)
+        val p = x.coerceIn(PROBABILITY_FLOOR, 1.0 - PROBABILITY_FLOOR)
         val loss = -(y * ln(p) + (1.0 - y) * ln(1.0 - p))
         inner.update(loss, timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.core.requirePositiveBins
 import com.eignex.kumulant.stat.quantile.SparseHistogramResult
 import kotlin.math.abs
 
@@ -15,7 +16,7 @@ import kotlin.math.abs
  * test on `[0, 1]`. Returns 0 if total finite weight is non-positive.
  */
 fun SparseHistogramResult.pitChiSquared(numBins: Int): Double {
-    require(numBins > 0) { "numBins must be > 0; got $numBins" }
+    requirePositiveBins(numBins)
     var total = 0.0
     var observedFinite = 0
     for (i in lowerBounds.indices) {
@@ -58,7 +59,7 @@ fun SparseHistogramResult.pitChiSquared(numBins: Int): Double {
  * overflow rows are excluded. Returns 0 when total finite weight is non-positive.
  */
 fun SparseHistogramResult.pitKsDistance(numBins: Int): Double {
-    require(numBins > 0) { "numBins must be > 0; got $numBins" }
+    requirePositiveBins(numBins)
     val width = 1.0 / numBins
     val weightPerBin = DoubleArray(numBins)
     var total = 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/package.md
@@ -49,6 +49,14 @@ matters. [ConfusionMatrixStat] is the full P/R/F1 surface with a
 per-class breakdown; reach for it when accuracy alone hides
 class-imbalance effects.
 
+Both take a `numClasses` and resolve labels the same way: a pair is
+scored only if both sides are exactly an integer in `[0, numClasses)`,
+and is ignored otherwise. That is what makes
+[ConfusionMatrixResult.accuracy] and [AccuracyStat]'s mean comparable on
+the same stream. A fractional label such as `1.5`, an out-of-range one,
+and `NaN` are all ignored by both rather than truncated into a class by
+one and refused by the other.
+
 ## Distributional forecast diagnostics
 
 The PIT (probability integral transform) family covers calibration of

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/BloomFilterStat.kt
@@ -140,9 +140,7 @@ class BloomFilterStat(
         // The hasher decides which bits a key sets, so OR-ing in words produced by a different mixer
         // relabels them as this filter's - and keys that were inserted then read back as absent,
         // which is the one thing a Bloom filter promises cannot happen.
-        require(values.hasher == hasherRef) {
-            "Cannot merge BloomFilterStat hashed with ${values.hasher} into one hashed with $hasherRef"
-        }
+        requireSameHasher("BloomFilterStat", values.hasher, hasherRef)
         require(values.words.size == wordCount) {
             "Cannot merge BloomFilterStat: expected $wordCount words, got ${values.words.size}"
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -15,7 +15,6 @@ import com.eignex.kumulant.stream.StreamLongArray
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.ceil
 
 /**
  * CountStat-MinStat sketch snapshot. [counters] is the [depth] x [width] matrix of counters in
@@ -147,7 +146,7 @@ class CountMinSketchStat(
         // nearest silently discarded everything below 0.5 - including totalSeen, so the stat denied
         // observations it had seen - whereas rounding up keeps every observation and leaves the
         // documented `estimate(x) >= true count(x)` intact, since it can only overshoot.
-        val w = ceil(weight).toLong().coerceIn(1L, MAX_COUNTER_STEP)
+        val w = weight.toCounterStep()
         for (row in 0 until depth) {
             val idx = (hasher.mix(value xor rowSalts[row]) and mask).toInt()
             counters.add(row * width + idx, w)
@@ -164,9 +163,7 @@ class CountMinSketchStat(
         // The hasher decides which cell a key lands in, so merging across mixers scatters the
         // incoming counts into cells this sketch will never probe - estimates then come out *below*
         // the true count, breaking the one-sided guarantee silently.
-        require(values.hasher == hasherRef) {
-            "Cannot merge CountMinSketchStat hashed with ${values.hasher} into one hashed with $hasherRef"
-        }
+        requireSameHasher("CountMinSketchStat", values.hasher, hasherRef)
         require(values.counters.size == counterCount) {
             "Cannot merge CountMinSketchStat: expected $counterCount counters, got ${values.counters.size}"
         }
@@ -201,13 +198,4 @@ class CountMinSketchStat(
         hasher,
         concurrency ?: this.concurrency,
     )
-
-    private companion object {
-        /**
-         * Largest single increment a counter accepts. Below Long.MAX_VALUE on purpose: saturating a
-         * counter at the type's ceiling used to make it indistinguishable from an unvisited row and
-         * a second such update wrapped it negative, both of which broke the one-sided guarantee.
-         */
-        const val MAX_COUNTER_STEP: Long = Long.MAX_VALUE / 1024
-    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -138,9 +138,7 @@ class MinHashStat(
     }
 
     override fun merge(values: MinHashResult) {
-        require(values.hasher == hasherRef) {
-            "Cannot merge MinHashStat hashed with ${values.hasher} into one hashed with $hasherRef"
-        }
+        requireSameHasher("MinHashStat", values.hasher, hasherRef)
         // Shape before array length; see HyperLogLogStat.merge. The signature count shadowed the
         // numHashes half of the check below, so a mismatched sketch never named its seed.
         require(values.numHashes == numHashes && values.seed == seed) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -141,12 +141,14 @@ class MinHashStat(
         require(values.hasher == hasherRef) {
             "Cannot merge MinHashStat hashed with ${values.hasher} into one hashed with $hasherRef"
         }
-        require(values.signatures.size == numHashes) {
-            "Cannot merge MinHashStat: expected $numHashes signatures, got ${values.signatures.size}"
-        }
+        // Shape before array length; see HyperLogLogStat.merge. The signature count shadowed the
+        // numHashes half of the check below, so a mismatched sketch never named its seed.
         require(values.numHashes == numHashes && values.seed == seed) {
             "Cannot merge MinHashStat with (numHashes=${values.numHashes}, seed=${values.seed}) " +
                 "into (numHashes=$numHashes, seed=$seed)"
+        }
+        require(values.signatures.size == numHashes) {
+            "Cannot merge MinHashStat: expected $numHashes signatures, got ${values.signatures.size}"
         }
         for (i in 0 until numHashes) {
             val incoming = values.signatures[i]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -139,8 +139,7 @@ class MinHashStat(
 
     override fun merge(values: MinHashResult) {
         requireSameHasher("MinHashStat", values.hasher, hasherRef)
-        // Shape before array length; see HyperLogLogStat.merge. The signature count shadowed the
-        // numHashes half of the check below, so a mismatched sketch never named its seed.
+        // Shape before array length; see HyperLogLogStat.merge.
         require(values.numHashes == numHashes && values.seed == seed) {
             "Cannot merge MinHashStat with (numHashes=${values.numHashes}, seed=${values.seed}) " +
                 "into (numHashes=$numHashes, seed=$seed)"

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
@@ -6,35 +6,26 @@ import kotlin.math.ceil
 /**
  * Largest single increment a sketch counter accepts.
  *
- * Below `Long.MAX_VALUE` on purpose: saturating a counter at the type's ceiling used to make it
- * indistinguishable from an unvisited row, and a second such update wrapped it negative - both of which
- * broke the one-sided guarantee the sketches exist to provide.
- *
- * [CountMinSketchStat] and [SpaceSavingStat] each declared this, under different names, and the second
- * one's KDoc said only that it "mirrors `CountMinSketchStat.MAX_COUNTER_STEP`". A comment was the entire
- * mechanism keeping two counter ceilings equal.
+ * Below `Long.MAX_VALUE` so a saturated counter stays distinguishable from an unvisited row and a further
+ * update cannot wrap it negative, either of which breaks the one-sided guarantee.
  */
 internal const val MAX_COUNTER_STEP: Long = Long.MAX_VALUE / 1024
 
 /**
  * Round a fractional observation weight up to the integer counter step a sketch can hold.
  *
- * Counting sketches store integers, so a weight has to be rounded before it can be added; rounding *up*
- * keeps the one-sided overestimate the guarantees are stated in terms of. The clamp at both ends is what
- * stops a zero or a huge weight breaking those guarantees, and both stats spelled the whole expression
- * out identically.
+ * Rounding *up* preserves the one-sided overestimate the guarantees are stated in terms of; the clamp
+ * keeps a zero or an enormous weight from breaking them.
  */
 internal fun Double.toCounterStep(): Long = ceil(this).toLong().coerceIn(1L, MAX_COUNTER_STEP)
 
 /**
  * Refuse to merge two sketches built on different hash functions.
  *
- * All five hashing sketches carried this check with the same message shape and its own copy of the
- * rationale. The rationale is worth stating once: a sketch's registers, bits or signatures are only
- * comparable under the same hash, so combining across hashers does not degrade the estimate gracefully -
- * it produces a number with no error bound at all, which is strictly worse than refusing.
+ * Registers, bits and signatures are only comparable under the same hash, so combining across hashers
+ * does not degrade the estimate gracefully - it yields a number with no error bound at all.
  *
- * @param statName the stat's own name, which is all that varied between the five copies.
+ * @param statName the stat's own name, for the message.
  * @param incoming the hasher recorded on the snapshot being merged in.
  * @param own the hasher this stat was built with.
  */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
@@ -1,0 +1,45 @@
+package com.eignex.kumulant.stat.sketch
+
+import com.eignex.kumulant.math.HasherRef
+import kotlin.math.ceil
+
+/**
+ * Largest single increment a sketch counter accepts.
+ *
+ * Below `Long.MAX_VALUE` on purpose: saturating a counter at the type's ceiling used to make it
+ * indistinguishable from an unvisited row, and a second such update wrapped it negative - both of which
+ * broke the one-sided guarantee the sketches exist to provide.
+ *
+ * [CountMinSketchStat] and [SpaceSavingStat] each declared this, under different names, and the second
+ * one's KDoc said only that it "mirrors `CountMinSketchStat.MAX_COUNTER_STEP`". A comment was the entire
+ * mechanism keeping two counter ceilings equal.
+ */
+internal const val MAX_COUNTER_STEP: Long = Long.MAX_VALUE / 1024
+
+/**
+ * Round a fractional observation weight up to the integer counter step a sketch can hold.
+ *
+ * Counting sketches store integers, so a weight has to be rounded before it can be added; rounding *up*
+ * keeps the one-sided overestimate the guarantees are stated in terms of. The clamp at both ends is what
+ * stops a zero or a huge weight breaking those guarantees, and both stats spelled the whole expression
+ * out identically.
+ */
+internal fun Double.toCounterStep(): Long = ceil(this).toLong().coerceIn(1L, MAX_COUNTER_STEP)
+
+/**
+ * Refuse to merge two sketches built on different hash functions.
+ *
+ * All five hashing sketches carried this check with the same message shape and its own copy of the
+ * rationale. The rationale is worth stating once: a sketch's registers, bits or signatures are only
+ * comparable under the same hash, so combining across hashers does not degrade the estimate gracefully -
+ * it produces a number with no error bound at all, which is strictly worse than refusing.
+ *
+ * @param statName the stat's own name, which is all that varied between the five copies.
+ * @param incoming the hasher recorded on the snapshot being merged in.
+ * @param own the hasher this stat was built with.
+ */
+internal fun requireSameHasher(statName: String, incoming: HasherRef, own: HasherRef) {
+    require(incoming == own) {
+        "Cannot merge $statName hashed with $incoming into one hashed with $own"
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -10,7 +10,6 @@ import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.welfordLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.math.ceil
 
 /**
  * Space-Saving heavy-hitters snapshot. [keys], [counts], [errors] are parallel arrays of
@@ -196,7 +195,7 @@ class SpaceSavingStat(
         // Capped as in CountMinSketchStat, and for the same reason: counts are Long and monotonically
         // increasing, so an unbounded step saturates a count and the next one wraps it negative,
         // which would drop a genuine heavy hitter out of the summary entirely.
-        val w = ceil(weight).toLong().coerceIn(1L, MAX_COUNT_STEP)
+        val w = weight.toCounterStep()
         if (useMisraGries) {
             admitMisraGries(value, w, 0L)
             totalSeenCell.add(1L)
@@ -268,9 +267,4 @@ class SpaceSavingStat(
     }
 
     override fun create(concurrency: Concurrency?) = SpaceSavingStat(capacity, concurrency ?: this.concurrency)
-
-    private companion object {
-        /** Largest single increment a count accepts; mirrors `CountMinSketchStat.MAX_COUNTER_STEP`. */
-        const val MAX_COUNT_STEP: Long = Long.MAX_VALUE / 1024
-    }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
@@ -82,12 +82,8 @@ internal class ArrayBins(private val mode: StreamMode) {
 /**
  * Bins allocated the first time an index arrives.
  *
- * These three governed the memory profile of every [com.eignex.kumulant.stat.quantile.DDSketchStat] and
- * [com.eignex.kumulant.stat.quantile.LinearHistogramStat] as three bare literals - `128`, `64`, `1.5` -
- * with the `64 = 128 / 2` relationship left as a coincidence a reader had to notice. It is not a
- * coincidence: the first index is placed at the *centre* of the initial span so that the next index in
- * either direction fits without regrowing, and an offset that was not half the span would make one
- * direction re-grow immediately.
+ * [INITIAL_CENTER_OFFSET] must stay half of this: the first index is placed at the centre of the span so
+ * the next one in either direction fits without regrowing.
  */
 private const val INITIAL_BINS: Int = 128
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
@@ -32,15 +32,15 @@ internal class ArrayBins(private val mode: StreamMode) {
             val newOffset: Int
 
             if (length == 0) {
-                newLength = 128
-                newOffset = index - 64
+                newLength = INITIAL_BINS
+                newOffset = index - INITIAL_CENTER_OFFSET
             } else {
                 newOffset = min(offset, index)
                 val maxIndex = max(offset + length - 1, index)
 
                 var capacity = length
                 while (newOffset + capacity <= maxIndex) {
-                    capacity = (capacity * 1.5).toInt() + 1
+                    capacity = (capacity * GROWTH_FACTOR).toInt() + 1
                 }
                 newLength = capacity
             }
@@ -78,3 +78,21 @@ internal class ArrayBins(private val mode: StreamMode) {
         stateRef.store(State(0, emptyArray()))
     }
 }
+
+/**
+ * Bins allocated the first time an index arrives.
+ *
+ * These three governed the memory profile of every [com.eignex.kumulant.stat.quantile.DDSketchStat] and
+ * [com.eignex.kumulant.stat.quantile.LinearHistogramStat] as three bare literals - `128`, `64`, `1.5` -
+ * with the `64 = 128 / 2` relationship left as a coincidence a reader had to notice. It is not a
+ * coincidence: the first index is placed at the *centre* of the initial span so that the next index in
+ * either direction fits without regrowing, and an offset that was not half the span would make one
+ * direction re-grow immediately.
+ */
+private const val INITIAL_BINS: Int = 128
+
+/** Half of [INITIAL_BINS], so the first index lands in the middle of the initial span. */
+private const val INITIAL_CENTER_OFFSET: Int = INITIAL_BINS / 2
+
+/** Geometric growth factor when the span has to widen. */
+private const val GROWTH_FACTOR: Double = 1.5

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ArrayBins.kt
@@ -9,7 +9,7 @@ import kotlin.math.min
  * Resizing creates a new array but copies the original StreamDouble instances,
  * guaranteeing zero dropped writes during concurrent access.
  */
-internal class ArrayBins(val mode: StreamMode) {
+internal class ArrayBins(private val mode: StreamMode) {
 
     private class State(val offset: Int, val bins: Array<StreamDouble>)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/AtomicMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/AtomicMode.kt
@@ -115,16 +115,6 @@ internal value class AtomicDoubleCellArray(val ref: KAtomicLongArray) : StreamDo
             currentBits = witness
         }
     }
-    override fun addAndGet(index: Int, delta: Double): Double {
-        var currentBits = ref.loadAt(index)
-        while (true) {
-            val nextVal = Double.fromBits(currentBits) + delta
-            val nextBits = nextVal.toRawBits()
-            val witness = ref.compareAndExchangeAt(index, currentBits, nextBits)
-            if (witness == currentBits) return nextVal
-            currentBits = witness
-        }
-    }
     override fun compareAndSet(index: Int, expectedValue: Double, newValue: Double): Boolean =
         ref.compareAndSetAt(index, expectedValue.toRawBits(), newValue.toRawBits())
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
@@ -43,10 +43,16 @@ internal fun Concurrency.welfordLock(): Mutex = when (this) {
     else -> NoopMutex
 }
 
-internal fun Concurrency.serializedLock(): Mutex = when (this) {
-    Concurrency.None -> NoopMutex
-    else -> PlatformMutex()
-}
+/**
+ * The lock a stat takes to serialise a multi-cell update.
+ *
+ * Delegates to the public [Concurrency.lock] rather than repeating its `when`. The two were
+ * byte-identical in two files, and `Mutex.kt` documented the coupling in prose - "the same contract the
+ * per-stat `serializedLock` uses" - with nothing enforcing it, so a change to the public mapping would
+ * have silently left all thirty-three internal call sites on the old one. The separate name is worth
+ * keeping because it says *why* the lock is being taken; the second copy of the mapping was not.
+ */
+internal fun Concurrency.serializedLock(): Mutex = lock()
 
 /** Cell mode for a single first-writer-wins field that needs CAS (e.g. a stat's
  *  lazily-initialised start timestamp). HighWrite's striped adders don't support

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
@@ -46,11 +46,8 @@ internal fun Concurrency.welfordLock(): Mutex = when (this) {
 /**
  * The lock a stat takes to serialise a multi-cell update.
  *
- * Delegates to the public [Concurrency.lock] rather than repeating its `when`. The two were
- * byte-identical in two files, and `Mutex.kt` documented the coupling in prose - "the same contract the
- * per-stat `serializedLock` uses" - with nothing enforcing it, so a change to the public mapping would
- * have silently left all thirty-three internal call sites on the old one. The separate name is worth
- * keeping because it says *why* the lock is being taken; the second copy of the mapping was not.
+ * Delegates to [Concurrency.lock] so the mapping lives in one place; the separate name is kept because it
+ * says why the lock is being taken.
  */
 internal fun Concurrency.serializedLock(): Mutex = lock()
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SerialMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SerialMode.kt
@@ -99,10 +99,6 @@ internal class SerialDoubleArray(val ref: DoubleArray) : StreamDoubleArray {
     override fun add(index: Int, delta: Double) {
         ref[index] += delta
     }
-    override fun addAndGet(index: Int, delta: Double): Double {
-        ref[index] += delta
-        return ref[index]
-    }
     override fun compareAndSet(index: Int, expectedValue: Double, newValue: Double): Boolean {
         if (ref[index].toRawBits() == expectedValue.toRawBits()) {
             ref[index] = newValue

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -116,3 +116,29 @@ internal class SliceRing<R : Result, S : Stat<R>>(
         }
     }
 }
+
+/**
+ * Slices a sliding window is divided into when the caller does not say.
+ *
+ * Declared twelve times: four live `Windowed*Stat` classes, four `windowed` DSL functions, and four
+ * `Windowed*` wire specs. The live and wire copies must agree or a materialised spec windows differently
+ * than the equivalent direct call, which is the same class of divergence that made a spec-built EXP3
+ * behave unlike a directly-built one.
+ *
+ * Ten is a resolution choice, not a tuning constant: it fixes the granularity at which the window can
+ * expire, so a one-minute window drops observations in six-second steps. More slices means finer expiry
+ * and proportionally more per-slice state.
+ */
+internal const val DEFAULT_WINDOW_SLICES: Int = 10
+
+/**
+ * Bounds a min-max scaler projects onto when the caller does not say.
+ *
+ * Declared thirteen times across the AST node, the four specs, the four DSL functions and the four live
+ * scalers. The unit interval is the only default that makes the scaler composable with the probability
+ * consumers - calibration, log loss, AUC - which all require `[0, 1]`.
+ */
+internal const val DEFAULT_TARGET_LOW: Double = 0.0
+
+/** Upper end of [DEFAULT_TARGET_LOW]'s interval. */
+internal const val DEFAULT_TARGET_HIGH: Double = 1.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -120,23 +120,17 @@ internal class SliceRing<R : Result, S : Stat<R>>(
 /**
  * Slices a sliding window is divided into when the caller does not say.
  *
- * Declared twelve times: four live `Windowed*Stat` classes, four `windowed` DSL functions, and four
- * `Windowed*` wire specs. The live and wire copies must agree or a materialised spec windows differently
- * than the equivalent direct call, which is the same class of divergence that made a spec-built EXP3
- * behave unlike a directly-built one.
- *
- * Ten is a resolution choice, not a tuning constant: it fixes the granularity at which the window can
- * expire, so a one-minute window drops observations in six-second steps. More slices means finer expiry
- * and proportionally more per-slice state.
+ * A resolution choice rather than a tuning constant: it sets the granularity at which the window
+ * expires, so a one-minute window drops observations in six-second steps. More slices buys finer expiry
+ * at proportionally more per-slice state. Shared by the live stats and the wire specs, which must agree.
  */
 internal const val DEFAULT_WINDOW_SLICES: Int = 10
 
 /**
  * Bounds a min-max scaler projects onto when the caller does not say.
  *
- * Declared thirteen times across the AST node, the four specs, the four DSL functions and the four live
- * scalers. The unit interval is the only default that makes the scaler composable with the probability
- * consumers - calibration, log loss, AUC - which all require `[0, 1]`.
+ * The unit interval, because it is what composes with the probability consumers - calibration, log loss,
+ * AUC - which all require `[0, 1]`.
  */
 internal const val DEFAULT_TARGET_LOW: Double = 0.0
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
@@ -7,14 +7,7 @@ private val monoStart = TimeSource.Monotonic.markNow()
 
 internal fun currentTimeNanos(): Long = monoStart.elapsedNow().inWholeNanoseconds
 
-/**
- * Nanoseconds per second, the conversion every rate and time-axis binding needs.
- *
- * Every timestamp in the library is nanoseconds, and five sites converted to seconds: one named it,
- * the other four wrote `1e9` inline. Same value either way, but a named constant next to
- * [currentTimeNanos] puts the unit contract where the clock is rather than leaving a bare literal to be
- * read as a tolerance or a capacity.
- */
+/** Nanoseconds per second: every timestamp in the library is nanoseconds, every rate is per second. */
 internal const val NANOS_PER_SECOND: Double = 1_000_000_000.0
 
 /**
@@ -110,10 +103,8 @@ internal interface StreamRef<T> {
     /**
      * Atomic compare-and-exchange; returns the witnessed prior value.
      *
-     * Mirrors the platform atomic's own surface. Production CAS on a reference always uses
-     * [compareAndSet] - the witness is only useful to a retry loop, and the cells that run those
-     * ([StreamDouble], [StreamDoubleArray]) reach for the backing atomic's `compareAndExchange`
-     * directly rather than coming through here. Exercised by `StreamModesTest` and `AtomicModeTest`.
+     * Present for parity with the platform atomic. No stat needs the witness on a reference cell, so
+     * this is exercised only by the mode tests; [compareAndSet] is the production entry point.
      */
     fun compareAndExchange(expectedValue: T, newValue: T): T
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
@@ -8,6 +8,16 @@ private val monoStart = TimeSource.Monotonic.markNow()
 internal fun currentTimeNanos(): Long = monoStart.elapsedNow().inWholeNanoseconds
 
 /**
+ * Nanoseconds per second, the conversion every rate and time-axis binding needs.
+ *
+ * Every timestamp in the library is nanoseconds, and five sites converted to seconds: one named it,
+ * the other four wrote `1e9` inline. Same value either way, but a named constant next to
+ * [currentTimeNanos] puts the unit contract where the clock is rather than leaving a bare literal to be
+ * read as a tolerance or a capacity.
+ */
+internal const val NANOS_PER_SECOND: Double = 1_000_000_000.0
+
+/**
  * Internal factory for the mutable scalar cells that back stat accumulators. Users
  * configure stats via [com.eignex.kumulant.core.Concurrency]; each stat translates that
  * intent into the cell encoding it needs.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
@@ -107,7 +107,14 @@ internal interface StreamRef<T> {
     /** Overwrite the referent with [value]. */
     fun store(value: T)
 
-    /** Atomic compare-and-exchange; returns the witnessed prior value. */
+    /**
+     * Atomic compare-and-exchange; returns the witnessed prior value.
+     *
+     * Mirrors the platform atomic's own surface. Production CAS on a reference always uses
+     * [compareAndSet] - the witness is only useful to a retry loop, and the cells that run those
+     * ([StreamDouble], [StreamDoubleArray]) reach for the backing atomic's `compareAndExchange`
+     * directly rather than coming through here. Exercised by `StreamModesTest` and `AtomicModeTest`.
+     */
     fun compareAndExchange(expectedValue: T, newValue: T): T
 
     /** Atomic compare-and-set; returns true iff the swap happened. */
@@ -124,7 +131,6 @@ internal interface StreamDoubleArray {
     fun load(index: Int): Double
     fun store(index: Int, value: Double)
     fun add(index: Int, delta: Double)
-    fun addAndGet(index: Int, delta: Double): Double
     fun compareAndSet(index: Int, expectedValue: Double, newValue: Double): Boolean
 }
 
@@ -146,7 +152,15 @@ internal interface StreamLongArray {
     /** Add [delta] in place at [index]. */
     fun add(index: Int, delta: Long)
 
-    /** Add [delta] at [index] and return the new value. */
+    /**
+     * Add [delta] at [index] and return the new value.
+     *
+     * Kept for symmetry with [StreamLong.addAndGet], which production code uses heavily. No stat needs
+     * the returned value from an array slot today, so the only caller is `AtomicModeTest`. Stated here
+     * because the alternative reading - a live API nobody happens to call - is the one that invites
+     * someone to build on it and find the fast paths untested. The `Double` counterpart had no caller
+     * at all, tests included, and was removed.
+     */
     fun addAndGet(index: Int, delta: Long): Long
 
     /** Atomic compare-and-set at [index]; returns true iff the swap happened. */

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/ConcurrencySweep.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/ConcurrencySweep.kt
@@ -6,17 +6,12 @@ import com.eignex.kumulant.core.SeriesStat
 import kotlin.test.assertEquals
 
 /**
- * The cross-mode agreement sweep, which eleven test files were each spelling out for themselves.
+ * The cross-mode agreement sweep.
  *
  * Every [Concurrency] mode is a different set of state cells behind the same recurrence, so under purely
- * sequential updates all of them must produce bit-identical results. That is the cheap check that catches
- * a mode branch wired to the wrong cell type or missing a lock, before the bench-side tests go looking for
- * real contention.
- *
- * The invariant was stated forty-nine times as an inline `getValue(Concurrency.None)` plus a loop. Written
- * out that often it stops reading as an invariant and starts reading as boilerplate, which is how a file
- * ends up quietly comparing only one field. Naming it makes the sweep something a new stat family opts
- * into rather than re-derives.
+ * sequential updates all of them must produce bit-identical results. That is the cheap check for a mode
+ * branch wired to the wrong cell type or missing a lock, before the bench-side tests look for real
+ * contention.
  */
 internal fun <R> assertModesAgree(label: String, reads: Map<Concurrency, R>) {
     val ref = reads.getValue(Concurrency.None)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/ConcurrencySweep.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/ConcurrencySweep.kt
@@ -1,0 +1,66 @@
+package com.eignex.kumulant
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.SeriesStat
+import kotlin.test.assertEquals
+
+/**
+ * The cross-mode agreement sweep, which eleven test files were each spelling out for themselves.
+ *
+ * Every [Concurrency] mode is a different set of state cells behind the same recurrence, so under purely
+ * sequential updates all of them must produce bit-identical results. That is the cheap check that catches
+ * a mode branch wired to the wrong cell type or missing a lock, before the bench-side tests go looking for
+ * real contention.
+ *
+ * The invariant was stated forty-nine times as an inline `getValue(Concurrency.None)` plus a loop. Written
+ * out that often it stops reading as an invariant and starts reading as boilerplate, which is how a file
+ * ends up quietly comparing only one field. Naming it makes the sweep something a new stat family opts
+ * into rather than re-derives.
+ */
+internal fun <R> assertModesAgree(label: String, reads: Map<Concurrency, R>) {
+    val ref = reads.getValue(Concurrency.None)
+    for ((mode, r) in reads) assertEquals(ref, r, "$label mode=$mode")
+}
+
+/** Builds one stat per mode with [factory] and drives each through [train], keyed by the mode used. */
+internal fun <S, R> readsPerMode(factory: (Concurrency) -> S, train: (S) -> R): Map<Concurrency, R> =
+    Concurrency.entries.associateWith { train(factory(it)) }
+
+/**
+ * Six values on a one-second grid.
+ *
+ * The fixture for stats whose recurrence is driven by the clock: the spacing has to be uneven enough that
+ * a decay factor computed per-observation differs from one computed per-interval, or a mode that confused
+ * the two would still agree.
+ */
+internal val TIMED_VALUES: DoubleArray = doubleArrayOf(1.0, 2.5, -1.0, 3.0, 0.5, 4.0)
+
+/** The timestamps [TIMED_VALUES] arrive at, in nanoseconds. */
+internal val TIMED_STAMPS: LongArray =
+    longArrayOf(0L, 1_000_000_000L, 2_000_000_000L, 3_000_000_000L, 4_000_000_000L, 5_000_000_000L)
+
+/**
+ * Eight values with eight varied weights.
+ *
+ * The fixture for stats that ignore the clock. It carries a zero, two negatives and a fractional weight
+ * on purpose, so a mode that dropped the weight argument or clamped it would show up rather than pass.
+ */
+internal val WEIGHTED_VALUES: DoubleArray = doubleArrayOf(1.0, -2.0, 3.5, 0.0, 4.2, -1.1, 7.0, 2.5)
+
+/** The weights [WEIGHTED_VALUES] arrive with. */
+internal val WEIGHTED_WEIGHTS: DoubleArray = doubleArrayOf(1.0, 2.0, 1.0, 3.0, 1.0, 1.0, 2.5, 0.5)
+
+/** Feeds [TIMED_VALUES] at [TIMED_STAMPS] with unit weight, reading at the last stamp. */
+internal fun <R : Result> timedReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
+    readsPerMode(factory) { s ->
+        for (i in TIMED_VALUES.indices) s.update(TIMED_VALUES[i], TIMED_STAMPS[i], 1.0)
+        s.read(TIMED_STAMPS.last())
+    }
+
+/** Feeds [WEIGHTED_VALUES] with [WEIGHTED_WEIGHTS], all at timestamp zero. */
+internal fun <R : Result> weightedReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
+    readsPerMode(factory) { s ->
+        for (i in WEIGHTED_VALUES.indices) s.update(WEIGHTED_VALUES[i], 0L, WEIGHTED_WEIGHTS[i])
+        s.read(0L)
+    }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
@@ -6,14 +6,8 @@ import kotlin.random.Random
 /**
  * Trains [stat] on a noisy linear ground truth, so a test can then assert the coefficients came back.
  *
- * Four test files carried this identical body, and the duplication was not harmless: the convergence
- * assertions downstream of it are tuned to *these* numbers. `n = 4000` draws, features uniform on
- * `[-1, 1]`, and noise uniform on `[-0.01, 0.01]` are what make a tolerance of `0.05` the right call
- * rather than a coin flip, and a fixed [seed] is what stops the whole family flaking one run in fifty.
- * With four copies, tightening the noise in one file silently changed what its tolerance meant while the
- * other three kept the old bargain.
- *
- * Typed against [RegressionStat] rather than a concrete stat because every caller only needs `update`.
+ * The convergence tolerances downstream are tuned to these numbers: `n = 4000` draws, features uniform on
+ * `[-1, 1]`, noise uniform on `[-0.01, 0.01]`, and a fixed [seed] so the family cannot flake.
  */
 internal fun fitLine(stat: RegressionStat<*>, slope: DoubleArray, intercept: Double, n: Int = 4000, seed: Long = 42L) {
     val rng = Random(seed)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
@@ -1,0 +1,33 @@
+package com.eignex.kumulant
+
+import com.eignex.kumulant.core.RegressionStat
+import kotlin.random.Random
+
+/**
+ * Trains [stat] on a noisy linear ground truth, so a test can then assert the coefficients came back.
+ *
+ * Four test files carried this identical body, and the duplication was not harmless: the convergence
+ * assertions downstream of it are tuned to *these* numbers. `n = 4000` draws, features uniform on
+ * `[-1, 1]`, and noise uniform on `[-0.01, 0.01]` are what make a tolerance of `0.05` the right call
+ * rather than a coin flip, and a fixed [seed] is what stops the whole family flaking one run in fifty.
+ * With four copies, tightening the noise in one file silently changed what its tolerance meant while the
+ * other three kept the old bargain.
+ *
+ * Typed against [RegressionStat] rather than a concrete stat because every caller only needs `update`.
+ */
+internal fun fitLine(
+    stat: RegressionStat<*>,
+    slope: DoubleArray,
+    intercept: Double,
+    n: Int = 4000,
+    seed: Long = 42L,
+) {
+    val rng = Random(seed)
+    repeat(n) {
+        val x = DoubleArray(slope.size) { rng.nextDouble() * 2.0 - 1.0 }
+        var y = intercept
+        for (i in slope.indices) y += slope[i] * x[i]
+        y += rng.nextDouble() * 0.02 - 0.01 // small noise
+        stat.update(x, y, 1.0)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestRegressionFixtures.kt
@@ -15,13 +15,7 @@ import kotlin.random.Random
  *
  * Typed against [RegressionStat] rather than a concrete stat because every caller only needs `update`.
  */
-internal fun fitLine(
-    stat: RegressionStat<*>,
-    slope: DoubleArray,
-    intercept: Double,
-    n: Int = 4000,
-    seed: Long = 42L,
-) {
+internal fun fitLine(stat: RegressionStat<*>, slope: DoubleArray, intercept: Double, n: Int = 4000, seed: Long = 42L) {
     val rng = Random(seed)
     repeat(n) {
         val x = DoubleArray(slope.size) { rng.nextDouble() * 2.0 - 1.0 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
@@ -5,10 +5,7 @@ import com.eignex.koblas.DenseVector
 /**
  * A feature vector, for the tests that need one.
  *
- * Fourteen test files declared this same one-liner, seven of them as a class member and seven as a
- * file-private function. It is here for the same reason [DELTA] is: not to save the lines, but so that
- * `DenseVector.of` has one call site in the test suite. Koblas moved its dense storage to column-major
- * after `v0.1.0`, a change no compiler catches, and a single point of construction is what makes the next
- * such change one edit rather than fourteen.
+ * One call site for `DenseVector.of` across the suite: koblas moved its dense storage to column-major
+ * after `v0.1.0`, a change no compiler catches, so the next one should be a single edit.
  */
 internal fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
@@ -1,0 +1,14 @@
+package com.eignex.kumulant
+
+import com.eignex.koblas.DenseVector
+
+/**
+ * A feature vector, for the tests that need one.
+ *
+ * Fourteen test files declared this same one-liner, seven of them as a class member and seven as a
+ * file-private function. It is here for the same reason [DELTA] is: not to save the lines, but so that
+ * `DenseVector.of` has one call site in the test suite. Koblas moved its dense storage to column-major
+ * after `v0.1.0`, a change no compiler catches, and a single point of construction is what makes the next
+ * such change one edit rather than fourteen.
+ */
+internal fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -1,0 +1,125 @@
+package com.eignex.kumulant.bandit
+
+import com.eignex.koblas.VectorView
+import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
+import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
+import com.eignex.kumulant.bandit.univariate.BernoulliArm
+import com.eignex.kumulant.bandit.univariate.BetaPosterior
+import com.eignex.kumulant.bandit.univariate.BoltzmannBandit
+import com.eignex.kumulant.bandit.univariate.Exp3Bandit
+import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
+import com.eignex.kumulant.bandit.univariate.RouletteWheelBandit
+import com.eignex.kumulant.bandit.univariate.ThompsonSampling
+import com.eignex.kumulant.bandit.univariate.TopTwoThompsonBandit
+import com.eignex.kumulant.feat
+import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val ARMS = 3
+
+/**
+ * Every arm-indexed entry point on every bandit rejects an out-of-range index.
+ *
+ * `Scorable`/`PerArmBandit` document an `IllegalArgumentException` for a bad index, and eight of the
+ * bandits enforced it by hand-copying the same `require` into their `update`. Copies are not coverage:
+ * `RegressionContextualBandit` had the check on none of its four arm-indexed methods, so a bad index
+ * there surfaced as whatever `IndexOutOfBoundsException` the first array access happened to raise -
+ * while a comment in `MultiArmedBandit.update` claimed "every sibling bandit validates this".
+ *
+ * The rule is swept rather than restated per bandit, because the failure mode was one member of the
+ * family being left out, and a per-bandit test is exactly what leaves one out.
+ */
+class ArmIndexContractSweepTest {
+
+    /** One bandit plus every way to name an arm on it. */
+    private class Probe(val name: String, val calls: List<Pair<String, (Int) -> Any?>>)
+
+    private val x: VectorView = feat(1.0, 1.0)
+
+    private fun probes(): List<Probe> {
+        val multiArmed = MultiArmedBandit(ARMS, ThompsonSampling(BernoulliArm(), BetaPosterior), Random(0))
+        val roulette = RouletteWheelBandit(ARMS, random = Random(0))
+        val boltzmann = BoltzmannBandit(ARMS, random = Random(0))
+        val exp3 = Exp3Bandit(ARMS, random = Random(0))
+        val topTwo = TopTwoThompsonBandit(ARMS, ThompsonSampling(BernoulliArm(), BetaPosterior), random = Random(0))
+        val knn = KnnContextualBandit(ARMS, random = Random(0))
+        val regression = RegressionContextualBandit(
+            nbrArms = ARMS,
+            template = BayesianRegressionStat(featureSize = 2),
+            posterior = MultivariateGaussian,
+            random = Random(0),
+        )
+        return listOf(
+            Probe("MultiArmedBandit", listOf(
+                "update" to { i -> multiArmed.update(i, 1.0) },
+                "evaluate" to { i -> multiArmed.evaluate(i) },
+                "armResult" to { i -> multiArmed.armResult(i) },
+                "armStat" to { i -> multiArmed.armStat(i) },
+            )),
+            Probe("RouletteWheelBandit", listOf(
+                "update" to { i -> roulette.update(i, 1.0) },
+                "evaluate" to { i -> roulette.evaluate(i) },
+            )),
+            Probe("BoltzmannBandit", listOf(
+                "update" to { i -> boltzmann.update(i, 1.0) },
+            )),
+            Probe("Exp3Bandit", listOf(
+                "update" to { i -> exp3.update(i, 1.0) },
+            )),
+            Probe("TopTwoThompsonBandit", listOf(
+                "update" to { i -> topTwo.update(i, 1.0) },
+            )),
+            Probe("KnnContextualBandit", listOf(
+                "update" to { i -> knn.update(i, x, 1.0) },
+                "evaluate" to { i -> knn.evaluate(i, x) },
+                "historySize" to { i -> knn.historySize(i) },
+                "armWeight" to { i -> knn.armWeight(i) },
+            )),
+            Probe("RegressionContextualBandit", listOf(
+                "update" to { i -> regression.update(i, x, 1.0) },
+                "evaluate" to { i -> regression.evaluate(i, x) },
+                "armResult" to { i -> regression.armResult(i) },
+                "armStat" to { i -> regression.armStat(i) },
+            )),
+        )
+    }
+
+    @Test
+    fun `every arm-indexed call rejects an out-of-range index`() {
+        // Negative and one-past-the-end. The negative case is the one a raw array access would also
+        // catch; `nbrArms` exactly is the one that reads as plausible and must still be refused.
+        val violations = mutableListOf<String>()
+        for (bad in listOf(-1, ARMS)) {
+            for (probe in probes()) {
+                for ((call, invoke) in probe.calls) {
+                    val thrown = runCatching { invoke(bad) }.exceptionOrNull()
+                    when {
+                        thrown == null -> violations += "${probe.name}.$call accepted index $bad"
+                        thrown !is IllegalArgumentException ->
+                            violations += "${probe.name}.$call threw ${thrown::class.simpleName} for $bad"
+                    }
+                }
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "the documented IllegalArgumentException was not raised")
+    }
+
+    @Test
+    fun `every arm-indexed call accepts every in-range index`() {
+        // Guards the rule above: a bandit that rejected every index would satisfy it.
+        val violations = mutableListOf<String>()
+        for (good in 0 until ARMS) {
+            for (probe in probes()) {
+                for ((call, invoke) in probe.calls) {
+                    runCatching { invoke(good) }.exceptionOrNull()?.let {
+                        violations += "${probe.name}.$call rejected valid index $good: ${it.message}"
+                    }
+                }
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "a valid arm index was refused")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -12,8 +12,8 @@ import com.eignex.kumulant.bandit.univariate.RouletteWheelBandit
 import com.eignex.kumulant.bandit.univariate.ThompsonSampling
 import com.eignex.kumulant.bandit.univariate.TopTwoThompsonBandit
 import com.eignex.kumulant.feat
-import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,37 +53,58 @@ class ArmIndexContractSweepTest {
             random = Random(0),
         )
         return listOf(
-            Probe("MultiArmedBandit", listOf(
-                "update" to { i -> multiArmed.update(i, 1.0) },
-                "evaluate" to { i -> multiArmed.evaluate(i) },
-                "armResult" to { i -> multiArmed.armResult(i) },
-                "armStat" to { i -> multiArmed.armStat(i) },
-            )),
-            Probe("RouletteWheelBandit", listOf(
-                "update" to { i -> roulette.update(i, 1.0) },
-                "evaluate" to { i -> roulette.evaluate(i) },
-            )),
-            Probe("BoltzmannBandit", listOf(
-                "update" to { i -> boltzmann.update(i, 1.0) },
-            )),
-            Probe("Exp3Bandit", listOf(
-                "update" to { i -> exp3.update(i, 1.0) },
-            )),
-            Probe("TopTwoThompsonBandit", listOf(
-                "update" to { i -> topTwo.update(i, 1.0) },
-            )),
-            Probe("KnnContextualBandit", listOf(
-                "update" to { i -> knn.update(i, x, 1.0) },
-                "evaluate" to { i -> knn.evaluate(i, x) },
-                "historySize" to { i -> knn.historySize(i) },
-                "armWeight" to { i -> knn.armWeight(i) },
-            )),
-            Probe("RegressionContextualBandit", listOf(
-                "update" to { i -> regression.update(i, x, 1.0) },
-                "evaluate" to { i -> regression.evaluate(i, x) },
-                "armResult" to { i -> regression.armResult(i) },
-                "armStat" to { i -> regression.armStat(i) },
-            )),
+            Probe(
+                "MultiArmedBandit",
+                listOf(
+                    "update" to { i -> multiArmed.update(i, 1.0) },
+                    "evaluate" to { i -> multiArmed.evaluate(i) },
+                    "armResult" to { i -> multiArmed.armResult(i) },
+                    "armStat" to { i -> multiArmed.armStat(i) },
+                ),
+            ),
+            Probe(
+                "RouletteWheelBandit",
+                listOf(
+                    "update" to { i -> roulette.update(i, 1.0) },
+                    "evaluate" to { i -> roulette.evaluate(i) },
+                ),
+            ),
+            Probe(
+                "BoltzmannBandit",
+                listOf(
+                    "update" to { i -> boltzmann.update(i, 1.0) },
+                ),
+            ),
+            Probe(
+                "Exp3Bandit",
+                listOf(
+                    "update" to { i -> exp3.update(i, 1.0) },
+                ),
+            ),
+            Probe(
+                "TopTwoThompsonBandit",
+                listOf(
+                    "update" to { i -> topTwo.update(i, 1.0) },
+                ),
+            ),
+            Probe(
+                "KnnContextualBandit",
+                listOf(
+                    "update" to { i -> knn.update(i, x, 1.0) },
+                    "evaluate" to { i -> knn.evaluate(i, x) },
+                    "historySize" to { i -> knn.historySize(i) },
+                    "armWeight" to { i -> knn.armWeight(i) },
+                ),
+            ),
+            Probe(
+                "RegressionContextualBandit",
+                listOf(
+                    "update" to { i -> regression.update(i, x, 1.0) },
+                    "evaluate" to { i -> regression.evaluate(i, x) },
+                    "armResult" to { i -> regression.armResult(i) },
+                    "armStat" to { i -> regression.armStat(i) },
+                ),
+            ),
         )
     }
 
@@ -98,6 +119,7 @@ class ArmIndexContractSweepTest {
                     val thrown = runCatching { invoke(bad) }.exceptionOrNull()
                     when {
                         thrown == null -> violations += "${probe.name}.$call accepted index $bad"
+
                         thrown !is IllegalArgumentException ->
                             violations += "${probe.name}.$call threw ${thrown::class.simpleName} for $bad"
                     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -23,14 +23,9 @@ private const val ARMS = 3
 /**
  * Every arm-indexed entry point on every bandit rejects an out-of-range index.
  *
- * `Scorable`/`PerArmBandit` document an `IllegalArgumentException` for a bad index, and eight of the
- * bandits enforced it by hand-copying the same `require` into their `update`. Copies are not coverage:
- * `RegressionContextualBandit` had the check on none of its four arm-indexed methods, so a bad index
- * there surfaced as whatever `IndexOutOfBoundsException` the first array access happened to raise -
- * while a comment in `MultiArmedBandit.update` claimed "every sibling bandit validates this".
- *
- * The rule is swept rather than restated per bandit, because the failure mode was one member of the
- * family being left out, and a per-bandit test is exactly what leaves one out.
+ * `Scorable` and `PerArmBandit` document an `IllegalArgumentException` for a bad index. Swept across the
+ * whole family rather than restated per bandit, because the failure mode is one member being left out -
+ * which is exactly what a per-bandit test misses.
  */
 class ArmIndexContractSweepTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -18,11 +18,11 @@ import com.eignex.kumulant.bandit.univariate.TopTwoThompsonSpec
 import com.eignex.kumulant.bandit.univariate.Ucb1Spec
 import com.eignex.kumulant.bandit.univariate.UnivariateBanditSpec
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
+import kotlinx.serialization.json.Json
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.Json
 
 class BanditFactoryTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.bandit.contextual.RegressionContextualSpec
 import com.eignex.kumulant.bandit.univariate.BernoulliArm
 import com.eignex.kumulant.bandit.univariate.BetaPosterior
 import com.eignex.kumulant.bandit.univariate.BoltzmannSpec
+import com.eignex.kumulant.bandit.univariate.Exp3Bandit
 import com.eignex.kumulant.bandit.univariate.Exp3Spec
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.MultiArmedSpec
@@ -17,11 +18,11 @@ import com.eignex.kumulant.bandit.univariate.TopTwoThompsonSpec
 import com.eignex.kumulant.bandit.univariate.Ucb1Spec
 import com.eignex.kumulant.bandit.univariate.UnivariateBanditSpec
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
-import kotlinx.serialization.json.Json
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 class BanditFactoryTest {
 
@@ -54,6 +55,31 @@ class BanditFactoryTest {
     fun `Exp3 spec materialises with default eta and gamma`() {
         val b = Exp3Spec(nbrArms = 3).materialize(Random(0))
         assertEquals(3, b.nbrArms)
+    }
+
+    @Test
+    fun `a spec-built Exp3 resolves the same gamma as the constructor`() {
+        // The factory inlined `min(K * eta, 1)`, which saturates at 1.0 for every arm count, so a
+        // spec-built EXP3 mixed in pure exploration and never consulted its weights - while the same
+        // bandit built directly got the corrected default and learned. Asserting on nbrArms alone,
+        // as the test above does, cannot see that: the two disagreed on the only field that matters.
+        for (arms in 2..12) {
+            val fromSpec = Exp3Spec(nbrArms = arms).materialize(Random(0))
+            val direct = Exp3Bandit(nbrArms = arms, random = Random(0))
+            assertEquals(direct.gamma, fromSpec.gamma, "gamma disagrees at K=$arms")
+            assertTrue(fromSpec.gamma < 1.0, "gamma saturated at K=$arms, so the play distribution is uniform")
+        }
+    }
+
+    @Test
+    fun `a spec-built Exp3 lets its weights steer the play distribution`() {
+        // The consequence, stated the way a caller would notice it. With gamma at 1.0 every arm gets
+        // exactly 1/K no matter what it earned, so this is what the saturation actually cost.
+        val b = Exp3Spec(nbrArms = 3).materialize(Random(0))
+        repeat(50) { b.update(armIndex = 0, value = 1.0) }
+
+        val p = b.playDistribution()
+        assertTrue(p[0] > p[1], "the rewarded arm should be played more often: ${p.toList()}")
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,5 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.kumulant.feat
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
@@ -9,6 +8,7 @@ import com.eignex.kumulant.bandit.univariate.BoltzmannBandit
 import com.eignex.kumulant.bandit.univariate.Exp3Bandit
 import com.eignex.kumulant.bandit.univariate.NormalTS
 import com.eignex.kumulant.bandit.univariate.TopTwoThompsonBandit
+import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
@@ -18,7 +18,6 @@ import kotlin.test.assertTrue
 /** Edge cases across Exp3, Exp4, Boltzmann, Knn, TopTwoTS that the per-class
  *  tests don't already cover. */
 class StandaloneBanditExtraTest {
-
 
     @Test
     fun `Exp3 gamma=1 produces uniform play distribution regardless of weights`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
@@ -19,7 +19,6 @@ import kotlin.test.assertTrue
  *  tests don't already cover. */
 class StandaloneBanditExtraTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `Exp3 gamma=1 produces uniform play distribution regardless of weights`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.koblas.VectorView
 import kotlin.math.abs
 import kotlin.random.Random
@@ -10,7 +10,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 class Exp4BanditTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `Exp4Bandit rejects bad inputs`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.kumulant.feat
 import com.eignex.koblas.VectorView
+import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
@@ -9,7 +9,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 class Exp4BanditTest {
-
 
     @Test
     fun `Exp4Bandit rejects bad inputs`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.kumulant.feat
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
@@ -11,7 +12,6 @@ import kotlin.test.assertTrue
 
 class KnnContextualBanditTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `KnnContextualBandit rejects bad inputs`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.kumulant.feat
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
+import com.eignex.kumulant.feat
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,7 +11,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class KnnContextualBanditTest {
-
 
     @Test
     fun `KnnContextualBandit rejects bad inputs`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.kumulant.feat
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.LinUcb
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
@@ -15,7 +15,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RegressionContextualBanditTest {
-
 
     @Test
     fun `constructor rejects non-positive nbrArms`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.kumulant.feat
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.LinUcb
@@ -15,7 +16,6 @@ import kotlin.test.assertTrue
 
 class RegressionContextualBanditTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `constructor rejects non-positive nbrArms`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/tree/RegressionContextualBanditTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/tree/RegressionContextualBanditTreeTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RandomForestRegressionStat
@@ -14,7 +14,6 @@ import kotlin.test.assertTrue
 
 class RegressionContextualBanditTreeTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `drives tree-based arms`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/tree/RegressionContextualBanditTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/tree/RegressionContextualBanditTreeTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.tree
 
-import com.eignex.kumulant.feat
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RandomForestRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RegressionTreeConfig
@@ -13,7 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class RegressionContextualBanditTreeTest {
-
 
     @Test
     fun `drives tree-based arms`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
@@ -44,7 +44,7 @@ class PairedAndDiscreteContractSweepTest {
         "PlattCalibrator" to PlattCalibrator(),
         "IsotonicCalibrator" to IsotonicCalibrator(),
         "ConfusionMatrix" to ConfusionMatrix(numClasses = 3),
-        "Accuracy" to Accuracy,
+        "Accuracy" to Accuracy(numClasses = 3),
     )
 
     private val discreteSpecs: List<Pair<String, DiscreteStatSpec<*>>> = listOf(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
@@ -4,11 +4,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * The tie and NaN conventions of the shared argmax, now that eight call sites depend on them.
+ * The tie and NaN conventions of the shared argmax, which every arm and class-label choice depends on.
  *
- * Both were previously undocumented and inconsistent: four bandits seeded the running best at
- * `-Infinity` and four models seeded it at `score(0)`, which are the same loop except when a score is
- * NaN. Pinning them here is the point of having one helper rather than eight loops.
+ * The two rules interact: seeding the running best at `-Infinity` is what makes a NaN score lose, and
+ * strict `>` is what resolves a tie to the lowest index.
  */
 class ArgMaxTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
@@ -1,0 +1,54 @@
+package com.eignex.kumulant.math
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The tie and NaN conventions of the shared argmax, now that eight call sites depend on them.
+ *
+ * Both were previously undocumented and inconsistent: four bandits seeded the running best at
+ * `-Infinity` and four models seeded it at `score(0)`, which are the same loop except when a score is
+ * NaN. Pinning them here is the point of having one helper rather than eight loops.
+ */
+class ArgMaxTest {
+
+    @Test
+    fun `the largest score wins`() {
+        assertEquals(2, argMaxOf(4) { doubleArrayOf(1.0, 3.0, 9.0, 2.0)[it] })
+    }
+
+    @Test
+    fun `a tie resolves to the lowest index`() {
+        // Relied on by every caller: ClassCounts documents it, and a forest's per-class vote is
+        // routinely tied on a leaf that saw one observation of each class.
+        assertEquals(1, argMaxOf(4) { doubleArrayOf(0.0, 5.0, 5.0, 5.0)[it] })
+    }
+
+    @Test
+    fun `a NaN score loses rather than winning`() {
+        // The convention that actually changed. Seeding from `score(0)` made a NaN first score
+        // unbeatable, because every comparison against NaN is false, so one poisoned class decided
+        // every later prediction. A NaN must lose to any finite score, wherever it sits.
+        assertEquals(1, argMaxOf(3) { doubleArrayOf(Double.NaN, 2.0, 1.0)[it] })
+        assertEquals(0, argMaxOf(3) { doubleArrayOf(2.0, Double.NaN, 1.0)[it] })
+    }
+
+    @Test
+    fun `an all-NaN set falls through to the first index`() {
+        // There is no meaningful answer here, so the requirement is only that it is defined and does
+        // not throw - which is the whole of the non-finite guarantee.
+        assertEquals(0, argMaxOf(3) { Double.NaN })
+    }
+
+    @Test
+    fun `negative infinity is still beaten by a real score`() {
+        // The seed value is -Infinity, so an arm genuinely scoring -Infinity must not be mistaken for
+        // "nothing seen yet" in a way that changes the winner.
+        assertEquals(2, argMaxOf(3) { doubleArrayOf(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, -5.0)[it] })
+    }
+
+    @Test
+    fun `a single candidate is its own argmax`() {
+        assertEquals(0, argMaxOf(1) { -17.0 })
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RegressionTreeConfig
@@ -12,7 +12,6 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
 
 class RegressionOpsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
@@ -13,7 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionOpsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
@@ -10,14 +10,10 @@ import kotlin.test.assertEquals
 /**
  * A list of stats reports the weakest guarantee its entries offer, not a flat [Concurrency.None].
  *
- * `AbstractStatGroup` carries a long note explaining why: a container is only as safe as its
- * least-protected member, and this property is what a caller introspects to decide whether reads need
- * external synchronisation. Reporting `None` for a list of `Strict` children was simply untrue.
- *
- * `AbstractStatGroup` was fixed. `AbstractListStats`, holding the same kind of children with the same
- * property, was not - so a `StatGroup` and a `ListStats` over identical entries disagreed about what
- * they guaranteed. That is worse than either answer alone, because it makes the property unreliable
- * rather than merely pessimistic.
+ * A container is only as safe as its least-protected member, and this property is what a caller
+ * introspects to decide whether reads need external synchronisation. `AbstractStatGroup` carries the same
+ * rule, and the two must agree over identical entries or the property is unreliable rather than merely
+ * pessimistic.
  */
 class ListStatsConcurrencyClaimTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
@@ -1,0 +1,56 @@
+package com.eignex.kumulant.schema
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.schema.runtime.ListStats
+import com.eignex.kumulant.stat.summary.SumResult
+import com.eignex.kumulant.stat.summary.SumStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A list of stats reports the weakest guarantee its entries offer, not a flat [Concurrency.None].
+ *
+ * `AbstractStatGroup` carries a long note explaining why: a container is only as safe as its
+ * least-protected member, and this property is what a caller introspects to decide whether reads need
+ * external synchronisation. Reporting `None` for a list of `Strict` children was simply untrue.
+ *
+ * `AbstractStatGroup` was fixed. `AbstractListStats`, holding the same kind of children with the same
+ * property, was not - so a `StatGroup` and a `ListStats` over identical entries disagreed about what
+ * they guaranteed. That is worse than either answer alone, because it makes the property unreliable
+ * rather than merely pessimistic.
+ */
+class ListStatsConcurrencyClaimTest {
+
+    @Test
+    fun `a list of strict stats does not claim to be unsynchronised`() {
+        val stats = ListStats("a" to SumStat(Concurrency.Strict), "b" to SumStat(Concurrency.Strict))
+
+        assertEquals(Concurrency.Strict, stats.concurrency, "a list of Strict entries reported otherwise")
+    }
+
+    @Test
+    fun `one weak entry drags the whole list down to it`() {
+        // The direction that matters for safety: a caller must not be told the list is Strict when one
+        // entry inside it is not.
+        val stats = ListStats("strict" to SumStat(Concurrency.Strict), "none" to SumStat(Concurrency.None))
+
+        assertEquals(Concurrency.None, stats.concurrency, "one unsynchronised entry was not reported")
+    }
+
+    @Test
+    fun `an explicit override still wins`() {
+        val stats = ListStats(
+            listOf("a" to SumStat(Concurrency.Strict)),
+            concurrency = Concurrency.Relaxed,
+        )
+
+        assertEquals(Concurrency.Relaxed, stats.concurrency, "the override was ignored")
+    }
+
+    @Test
+    fun `an empty list falls back to None`() {
+        val stats = ListStats<SumResult>(emptyList())
+
+        assertEquals(Concurrency.None, stats.concurrency)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.operation.foldRegression
@@ -19,7 +19,6 @@ import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionListStatsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.operation.foldRegression
 import com.eignex.kumulant.schema.decay.*
 import com.eignex.kumulant.schema.expr.*
@@ -18,7 +18,6 @@ import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
 
 class RegressionListStatsTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.schema.decay.*
 import com.eignex.kumulant.schema.expr.*
 import com.eignex.kumulant.schema.ops.*
@@ -18,7 +18,6 @@ import com.eignex.kumulant.stat.summary.SumResult
 import com.eignex.skema.SchemaJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
 
 class RegressionSpecsRoundTripTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionSpecsRoundTripTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.schema.decay.*
@@ -19,7 +19,6 @@ import com.eignex.skema.SchemaJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private fun feat(vararg xs: Double) = DenseVector.of(xs)
 
 class RegressionSpecsRoundTripTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
@@ -1,0 +1,186 @@
+package com.eignex.kumulant.schema
+
+import com.eignex.kumulant.core.DiscreteStat
+import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.schema.runtime.materialize
+import com.eignex.kumulant.schema.spec.Adwin
+import com.eignex.kumulant.schema.spec.Auc
+import com.eignex.kumulant.schema.spec.BloomFilter
+import com.eignex.kumulant.schema.spec.CountMinSketch
+import com.eignex.kumulant.schema.spec.CounterRate
+import com.eignex.kumulant.schema.spec.Cusum
+import com.eignex.kumulant.schema.spec.DDSketch
+import com.eignex.kumulant.schema.spec.DiscreteStatSpec
+import com.eignex.kumulant.schema.spec.FrugalQuantile
+import com.eignex.kumulant.schema.spec.HdrHistogram
+import com.eignex.kumulant.schema.spec.HyperLogLog
+import com.eignex.kumulant.schema.spec.LinearCounting
+import com.eignex.kumulant.schema.spec.Mad
+import com.eignex.kumulant.schema.spec.MinHash
+import com.eignex.kumulant.schema.spec.PageHinkley
+import com.eignex.kumulant.schema.spec.PairedStatSpec
+import com.eignex.kumulant.schema.spec.QuantileFilter
+import com.eignex.kumulant.schema.spec.Reliability
+import com.eignex.kumulant.schema.spec.SeriesStatSpec
+import com.eignex.kumulant.schema.spec.TDigest
+import com.eignex.kumulant.stat.anomaly.QuantileFilterStat
+import com.eignex.kumulant.stat.calibration.ReliabilityStat
+import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
+import com.eignex.kumulant.stat.cardinality.LinearCountingStat
+import com.eignex.kumulant.stat.change.AdwinStat
+import com.eignex.kumulant.stat.change.CusumStat
+import com.eignex.kumulant.stat.change.PageHinkleyStat
+import com.eignex.kumulant.stat.quantile.DDSketchStat
+import com.eignex.kumulant.stat.quantile.FrugalQuantileStat
+import com.eignex.kumulant.stat.quantile.HdrHistogramStat
+import com.eignex.kumulant.stat.quantile.TDigestStat
+import com.eignex.kumulant.stat.rate.CounterRateStat
+import com.eignex.kumulant.stat.score.AucStat
+import com.eignex.kumulant.stat.sketch.BloomFilterStat
+import com.eignex.kumulant.stat.sketch.CountMinSketchStat
+import com.eignex.kumulant.stat.sketch.MinHashStat
+import com.eignex.kumulant.stat.summary.MadStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A default-constructed spec materialises to the same stat a default-constructed stat gives you.
+ *
+ * `schema/spec/Stats.kt` states the policy in a comment - "Defaults match the underlying stat's primary
+ * constructor so authored payloads stay terse under `encodeDefaults = false`" - and nothing enforced it.
+ * Roughly fifty defaulted spec fields are hand-copied second declarations of a value that lives in a stat
+ * constructor, and editing either side alone compiles clean and passes every other test.
+ *
+ * That is not hypothetical. `Exp3Spec.materialize` resolved its default `gamma` with a formula the
+ * bandit's own `defaultGamma` had been *fixed* to stop using, so every EXP3 built from a wire spec was a
+ * uniform random sampler while the same bandit constructed directly learned normally. It went unnoticed
+ * because the factory test asserted only on `nbrArms`.
+ *
+ * The check is behavioural rather than field-by-field on purpose: it needs no reflection, which common
+ * Kotlin code cannot rely on across thirteen targets, and it catches a drift in *any* default - including
+ * ones added later - without this file having to enumerate them. Feed both stats the same stream and their
+ * reads must agree; a default that drifts changes an output.
+ *
+ * Deliberately excluded: `ReservoirHistogram`, whose stat defaults its seed to `Random.Default.nextLong()`
+ * so two instances legitimately disagree. That omission is the spec layer getting it right, not a gap.
+ */
+class SpecDefaultParityTest {
+
+    private val values = doubleArrayOf(0.1, 1.2, 3.7, 0.5, 2.8, 1.0, 4.5, 0.3, 2.1, 1.7, 3.0, 0.8)
+    private val keys = longArrayOf(1L, 2L, 3L, 2L, 1L, 4L, 5L, 1L, 6L, 7L, 8L, 3L)
+    private val stamps = LongArray(12) { it * 1_000_000_000L }
+
+    private fun <R : Result> series(
+        name: String,
+        spec: SeriesStatSpec<R>,
+        direct: SeriesStat<R>,
+    ): Triple<String, SeriesStat<*>, SeriesStat<*>> = Triple(name, spec.materialize(), direct)
+
+    private fun <R : Result> discrete(
+        name: String,
+        spec: DiscreteStatSpec<R>,
+        direct: DiscreteStat<R>,
+    ): Triple<String, DiscreteStat<*>, DiscreteStat<*>> = Triple(name, spec.materialize(), direct)
+
+    private fun <R : Result> paired(
+        name: String,
+        spec: PairedStatSpec<R>,
+        direct: PairedStat<R>,
+    ): Triple<String, PairedStat<*>, PairedStat<*>> = Triple(name, spec.materialize(), direct)
+
+    @Test
+    fun `every series spec default matches the stat it materialises`() {
+        val pairs = listOf(
+            series("Cusum", Cusum(), CusumStat()),
+            series("PageHinkley", PageHinkley(), PageHinkleyStat()),
+            series("Adwin", Adwin(), AdwinStat()),
+            series("Mad", Mad(), MadStat()),
+            series("QuantileFilter", QuantileFilter(), QuantileFilterStat()),
+            series("DDSketch", DDSketch(), DDSketchStat()),
+            series("TDigest", TDigest(), TDigestStat()),
+            series("HdrHistogram", HdrHistogram(), HdrHistogramStat()),
+            series("CounterRate", CounterRate(), CounterRateStat()),
+            // q has no default on either side, so it is supplied identically; the point here is that
+            // stepSize and initialEstimate, which do, agree.
+            series("FrugalQuantile", FrugalQuantile(q = 0.9), FrugalQuantileStat(q = 0.9)),
+        )
+        val violations = mutableListOf<String>()
+        for ((name, fromSpec, direct) in pairs) {
+            for (i in values.indices) {
+                fromSpec.update(values[i], stamps[i], 1.0)
+                direct.update(values[i], stamps[i], 1.0)
+            }
+            val a = fromSpec.read(stamps.last())
+            val b = direct.read(stamps.last())
+            if (a != b) violations += "$name: spec default gave $a, stat default gave $b"
+        }
+        assertEquals(emptyList(), violations.toList(), "a spec default has drifted from its stat's")
+    }
+
+    @Test
+    fun `every discrete spec default matches the stat it materialises`() {
+        val pairs = listOf(
+            discrete("HyperLogLog", HyperLogLog(), HyperLogLogStat()),
+            discrete("LinearCounting", LinearCounting(), LinearCountingStat()),
+            discrete("BloomFilter", BloomFilter(), BloomFilterStat()),
+            discrete("CountMinSketch", CountMinSketch(), CountMinSketchStat()),
+            discrete("MinHash", MinHash(), MinHashStat()),
+        )
+        val violations = mutableListOf<String>()
+        for ((name, fromSpec, direct) in pairs) {
+            for (i in keys.indices) {
+                fromSpec.update(keys[i], stamps[i], 1.0)
+                direct.update(keys[i], stamps[i], 1.0)
+            }
+            val a = fromSpec.read(stamps.last())
+            val b = direct.read(stamps.last())
+            if (a != b) violations += "$name: spec default gave $a, stat default gave $b"
+        }
+        assertEquals(emptyList(), violations.toList(), "a spec default has drifted from its stat's")
+    }
+
+    @Test
+    fun `every paired spec default matches the stat it materialises`() {
+        val pairs = listOf(
+            paired("Auc", Auc(), AucStat()),
+            // numBins is required on both sides; included because Reliability has no other field and
+            // this pins that the spec forwards it rather than substituting a default of its own.
+            paired("Reliability", Reliability(numBins = 10), ReliabilityStat(numBins = 10)),
+        )
+        val violations = mutableListOf<String>()
+        for ((name, fromSpec, direct) in pairs) {
+            for (i in values.indices) {
+                val p = values[i] / 5.0
+                val obs = if (i % 2 == 0) 1.0 else 0.0
+                fromSpec.update(p, obs, stamps[i], 1.0)
+                direct.update(p, obs, stamps[i], 1.0)
+            }
+            val a = fromSpec.read(stamps.last())
+            val b = direct.read(stamps.last())
+            if (a != b) violations += "$name: spec default gave $a, stat default gave $b"
+        }
+        assertEquals(emptyList(), violations.toList(), "a spec default has drifted from its stat's")
+    }
+
+    @Test
+    fun `the sweep can actually see a drifted default`() {
+        // Guards the three sweeps above. If a read were insensitive to the defaults - because the result
+        // type has identity equality, say, or because the stream never exercises the parameter - they
+        // would pass no matter what drifted. Deliberately mis-set one default and confirm the same
+        // comparison catches it.
+        val drifted = Cusum(threshold = 999.0).materialize()
+        val direct = CusumStat()
+        for (i in values.indices) {
+            drifted.update(values[i], stamps[i], 1.0)
+            direct.update(values[i], stamps[i], 1.0)
+        }
+
+        assertEquals(
+            false,
+            drifted.read(stamps.last()) == direct.read(stamps.last()),
+            "a deliberately wrong default went undetected, so the sweeps above prove nothing",
+        )
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
@@ -48,23 +48,16 @@ import kotlin.test.assertEquals
 /**
  * A default-constructed spec materialises to the same stat a default-constructed stat gives you.
  *
- * `schema/spec/Stats.kt` states the policy in a comment - "Defaults match the underlying stat's primary
- * constructor so authored payloads stay terse under `encodeDefaults = false`" - and nothing enforced it.
- * Roughly fifty defaulted spec fields are hand-copied second declarations of a value that lives in a stat
- * constructor, and editing either side alone compiles clean and passes every other test.
+ * `schema/spec/Stats.kt` declares that spec defaults match the underlying stat's primary constructor, so
+ * authored payloads stay terse under `encodeDefaults = false`. Nothing else enforces it, and editing
+ * either side alone compiles clean.
  *
- * That is not hypothetical. `Exp3Spec.materialize` resolved its default `gamma` with a formula the
- * bandit's own `defaultGamma` had been *fixed* to stop using, so every EXP3 built from a wire spec was a
- * uniform random sampler while the same bandit constructed directly learned normally. It went unnoticed
- * because the factory test asserted only on `nbrArms`.
+ * Behavioural rather than field-by-field, so it needs no reflection - which common Kotlin cannot rely on
+ * across thirteen targets - and so it covers defaults added after this file was written. Feed both stats
+ * the same stream and their reads must agree.
  *
- * The check is behavioural rather than field-by-field on purpose: it needs no reflection, which common
- * Kotlin code cannot rely on across thirteen targets, and it catches a drift in *any* default - including
- * ones added later - without this file having to enumerate them. Feed both stats the same stream and their
- * reads must agree; a default that drifts changes an output.
- *
- * Deliberately excluded: `ReservoirHistogram`, whose stat defaults its seed to `Random.Default.nextLong()`
- * so two instances legitimately disagree. That omission is the spec layer getting it right, not a gap.
+ * `ReservoirHistogram` is excluded: its stat defaults the seed to `Random.Default.nextLong()`, so two
+ * instances legitimately disagree.
  */
 class SpecDefaultParityTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
@@ -286,7 +286,7 @@ class StatsRoundTripTest {
     }
 
     @Test fun `accuracyConfig round trips`() {
-        assertEquals(Accuracy, roundTrip(Accuracy))
+        assertEquals(Accuracy(numClasses = 4), roundTrip(Accuracy(numClasses = 4)))
     }
 
     @Test fun `hyperLogLogConfig round trips`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
@@ -1,0 +1,132 @@
+package com.eignex.kumulant.stat.change
+
+import com.eignex.kumulant.DELTA
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A fresh change detector adopts a merged snapshot rather than averaging against its own zero.
+ *
+ * Both stats merge approximately, by averaging the drift cells, and that is the documented deal: there
+ * is no exact way to combine two CUSUM walks. But averaging is only meaningful between two walks that
+ * both happened. Against an empty stat the "other" walk is a zero that no observation produced, so the
+ * average halved whatever the worker had accumulated.
+ *
+ * Halving the drift is not a rounding matter here. `alarmUp` compares the cumulative sum directly
+ * against `threshold`, so a coordinator built to fan a stream out to N workers and merge their
+ * snapshots back needed twice the real shift before it would fire - and the *baselines* (`target`,
+ * `mean`, `minPositive`, `maxNegative`) all merged exactly, so the numbers stayed plausible while the
+ * alarm silently stopped tripping. `RecursiveVarianceStat.merge` records the same defect and its fix;
+ * these two were the stats that never got it.
+ */
+class ChangeStatMergeAdoptionTest {
+
+    private fun cusumSnapshot(): CusumResult {
+        val worker = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
+        repeat(20) { worker.update(2.0) }
+        return worker.read()
+    }
+
+    @Test
+    fun `an empty CusumStat adopts a merged snapshot exactly`() {
+        val snapshot = cusumSnapshot()
+        assertTrue(snapshot.cusumPositive > 0.0, "the fixture never drifted, so it proves nothing")
+
+        val coordinator = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
+        coordinator.merge(snapshot)
+
+        val merged = coordinator.read()
+        assertEquals(snapshot.cusumPositive, merged.cusumPositive, DELTA, "the drift was halved")
+        assertEquals(snapshot.cusumNegative, merged.cusumNegative, DELTA, "the negative drift was halved")
+    }
+
+    @Test
+    fun `a merged snapshot still raises the alarm it raised on the worker`() {
+        // The consequence a caller would actually hit, and the reason the halving mattered.
+        //
+        // The threshold is deliberately picked to sit between the real drift and half of it, or the
+        // test proves nothing: at a low threshold even a halved sum still alarms, and the assertion
+        // passes on the unfixed code. The worker's drift is 20 * (2.0 - 0.5) = 30.
+        val worker = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 20.0)
+        repeat(20) { worker.update(2.0) }
+        val snapshot = worker.read()
+        assertTrue(snapshot.alarmUp, "the fixture did not alarm, so the assertion below is vacuous")
+        assertTrue(0.5 * snapshot.cusumPositive < 20.0, "halving would still alarm, so this cannot discriminate")
+
+        val coordinator = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 20.0)
+        coordinator.merge(snapshot)
+
+        assertTrue(coordinator.read().alarmUp, "the coordinator lost an alarm the worker had raised")
+    }
+
+    @Test
+    fun `a non-empty CusumStat still averages`() {
+        // Guards the rule above: adopting unconditionally would satisfy both tests and break the
+        // documented approximate-merge behaviour for the case it was written for.
+        val a = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
+        repeat(20) { a.update(2.0) }
+        val own = a.read().cusumPositive
+
+        val snapshot = cusumSnapshot()
+        a.merge(snapshot)
+
+        assertEquals(0.5 * (own + snapshot.cusumPositive), a.read().cusumPositive, DELTA)
+    }
+
+    @Test
+    fun `an empty CusumStat that has been reset adopts again`() {
+        // reset() has to clear the new initialized cell too, or a reused coordinator keeps halving.
+        val coordinator = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
+        repeat(20) { coordinator.update(2.0) }
+        coordinator.reset()
+
+        val snapshot = cusumSnapshot()
+        coordinator.merge(snapshot)
+
+        assertEquals(snapshot.cusumPositive, coordinator.read().cusumPositive, DELTA, "reset left it primed")
+    }
+
+    /**
+     * A level shift, not a constant stream.
+     *
+     * Page-Hinkley subtracts its own running mean, so a constant input drifts nowhere - the mean
+     * converges on the value and every deviation is zero. The drift only accumulates once the input
+     * departs from the history the mean was built on.
+     */
+    private fun pageHinkleySnapshot(): PageHinkleyResult {
+        val worker = PageHinkleyStat(delta = 0.005, threshold = 50.0)
+        repeat(60) { worker.update(0.0) }
+        repeat(60) { worker.update(5.0) }
+        return worker.read()
+    }
+
+    @Test
+    fun `an empty PageHinkleyStat adopts the merged drift exactly`() {
+        val snapshot = pageHinkleySnapshot()
+        assertTrue(snapshot.cumulativePositive > 0.0, "the fixture never drifted, so it proves nothing")
+
+        val coordinator = PageHinkleyStat(delta = 0.005, threshold = 50.0)
+        coordinator.merge(snapshot)
+
+        val merged = coordinator.read()
+        assertEquals(snapshot.cumulativePositive, merged.cumulativePositive, DELTA, "the drift was halved")
+        assertEquals(snapshot.cumulativeNegative, merged.cumulativeNegative, DELTA, "the drift was halved")
+        // The mean already adopted correctly, because a localCount of zero weights it out. Pinned so
+        // the fix is visibly about the two cells that did not.
+        assertEquals(snapshot.mean, merged.mean, DELTA, "the mean should always have adopted")
+    }
+
+    @Test
+    fun `a non-empty PageHinkleyStat still averages the drift`() {
+        val a = PageHinkleyStat(delta = 0.005, threshold = 50.0)
+        repeat(60) { a.update(0.0) }
+        repeat(60) { a.update(5.0) }
+        val own = a.read().cumulativePositive
+
+        val snapshot = pageHinkleySnapshot()
+        a.merge(snapshot)
+
+        assertEquals(0.5 * (own + snapshot.cumulativePositive), a.read().cumulativePositive, DELTA)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
@@ -8,17 +8,10 @@ import kotlin.test.assertTrue
 /**
  * A fresh change detector adopts a merged snapshot rather than averaging against its own zero.
  *
- * Both stats merge approximately, by averaging the drift cells, and that is the documented deal: there
- * is no exact way to combine two CUSUM walks. But averaging is only meaningful between two walks that
- * both happened. Against an empty stat the "other" walk is a zero that no observation produced, so the
- * average halved whatever the worker had accumulated.
- *
- * Halving the drift is not a rounding matter here. `alarmUp` compares the cumulative sum directly
- * against `threshold`, so a coordinator built to fan a stream out to N workers and merge their
- * snapshots back needed twice the real shift before it would fire - and the *baselines* (`target`,
- * `mean`, `minPositive`, `maxNegative`) all merged exactly, so the numbers stayed plausible while the
- * alarm silently stopped tripping. `RecursiveVarianceStat.merge` records the same defect and its fix;
- * these two were the stats that never got it.
+ * Both stats merge approximately by averaging the drift cells, which is only meaningful between two walks
+ * that both happened; against an empty stat the other operand is a zero no observation produced. That
+ * matters because `alarmUp` thresholds on the cumulative sum directly, so a halved drift needs twice the
+ * real shift to fire, while the baselines merge exactly and keep the numbers looking plausible.
  */
 class ChangeStatMergeAdoptionTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.decay
 
-import com.eignex.kumulant.timedReads
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.timedReads
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
@@ -9,7 +9,6 @@ import kotlin.time.Duration.Companion.seconds
 /** Cross-mode smoke tests for decay stats; math must match across modes under
  *  sequential single-threaded updates. */
 class DecayStatConcurrencyTest {
-
 
     @Test
     fun `EwmaMeanStat sequential math equal across modes`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
@@ -1,8 +1,7 @@
 package com.eignex.kumulant.stat.decay
 
+import com.eignex.kumulant.timedReads
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.SeriesStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
@@ -11,20 +10,10 @@ import kotlin.time.Duration.Companion.seconds
  *  sequential single-threaded updates. */
 class DecayStatConcurrencyTest {
 
-    private val values = doubleArrayOf(1.0, 2.5, -1.0, 3.0, 0.5, 4.0)
-    private val timestamps =
-        longArrayOf(0L, 1_000_000_000L, 2_000_000_000L, 3_000_000_000L, 4_000_000_000L, 5_000_000_000L)
-
-    private fun <R : Result> sequentialReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
-        Concurrency.entries.associateWith { mode ->
-            val s = factory(mode)
-            for (i in values.indices) s.update(values[i], timestamps[i], 1.0)
-            s.read(timestamps.last())
-        }
 
     @Test
     fun `EwmaMeanStat sequential math equal across modes`() {
-        val reads = sequentialReads { EwmaMeanStat(alpha = 0.3, concurrency = it) }
+        val reads = timedReads { EwmaMeanStat(alpha = 0.3, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "EwmaMean totalWeights mode=$mode")
@@ -34,7 +23,7 @@ class DecayStatConcurrencyTest {
 
     @Test
     fun `EwmaVarianceStat sequential math equal across modes`() {
-        val reads = sequentialReads { EwmaVarianceStat(alpha = 0.3, concurrency = it) }
+        val reads = timedReads { EwmaVarianceStat(alpha = 0.3, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "EwmaVariance totalWeights mode=$mode")
@@ -45,7 +34,7 @@ class DecayStatConcurrencyTest {
 
     @Test
     fun `DecayingMeanStat sequential math equal across modes`() {
-        val reads = sequentialReads { DecayingMeanStat(halfLife = 2.seconds, concurrency = it) }
+        val reads = timedReads { DecayingMeanStat(halfLife = 2.seconds, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "DecayingMean totalWeights mode=$mode")
@@ -55,7 +44,7 @@ class DecayStatConcurrencyTest {
 
     @Test
     fun `DecayingVarianceStat sequential math equal across modes`() {
-        val reads = sequentialReads { DecayingVarianceStat(halfLife = 2.seconds, concurrency = it) }
+        val reads = timedReads { DecayingVarianceStat(halfLife = 2.seconds, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "DecayingVariance totalWeights mode=$mode")
@@ -66,7 +55,7 @@ class DecayStatConcurrencyTest {
 
     @Test
     fun `DecayingSumStat sequential math equal across modes`() {
-        val reads = sequentialReads { DecayingSumStat(halfLife = 2.seconds, concurrency = it) }
+        val reads = timedReads { DecayingSumStat(halfLife = 2.seconds, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.sum, r.sum, 1e-9, "DecayingSum sum mode=$mode")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStatTest.kt
@@ -7,14 +7,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class EwmaMeanStatTest {
-    private val delta = 1e-9
 
     @Test
     fun `EwmaMeanStat create produces fresh independent stat`() {
         val m1 = EwmaMeanStat(alpha = 0.5).apply { update(10.0) }
         val m2 = m1.create()
         repeat(10) { m1.update(10.0) }
-        assertEquals(0.0, m2.read().mean, delta)
+        assertEquals(0.0, m2.read().mean, DELTA)
         assertTrue(m1.read().mean > 0.0)
     }
 
@@ -26,7 +25,7 @@ class EwmaMeanStatTest {
 
         d1.merge(d2)
 
-        assertEquals(15.0, d1.read().mean, delta)
+        assertEquals(15.0, d1.read().mean, DELTA)
     }
 
     @Test
@@ -46,7 +45,7 @@ class EwmaMeanStatTest {
         val meanStat = EwmaMeanStat(alpha = 0.5)
         meanStat.update(10.0)
         meanStat.reset()
-        assertEquals(0.0, meanStat.read().mean, delta)
+        assertEquals(0.0, meanStat.read().mean, DELTA)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class EwmaVarianceStatTest {
-    private val delta = 1e-9
 
     @Test
     fun `EwmaVarianceStat create produces fresh independent stat`() {
@@ -17,7 +16,7 @@ class EwmaVarianceStatTest {
         }
         val v2 = v1.create()
         repeat(10) { v1.update(1000.0) }
-        assertEquals(0.0, v2.read().totalWeights, delta)
+        assertEquals(0.0, v2.read().totalWeights, DELTA)
         assertTrue(v1.read().totalWeights > 0.0)
     }
 
@@ -43,15 +42,15 @@ class EwmaVarianceStatTest {
 
         stat.merge(WeightedVarianceResult(0.0, 0.0, 0.0))
 
-        assertEquals(currentVar, stat.read().variance, delta)
+        assertEquals(currentVar, stat.read().variance, DELTA)
     }
 
     @Test
     fun `EwmaVarianceStat bias correction prevents zero division`() {
         val stat = EwmaVarianceStat(alpha = 0.1)
 
-        assertEquals(0.0, stat.read().mean, delta)
-        assertEquals(0.0, stat.read().variance, delta)
+        assertEquals(0.0, stat.read().mean, DELTA)
+        assertEquals(0.0, stat.read().variance, DELTA)
     }
 
     @Test
@@ -60,9 +59,9 @@ class EwmaVarianceStatTest {
         varStat.update(10.0)
         varStat.update(20.0)
         varStat.reset()
-        assertEquals(0.0, varStat.read().mean, delta)
-        assertEquals(0.0, varStat.read().variance, delta)
-        assertEquals(0.0, varStat.read().totalWeights, delta)
+        assertEquals(0.0, varStat.read().mean, DELTA)
+        assertEquals(0.0, varStat.read().variance, DELTA)
+        assertEquals(0.0, varStat.read().totalWeights, DELTA)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
@@ -1,10 +1,10 @@
 package com.eignex.kumulant.stat.event
 
+import com.eignex.kumulant.WEIGHTED_WEIGHTS
+import com.eignex.kumulant.weightedReads
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.SeriesStat
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Cross-mode smoke tests for the event family: each stat should produce identical math
@@ -12,21 +12,11 @@ import kotlin.test.assertEquals
  */
 class EventStatConcurrencyTest {
 
-    private val values = doubleArrayOf(1.0, -2.0, 3.5, 0.0, 4.2, -1.1, 7.0, 2.5)
-    private val weights = doubleArrayOf(1.0, 2.0, 1.0, 3.0, 1.0, 1.0, 2.5, 0.5)
-
-    private fun <R : Result> sequentialReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
-        Concurrency.entries.associateWith { mode ->
-            val s = factory(mode)
-            for (i in values.indices) s.update(values[i], 0L, weights[i])
-            s.read(0L)
-        }
 
     @Test
     fun `ExcursionStat sequential math equal across modes`() {
-        val reads = sequentialReads { ExcursionStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "ExcursionStat mode=$mode")
+        val reads = weightedReads { ExcursionStat(concurrency = it) }
+        assertModesAgree("ExcursionStat", reads)
     }
 
     @Test
@@ -34,17 +24,15 @@ class EventStatConcurrencyTest {
         val flagValues = doubleArrayOf(1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0)
         val reads = Concurrency.entries.associateWith { mode ->
             val s = RunLengthStat(concurrency = mode)
-            for (i in flagValues.indices) s.update(flagValues[i], 0L, weights[i])
+            for (i in flagValues.indices) s.update(flagValues[i], 0L, WEIGHTED_WEIGHTS[i])
             s.read(0L)
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "RunLengthStat mode=$mode")
+        assertModesAgree("RunLengthStat", reads)
     }
 
     @Test
     fun `CrossingStat sequential math equal across modes`() {
-        val reads = sequentialReads { CrossingStat(level = 1.0, concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "CrossingStat mode=$mode")
+        val reads = weightedReads { CrossingStat(level = 1.0, concurrency = it) }
+        assertModesAgree("CrossingStat", reads)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.stat.event
 
 import com.eignex.kumulant.WEIGHTED_WEIGHTS
-import com.eignex.kumulant.weightedReads
 import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.weightedReads
 import kotlin.test.Test
 
 /**
@@ -11,7 +11,6 @@ import kotlin.test.Test
  * under sequential single-threaded updates regardless of the [Concurrency] mode chosen.
  */
 class EventStatConcurrencyTest {
-
 
     @Test
     fun `ExcursionStat sequential math equal across modes`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stat.forecast
 
-import com.eignex.kumulant.timedReads
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.timedReads
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /** Cross-mode smoke tests for the forecast family. */
 class ForecastStatConcurrencyTest {
-
 
     @Test
     fun `HoltStat sequential math equal across modes`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
@@ -1,28 +1,17 @@
 package com.eignex.kumulant.stat.forecast
 
+import com.eignex.kumulant.timedReads
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.SeriesStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /** Cross-mode smoke tests for the forecast family. */
 class ForecastStatConcurrencyTest {
 
-    private val values = doubleArrayOf(1.0, 2.5, -1.0, 3.0, 0.5, 4.0)
-    private val timestamps =
-        longArrayOf(0L, 1_000_000_000L, 2_000_000_000L, 3_000_000_000L, 4_000_000_000L, 5_000_000_000L)
-
-    private fun <R : Result> sequentialReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
-        Concurrency.entries.associateWith { mode ->
-            val s = factory(mode)
-            for (i in values.indices) s.update(values[i], timestamps[i], 1.0)
-            s.read(timestamps.last())
-        }
 
     @Test
     fun `HoltStat sequential math equal across modes`() {
-        val reads = sequentialReads { HoltStat(alpha = 0.3, beta = 0.1, phi = 0.9, concurrency = it) }
+        val reads = timedReads { HoltStat(alpha = 0.3, beta = 0.1, phi = 0.9, concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.level, r.level, 1e-9, "Holt level mode=$mode")
@@ -32,7 +21,7 @@ class ForecastStatConcurrencyTest {
 
     @Test
     fun `SeasonalSmoothingStat sequential math equal across modes`() {
-        val reads = sequentialReads {
+        val reads = timedReads {
             SeasonalSmoothingStat(alpha = 0.3, beta = 0.1, gamma = 0.2, period = 3, concurrency = it)
         }
         val ref = reads.getValue(Concurrency.None)
@@ -46,7 +35,7 @@ class ForecastStatConcurrencyTest {
 
     @Test
     fun `RecursiveVarianceStat sequential math equal across modes`() {
-        val reads = sequentialReads {
+        val reads = timedReads {
             RecursiveVarianceStat(omega = 0.1, alpha = 0.2, beta = 0.7, concurrency = it)
         }
         val ref = reads.getValue(Concurrency.None)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.quantile
 
-import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.quantile
 
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import kotlin.test.Test
@@ -96,7 +97,6 @@ class ThresholdBucketStatTest {
             for (v in values) s.update(v)
             s.read()
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "ThresholdBucketStat mode=$mode")
+        assertModesAgree("ThresholdBucketStat", reads)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatConcurrencyTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.rate
 
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,8 +18,7 @@ class RateStatConcurrencyTest {
             for (i in values.indices) s.update(values[i], timestamps[i])
             s.read(timestamps.last())
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "RateStat mode=$mode")
+        assertModesAgree("RateStat", reads)
     }
 
     @Test
@@ -29,8 +29,7 @@ class RateStatConcurrencyTest {
             for (i in counters.indices) s.update(counters[i], timestamps[i])
             s.read(timestamps.last())
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "CounterRateStat mode=$mode")
+        assertModesAgree("CounterRateStat", reads)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.optimizer.Adagrad
 import com.eignex.kumulant.schema.optimizer.Adam
 import com.eignex.kumulant.schema.optimizer.Rmsprop

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
+import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.schema.optimizer.Adagrad
 import com.eignex.kumulant.schema.optimizer.Adam
@@ -15,23 +16,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class OptimizerTest {
-
-    private fun fitLine(
-        stat: StochasticRegressionStat,
-        truth: DoubleArray,
-        intercept: Double,
-        n: Int = 4000,
-        seed: Long = 42L,
-    ) {
-        val rng = Random(seed)
-        repeat(n) {
-            val x = DoubleArray(truth.size) { rng.nextDouble() * 2.0 - 1.0 }
-            var y = intercept
-            for (i in truth.indices) y += truth[i] * x[i]
-            y += rng.nextDouble() * 0.02 - 0.01
-            stat.update(x, y, 1.0)
-        }
-    }
 
     private fun assertConverges(stat: StochasticRegressionStat, truth: DoubleArray, intercept: Double, tol: Double) {
         fitLine(stat, truth, intercept)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
@@ -8,21 +8,10 @@ import kotlin.test.assertTrue
 /**
  * The SMW downdate refuses an observation whose scale factor is not a usable number.
  *
- * The guard used to read `if (denom == 0.0)`, which is the one case that cannot occur: `xT S x` is
- * non-negative for a positive-definite `S` and the per-observation precision is non-negative, so `denom`
- * is at least 1. Hitting exactly zero requires an `S` already outside the cone, and in that regime the
- * argument to `sqrt` is *negative*, so the result is NaN and `NaN == 0.0` is false. The guard's only
- * reachable input was the one it failed to catch.
- *
- * The cheaper path to the same failure needs no instability at all: `Link.Log.curvature` is `exp(eta)`,
- * which overflows to `+Infinity` for a large linear predictor. Then the numerator and denominator are
- * both infinite and their ratio is NaN.
- *
- * Why it matters more here than elsewhere: the NaN does not stop at the rejected observation. It reaches
- * `ger`, which writes it into the covariance, and every later prediction reads through that covariance.
- * The model is dead from then on with nothing in the result saying so. A non-finite value is allowed to
- * poison a stat under [com.eignex.kumulant.core.Stat]'s contract, but here it is the *stat's own*
- * arithmetic manufacturing the NaN out of finite inputs, which is a defect rather than propagation.
+ * `Link.Log.curvature` is `exp(eta)`, which overflows to `+Infinity` for a large linear predictor, making
+ * the scale factor `Infinity / Infinity`. Every input below is finite, so the NaN is manufactured by the
+ * stat's own arithmetic rather than propagated - and it would land in the covariance, which every later
+ * prediction reads through.
  */
 class BayesianDenomGuardTest {
 
@@ -42,16 +31,8 @@ class BayesianDenomGuardTest {
 
     @Test
     fun `the fit survives the first observation instead of collapsing on the second`() {
-        // Measured behaviour, before and after. On the unfixed code the first observation lands and the
-        // *second* turns every field to NaN, permanently:
-        //
-        //     i=1  w=99998.90001187997  cov=0.9999990001088008
-        //     i=2  w=NaN                cov=NaN
-        //
-        // With the guard widened, the fit from the first observation stays put and each later one is
-        // refused, because `exp(eta)` for that linear predictor is infinite and there is no finite
-        // update to apply. Frozen at a real fit beats NaN: the caller still gets the numbers the data
-        // supported, and `totalWeights` still says how many observations were absorbed.
+        // The fit from the first observation stays put and each later one is refused, since `exp(eta)`
+        // for that linear predictor is infinite and there is no finite update to apply.
         val stat = BayesianRegressionStat(featureSize = 1, link = Link.Log, priorVariance = 1e6)
 
         stat.update(feat(1.0), 1e5, 1.0)
@@ -63,9 +44,8 @@ class BayesianDenomGuardTest {
         assertTrue(!r.covariance[0, 0].isNaN(), "the covariance collapsed to NaN")
         assertEquals(afterFirst, r.weights[0], "the refused observations should have left the fit alone")
 
-        // `predict` is `exp(eta)` under the Log link, so it overflows to Infinity for a linear predictor
-        // this large. That is the correct answer for the fitted model, not corruption - the distinction
-        // the assertions above are drawn around. A NaN would mean the arithmetic broke.
+        // `predict` is `exp(eta)` under the Log link, so Infinity is the correct answer for a linear
+        // predictor this large. A NaN would mean the arithmetic broke.
         assertTrue(!r.predict(feat(1.0)).isNaN(), "prediction is NaN, so the covariance is still poisoned")
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
@@ -1,0 +1,85 @@
+package com.eignex.kumulant.stat.regression.glm
+
+import com.eignex.kumulant.feat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The SMW downdate refuses an observation whose scale factor is not a usable number.
+ *
+ * The guard used to read `if (denom == 0.0)`, which is the one case that cannot occur: `xT S x` is
+ * non-negative for a positive-definite `S` and the per-observation precision is non-negative, so `denom`
+ * is at least 1. Hitting exactly zero requires an `S` already outside the cone, and in that regime the
+ * argument to `sqrt` is *negative*, so the result is NaN and `NaN == 0.0` is false. The guard's only
+ * reachable input was the one it failed to catch.
+ *
+ * The cheaper path to the same failure needs no instability at all: `Link.Log.curvature` is `exp(eta)`,
+ * which overflows to `+Infinity` for a large linear predictor. Then the numerator and denominator are
+ * both infinite and their ratio is NaN.
+ *
+ * Why it matters more here than elsewhere: the NaN does not stop at the rejected observation. It reaches
+ * `ger`, which writes it into the covariance, and every later prediction reads through that covariance.
+ * The model is dead from then on with nothing in the result saying so. A non-finite value is allowed to
+ * poison a stat under [com.eignex.kumulant.core.Stat]'s contract, but here it is the *stat's own*
+ * arithmetic manufacturing the NaN out of finite inputs, which is a defect rather than propagation.
+ */
+class BayesianDenomGuardTest {
+
+    @Test
+    fun `an overflowing Poisson curvature does not poison the covariance`() {
+        // Log link, and a linear predictor driven far enough up that exp(eta) overflows. Every input
+        // here is finite: the feature is 1.0, the target is a plausible count, the weight is 1.0.
+        val stat = BayesianRegressionStat(featureSize = 1, link = Link.Log, priorVariance = 1e6)
+
+        repeat(200) { stat.update(feat(1.0), 1e5, 1.0) }
+
+        val r = stat.read()
+        assertTrue(r.weights[0].isFinite(), "the coefficient went non-finite: ${r.weights[0]}")
+        assertTrue(r.bias.isFinite(), "the bias went non-finite: ${r.bias}")
+        assertTrue(r.covariance[0, 0].isFinite(), "the covariance went non-finite: ${r.covariance[0, 0]}")
+    }
+
+    @Test
+    fun `the fit survives the first observation instead of collapsing on the second`() {
+        // Measured behaviour, before and after. On the unfixed code the first observation lands and the
+        // *second* turns every field to NaN, permanently:
+        //
+        //     i=1  w=99998.90001187997  cov=0.9999990001088008
+        //     i=2  w=NaN                cov=NaN
+        //
+        // With the guard widened, the fit from the first observation stays put and each later one is
+        // refused, because `exp(eta)` for that linear predictor is infinite and there is no finite
+        // update to apply. Frozen at a real fit beats NaN: the caller still gets the numbers the data
+        // supported, and `totalWeights` still says how many observations were absorbed.
+        val stat = BayesianRegressionStat(featureSize = 1, link = Link.Log, priorVariance = 1e6)
+
+        stat.update(feat(1.0), 1e5, 1.0)
+        val afterFirst = stat.read().weights[0]
+        repeat(50) { stat.update(feat(1.0), 1e5, 1.0) }
+
+        val r = stat.read()
+        assertTrue(!r.weights[0].isNaN(), "the coefficient collapsed to NaN")
+        assertTrue(!r.covariance[0, 0].isNaN(), "the covariance collapsed to NaN")
+        assertEquals(afterFirst, r.weights[0], "the refused observations should have left the fit alone")
+
+        // `predict` is `exp(eta)` under the Log link, so it overflows to Infinity for a linear predictor
+        // this large. That is the correct answer for the fitted model, not corruption - the distinction
+        // the assertions above are drawn around. A NaN would mean the arithmetic broke.
+        assertTrue(!r.predict(feat(1.0)).isNaN(), "prediction is NaN, so the covariance is still poisoned")
+    }
+
+    @Test
+    fun `an ordinary Poisson stream still trains`() {
+        // Guards the two above: a stat that refused every observation would satisfy them. The Log link
+        // has to keep working on the counts it is actually for.
+        val stat = BayesianRegressionStat(featureSize = 1, link = Link.Log)
+
+        val before = stat.read().weights[0]
+        for (i in 1..200) stat.update(feat(if (i % 2 == 0) 1.0 else -1.0), (i % 5).toDouble(), 1.0)
+
+        val r = stat.read()
+        assertTrue(r.weights[0] != before, "the Log-link model ignored a perfectly ordinary stream")
+        assertTrue(r.weights[0].isFinite(), "the coefficient went non-finite: ${r.weights[0]}")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.RegressionStat
 import kotlin.math.abs
@@ -9,23 +10,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class BayesianRegressionStatTest {
-
-    private fun fitLine(
-        stat: RegressionStat<*>,
-        slope: DoubleArray,
-        intercept: Double,
-        n: Int = 4000,
-        seed: Long = 42L,
-    ) {
-        val rng = Random(seed)
-        repeat(n) {
-            val x = DoubleArray(slope.size) { rng.nextDouble() * 2.0 - 1.0 }
-            var y = intercept
-            for (i in slope.indices) y += slope[i] * x[i]
-            y += rng.nextDouble() * 0.02 - 0.01 // small noise
-            stat.update(x, y, 1.0)
-        }
-    }
 
     // The factor is downdated alongside the covariance rather than refactorized, so the two can
     // only be trusted to agree if every downdate lands. L * LT has to stay equal to S. The

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,8 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
-import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.fitLine
 import kotlin.math.abs
 import kotlin.math.exp
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.core.RegressionStat
 import kotlin.math.abs
 import kotlin.random.Random
@@ -8,23 +9,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class DiagonalRegressionStatTest {
-
-    private fun fitLine(
-        stat: RegressionStat<*>,
-        slope: DoubleArray,
-        intercept: Double,
-        n: Int = 4000,
-        seed: Long = 42L,
-    ) {
-        val rng = Random(seed)
-        repeat(n) {
-            val x = DoubleArray(slope.size) { rng.nextDouble() * 2.0 - 1.0 }
-            var y = intercept
-            for (i in slope.indices) y += slope[i] * x[i]
-            y += rng.nextDouble() * 0.02 - 0.01 // small noise
-            stat.update(x, y, 1.0)
-        }
-    }
 
     @Test
     fun `diagonal should recover ground truth weights with finite per-coefficient precision`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
@@ -1,7 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.kumulant.fitLine
-import com.eignex.kumulant.core.RegressionStat
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -12,23 +13,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 class StochasticRegressionStatTest {
-
-    private fun fitLine(
-        stat: RegressionStat<*>,
-        slope: DoubleArray,
-        intercept: Double,
-        n: Int = 4000,
-        seed: Long = 42L,
-    ) {
-        val rng = Random(seed)
-        repeat(n) {
-            val x = DoubleArray(slope.size) { rng.nextDouble() * 2.0 - 1.0 }
-            var y = intercept
-            for (i in slope.indices) y += slope[i] * x[i]
-            y += rng.nextDouble() * 0.02 - 0.01 // small noise
-            stat.update(x, y, 1.0)
-        }
-    }
 
     @Test
     fun `sgd should recover ground truth weights`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -1,9 +1,8 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.kumulant.fitLine
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.RegressionStat
+import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.optimizer.Sgd
 import kotlin.math.abs
 import kotlin.math.exp

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.kumulant.feat
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.feat
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,7 +9,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class DecisionTreeRegressionStatTest {
-
 
     @Test
     fun `rejects bad featureSize`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.core.Concurrency
 import kotlin.random.Random
 import kotlin.test.Test
@@ -10,7 +10,6 @@ import kotlin.test.assertTrue
 
 class DecisionTreeRegressionStatTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `rejects bad featureSize`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertTrue
 
 class RandomForestRegressionStatTest {
 
-
     @Test
     fun `predict averages across trees`() {
         val stat = RandomForestRegressionStat(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,7 +9,6 @@ import kotlin.test.assertTrue
 
 class RandomForestRegressionStatTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `predict averages across trees`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertTrue
 
 class RegressionTreeTest {
 
-
     private fun newTree(
         candidates: List<SerializableSplit> = emptyList(),
         config: RegressionTreeConfig = RegressionTreeConfig(),

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTreeTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class RegressionTreeTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     private fun newTree(
         candidates: List<SerializableSplit> = emptyList(),

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertTrue
 
 class SplitTest {
 
-
     @Test
     fun `ThresholdSplit routes by inclusive less-than-or-equal`() {
         val s = ThresholdSplit(featureIndex = 0, threshold = 0.5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.X
 import com.eignex.kumulant.schema.expr.gt
@@ -11,7 +11,6 @@ import kotlin.test.assertTrue
 
 class SplitTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `ThresholdSplit routes by inclusive less-than-or-equal`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.math.abs
 import kotlin.math.sqrt
@@ -10,7 +10,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class TreePosteriorsTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     private fun snap(value: WeightedVarianceResult): TreeRegressionResult = TreeRegressionResult(TreeLeafResult(value))
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class TreePosteriorsTest {
 
-
     private fun snap(value: WeightedVarianceResult): TreeRegressionResult = TreeRegressionResult(TreeLeafResult(value))
 
     private fun split(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,7 +8,6 @@ import kotlin.test.assertTrue
 
 class TreeRegressionResultTest {
 
-    private fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
 
     @Test
     fun `findLeaf returns the leaf value for a flat tree`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertTrue
 
 class TreeRegressionResultTest {
 
-
     @Test
     fun `findLeaf returns the leaf value for a flat tree`() {
         val leafVal = WeightedVarianceResult(5.0, 2.0, 0.5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
@@ -29,9 +29,7 @@ class AccuracyStatTest {
 
     @Test
     fun `a non-integral label is not a class and is ignored`() {
-        // This is what changed. Labels were compared on `toLong()`, which truncates, so 1.5 and 1.9 both
-        // named class 1 and matched each other - while ConfusionMatrixStat, documented as computing the
-        // same accuracy, rejected both observations outright.
+        // A truncating comparison would make 1.5 and 1.9 both name class 1 and match each other.
         val s = AccuracyStat(numClasses = 3)
         s.update(1.0, 1.0)
         s.update(1.5, 1.9)
@@ -42,7 +40,7 @@ class AccuracyStatTest {
 
     @Test
     fun `a label outside the declared range is ignored`() {
-        // The other half of what numClasses buys: the old stat was unbounded, so any label at all counted.
+        // The other half of what numClasses buys: an unbounded stat would count any label at all.
         val s = AccuracyStat(numClasses = 3)
         s.update(1.0, 1.0)
         s.update(7.0, 7.0)
@@ -53,8 +51,8 @@ class AccuracyStatTest {
 
     @Test
     fun `a NaN label is ignored rather than scored as class zero`() {
-        // `NaN.toLong()` is 0, so a NaN prediction against a NaN truth used to score as a correct
-        // class-0 prediction. asClassLabel rejects it via the same round-trip that rejects 1.5.
+        // `NaN.toLong()` is 0, so a truncating comparison would score a NaN pair as a correct class-0
+        // prediction. asClassLabel rejects it via the same round-trip that rejects 1.5.
         val s = AccuracyStat(numClasses = 3)
         s.update(0.0, 1.0)
         s.update(Double.NaN, Double.NaN)
@@ -65,8 +63,8 @@ class AccuracyStatTest {
 
     @Test
     fun `it agrees with ConfusionMatrixStat on the same stream`() {
-        // The invariant the change exists for. ConfusionMatrixResult.accuracy is offered so a caller can
-        // cross-check the two, and that was only meaningful on a stream of clean in-range integer labels.
+        // ConfusionMatrixResult.accuracy is offered so a caller can cross-check the two, which requires
+        // that they agree on which observations count, not merely on how they are counted.
         val accuracy = AccuracyStat(numClasses = 3)
         val matrix = ConfusionMatrixStat(numClasses = 3)
         val pairs = listOf(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
@@ -3,12 +3,13 @@ package com.eignex.kumulant.stat.score
 import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class AccuracyStatTest {
 
     @Test
     fun `accuracy is the fraction of matching class labels`() {
-        val s = AccuracyStat()
+        val s = AccuracyStat(numClasses = 3)
         s.update(1.0, 1.0)
         s.update(0.0, 0.0)
         s.update(1.0, 0.0)
@@ -19,10 +20,69 @@ class AccuracyStatTest {
     }
 
     @Test
-    fun `class labels round trip through toLong so integer doubles compare safely`() {
-        val s = AccuracyStat()
+    fun `integer doubles name the class they look like`() {
+        val s = AccuracyStat(numClasses = 8)
         s.update(7.0, 7.0)
         s.update(2.0, 3.0)
         assertEquals(0.5, s.read().mean, DELTA)
+    }
+
+    @Test
+    fun `a non-integral label is not a class and is ignored`() {
+        // This is what changed. Labels were compared on `toLong()`, which truncates, so 1.5 and 1.9 both
+        // named class 1 and matched each other - while ConfusionMatrixStat, documented as computing the
+        // same accuracy, rejected both observations outright.
+        val s = AccuracyStat(numClasses = 3)
+        s.update(1.0, 1.0)
+        s.update(1.5, 1.9)
+
+        assertEquals(1.0, s.read().mean, DELTA, "a fractional label was scored as a class")
+        assertEquals(1.0, s.read().totalWeights, DELTA, "a fractional label was counted as an observation")
+    }
+
+    @Test
+    fun `a label outside the declared range is ignored`() {
+        // The other half of what numClasses buys: the old stat was unbounded, so any label at all counted.
+        val s = AccuracyStat(numClasses = 3)
+        s.update(1.0, 1.0)
+        s.update(7.0, 7.0)
+        s.update(-1.0, -1.0)
+
+        assertEquals(1.0, s.read().totalWeights, DELTA, "an out-of-range label was counted")
+    }
+
+    @Test
+    fun `a NaN label is ignored rather than scored as class zero`() {
+        // `NaN.toLong()` is 0, so a NaN prediction against a NaN truth used to score as a correct
+        // class-0 prediction. asClassLabel rejects it via the same round-trip that rejects 1.5.
+        val s = AccuracyStat(numClasses = 3)
+        s.update(0.0, 1.0)
+        s.update(Double.NaN, Double.NaN)
+
+        assertEquals(0.0, s.read().mean, DELTA, "a NaN pair was scored as a match")
+        assertEquals(1.0, s.read().totalWeights, DELTA, "a NaN pair was counted as an observation")
+    }
+
+    @Test
+    fun `it agrees with ConfusionMatrixStat on the same stream`() {
+        // The invariant the change exists for. ConfusionMatrixResult.accuracy is offered so a caller can
+        // cross-check the two, and that was only meaningful on a stream of clean in-range integer labels.
+        val accuracy = AccuracyStat(numClasses = 3)
+        val matrix = ConfusionMatrixStat(numClasses = 3)
+        val pairs = listOf(
+            1.0 to 1.0, 0.0 to 0.0, 1.0 to 0.0, 2.0 to 2.0, 0.0 to 1.0,
+            1.5 to 1.9, 7.0 to 7.0, -1.0 to 0.0, Double.NaN to 1.0, 2.0 to Double.NaN,
+        )
+        for ((p, t) in pairs) {
+            accuracy.update(p, t)
+            matrix.update(p, t)
+        }
+
+        assertEquals(matrix.read().accuracy, accuracy.read().mean, DELTA, "the two disagree on accuracy")
+    }
+
+    @Test
+    fun `a non-positive class count is refused`() {
+        assertFailsWith<IllegalArgumentException> { AccuracyStat(numClasses = 0) }
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ScoreStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/ScoreStatConcurrencyTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.calibration.ReliabilityStat
 import kotlin.test.Test
@@ -82,7 +83,6 @@ class ScoreStatConcurrencyTest {
             for (i in preds.indices) s.update(preds[i], obs[i])
             s.read(0L)
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "ReliabilityStat mode=$mode")
+        assertModesAgree("ReliabilityStat", reads)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MomentsStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MomentsStatTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.DELTA
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -7,7 +8,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class MomentsStatTest {
-    private val delta = 1e-9
 
     @Test
     fun `create produces fresh independent stat`() {
@@ -18,8 +18,8 @@ class MomentsStatTest {
         }
         val m2 = m1.create()
         m1.update(4.0)
-        assertEquals(4.0, m1.read().totalWeights, delta)
-        assertEquals(0.0, m2.read().totalWeights, delta)
+        assertEquals(4.0, m1.read().totalWeights, DELTA)
+        assertEquals(0.0, m2.read().totalWeights, DELTA)
     }
 
     @Test
@@ -29,8 +29,8 @@ class MomentsStatTest {
         val data = listOf(1.0, 2.0, 3.0, 4.0, 5.0)
         data.forEach { stat.update(it, 1.0) }
 
-        assertEquals(3.0, stat.read().mean, delta)
-        assertEquals(0.0, stat.read().skewness, delta)
+        assertEquals(3.0, stat.read().mean, DELTA)
+        assertEquals(0.0, stat.read().skewness, DELTA)
     }
 
     @Test
@@ -79,8 +79,8 @@ class MomentsStatTest {
 
         m1.merge(m2.read())
 
-        assertEquals(60.5, m1.read().mean, delta)
-        assertEquals(4.0, m1.read().totalWeights, delta)
+        assertEquals(60.5, m1.read().mean, DELTA)
+        assertEquals(4.0, m1.read().totalWeights, DELTA)
     }
 
     @Test
@@ -90,11 +90,11 @@ class MomentsStatTest {
         stat.update(20.0)
         stat.reset()
 
-        assertEquals(0.0, stat.read().totalWeights, delta)
-        assertEquals(0.0, stat.read().mean, delta)
-        assertEquals(0.0, stat.read().variance, delta)
-        assertEquals(0.0, stat.read().skewness, delta)
-        assertEquals(0.0, stat.read().kurtosis, delta)
+        assertEquals(0.0, stat.read().totalWeights, DELTA)
+        assertEquals(0.0, stat.read().mean, DELTA)
+        assertEquals(0.0, stat.read().variance, DELTA)
+        assertEquals(0.0, stat.read().skewness, DELTA)
+        assertEquals(0.0, stat.read().kurtosis, DELTA)
     }
 
     @Test
@@ -102,33 +102,33 @@ class MomentsStatTest {
         val stat = MomentsStat()
         listOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0).forEach { stat.update(it, 1.0) }
         val r = stat.read()
-        assertEquals(5.0, r.mean, delta)
-        assertEquals(4.0, r.variance, delta)
-        assertEquals(32.0 / 7.0, r.sampleVariance, delta)
-        assertEquals(sqrt(32.0 / 7.0), r.sampleStdDev, delta)
+        assertEquals(5.0, r.mean, DELTA)
+        assertEquals(4.0, r.variance, DELTA)
+        assertEquals(32.0 / 7.0, r.sampleVariance, DELTA)
+        assertEquals(sqrt(32.0 / 7.0), r.sampleStdDev, DELTA)
     }
 
     @Test
     fun `sampleVariance is zero when totalWeights le 1`() {
         val empty = MomentsStat().read()
-        assertEquals(0.0, empty.sampleVariance, delta)
-        assertEquals(0.0, empty.sampleStdDev, delta)
+        assertEquals(0.0, empty.sampleVariance, DELTA)
+        assertEquals(0.0, empty.sampleStdDev, DELTA)
 
         val one = MomentsStat().apply { update(42.0, 1.0) }.read()
-        assertEquals(0.0, one.sampleVariance, delta)
-        assertEquals(0.0, one.sampleStdDev, delta)
+        assertEquals(0.0, one.sampleVariance, DELTA)
+        assertEquals(0.0, one.sampleStdDev, DELTA)
     }
 
     @Test
     fun `unbiasedSkewness is zero with two or fewer samples`() {
         val empty = MomentsStat().read()
-        assertEquals(0.0, empty.unbiasedSkewness, delta)
+        assertEquals(0.0, empty.unbiasedSkewness, DELTA)
 
         val two = MomentsStat().apply {
             update(1.0, 1.0)
             update(3.0, 1.0)
         }.read()
-        assertEquals(0.0, two.unbiasedSkewness, delta)
+        assertEquals(0.0, two.unbiasedSkewness, DELTA)
     }
 
     @Test
@@ -138,7 +138,7 @@ class MomentsStatTest {
         val r = stat.read()
         val n = r.totalWeights
         val expected = (sqrt(n * (n - 1)) / (n - 2)) * r.skewness
-        assertEquals(expected, r.unbiasedSkewness, delta)
+        assertEquals(expected, r.unbiasedSkewness, DELTA)
         assertTrue(r.unbiasedSkewness > r.skewness)
     }
 
@@ -149,7 +149,7 @@ class MomentsStatTest {
             update(2.0, 1.0)
             update(3.0, 1.0)
         }.read()
-        assertEquals(0.0, three.unbiasedKurtosis, delta)
+        assertEquals(0.0, three.unbiasedKurtosis, DELTA)
     }
 
     @Test
@@ -159,7 +159,7 @@ class MomentsStatTest {
         val r = stat.read()
         val n = r.totalWeights
         val expected = ((n - 1) / ((n - 2) * (n - 3))) * ((n + 1) * r.kurtosis + 6.0)
-        assertEquals(expected, r.unbiasedKurtosis, delta)
+        assertEquals(expected, r.unbiasedKurtosis, DELTA)
     }
 
     /** Weighted central moments computed directly, as the reference for the recurrences. */
@@ -174,7 +174,7 @@ class MomentsStatTest {
         return MomentsResult(w, mean, central(2), central(3), central(4))
     }
 
-    private fun assertMomentsEqual(expected: MomentsResult, actual: MomentsResult, tolerance: Double = delta) {
+    private fun assertMomentsEqual(expected: MomentsResult, actual: MomentsResult, tolerance: Double = DELTA) {
         assertEquals(expected.totalWeights, actual.totalWeights, tolerance, "totalWeights")
         assertEquals(expected.mean, actual.mean, tolerance, "mean")
         assertEquals(expected.m2, actual.m2, tolerance, "m2")
@@ -218,8 +218,8 @@ class MomentsStatTest {
         val values = listOf(1.0, 1.0, 1.0, 2.0, 10.0)
         val unit = MomentsStat().apply { values.forEach { update(it, 1.0) } }.read()
         val scaled = MomentsStat().apply { values.forEach { update(it, 7.0) } }.read()
-        assertEquals(unit.skewness, scaled.skewness, delta)
-        assertEquals(unit.kurtosis, scaled.kurtosis, delta)
+        assertEquals(unit.skewness, scaled.skewness, DELTA)
+        assertEquals(unit.kurtosis, scaled.kurtosis, DELTA)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
@@ -2,9 +2,9 @@ package com.eignex.kumulant.stat.summary
 
 import com.eignex.kumulant.WEIGHTED_VALUES
 import com.eignex.kumulant.WEIGHTED_WEIGHTS
-import com.eignex.kumulant.weightedReads
 import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.weightedReads
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -15,7 +15,6 @@ import kotlin.test.assertEquals
  * before the bench-side concurrency tests exercise actual contention.
  */
 class SummaryStatConcurrencyTest {
-
 
     @Test
     fun `SumStat sequential math equal across modes`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
@@ -1,8 +1,10 @@
 package com.eignex.kumulant.stat.summary
 
+import com.eignex.kumulant.WEIGHTED_VALUES
+import com.eignex.kumulant.WEIGHTED_WEIGHTS
+import com.eignex.kumulant.weightedReads
+import com.eignex.kumulant.assertModesAgree
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.SeriesStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,62 +16,48 @@ import kotlin.test.assertEquals
  */
 class SummaryStatConcurrencyTest {
 
-    private val values = doubleArrayOf(1.0, -2.0, 3.5, 0.0, 4.2, -1.1, 7.0, 2.5)
-    private val weights = doubleArrayOf(1.0, 2.0, 1.0, 3.0, 1.0, 1.0, 2.5, 0.5)
-
-    private fun <R : Result> sequentialReads(factory: (Concurrency) -> SeriesStat<R>): Map<Concurrency, R> =
-        Concurrency.entries.associateWith { mode ->
-            val s = factory(mode)
-            for (i in values.indices) s.update(values[i], 0L, weights[i])
-            s.read(0L)
-        }
 
     @Test
     fun `SumStat sequential math equal across modes`() {
-        val reads = sequentialReads { SumStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "SumStat mode=$mode")
+        val reads = weightedReads { SumStat(concurrency = it) }
+        assertModesAgree("SumStat", reads)
     }
 
     @Test
     fun `CountStat sequential math equal across modes`() {
-        val reads = sequentialReads { CountStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "CountStat mode=$mode")
+        val reads = weightedReads { CountStat(concurrency = it) }
+        assertModesAgree("CountStat", reads)
     }
 
     @Test
     fun `TotalWeightsStat sequential math equal across modes`() {
-        val reads = sequentialReads { TotalWeightsStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "TotalWeightsStat mode=$mode")
+        val reads = weightedReads { TotalWeightsStat(concurrency = it) }
+        assertModesAgree("TotalWeightsStat", reads)
     }
 
     @Test
     fun `ArgMinStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = ArgMinStat(concurrency = mode)
-            for (i in values.indices) s.update(values[i], i.toLong(), weights[i])
+            for (i in WEIGHTED_VALUES.indices) s.update(WEIGHTED_VALUES[i], i.toLong(), WEIGHTED_WEIGHTS[i])
             s.read(0L)
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "ArgMinStat mode=$mode")
+        assertModesAgree("ArgMinStat", reads)
     }
 
     @Test
     fun `ArgMaxStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = ArgMaxStat(concurrency = mode)
-            for (i in values.indices) s.update(values[i], i.toLong(), weights[i])
+            for (i in WEIGHTED_VALUES.indices) s.update(WEIGHTED_VALUES[i], i.toLong(), WEIGHTED_WEIGHTS[i])
             s.read(0L)
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "ArgMaxStat mode=$mode")
+        assertModesAgree("ArgMaxStat", reads)
     }
 
     @Test
     fun `MeanStat sequential math equal across modes`() {
-        val reads = sequentialReads { MeanStat(concurrency = it) }
+        val reads = weightedReads { MeanStat(concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "MeanStat totalWeights mode=$mode")
@@ -79,7 +67,7 @@ class SummaryStatConcurrencyTest {
 
     @Test
     fun `VarianceStat sequential math equal across modes`() {
-        val reads = sequentialReads { VarianceStat(concurrency = it) }
+        val reads = weightedReads { VarianceStat(concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "VarianceStat totalWeights mode=$mode")
@@ -90,7 +78,7 @@ class SummaryStatConcurrencyTest {
 
     @Test
     fun `MomentsStat sequential math equal across modes`() {
-        val reads = sequentialReads { MomentsStat(concurrency = it) }
+        val reads = weightedReads { MomentsStat(concurrency = it) }
         val ref = reads.getValue(Concurrency.None)
         for ((mode, r) in reads) {
             assertEquals(ref.totalWeights, r.totalWeights, 1e-9, "MomentsStat totalWeights mode=$mode")
@@ -103,23 +91,20 @@ class SummaryStatConcurrencyTest {
 
     @Test
     fun `MinStat sequential math equal across modes`() {
-        val reads = sequentialReads { MinStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "MinStat mode=$mode")
+        val reads = weightedReads { MinStat(concurrency = it) }
+        assertModesAgree("MinStat", reads)
     }
 
     @Test
     fun `MaxStat sequential math equal across modes`() {
-        val reads = sequentialReads { MaxStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "MaxStat mode=$mode")
+        val reads = weightedReads { MaxStat(concurrency = it) }
+        assertModesAgree("MaxStat", reads)
     }
 
     @Test
     fun `RangeStat sequential math equal across modes`() {
-        val reads = sequentialReads { RangeStat(concurrency = it) }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "RangeStat mode=$mode")
+        val reads = weightedReads { RangeStat(concurrency = it) }
+        assertModesAgree("RangeStat", reads)
     }
 
     @Test
@@ -127,21 +112,20 @@ class SummaryStatConcurrencyTest {
         val bernValues = doubleArrayOf(1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0)
         val reads = Concurrency.entries.associateWith { mode ->
             val s = BernoulliSumStat(concurrency = mode)
-            for (i in bernValues.indices) s.update(bernValues[i], 0L, weights[i])
+            for (i in bernValues.indices) s.update(bernValues[i], 0L, WEIGHTED_WEIGHTS[i])
             s.read(0L)
         }
-        val ref = reads.getValue(Concurrency.None)
-        for ((mode, r) in reads) assertEquals(ref, r, "BernoulliSumStat mode=$mode")
+        assertModesAgree("BernoulliSumStat", reads)
     }
 
     @Test
     fun `merge across modes preserves math`() {
-        val a = SumStat(concurrency = Concurrency.None).apply { for (v in values) update(v, 0L, 1.0) }
+        val a = SumStat(concurrency = Concurrency.None).apply { for (v in WEIGHTED_VALUES) update(v, 0L, 1.0) }
         for (mode in Concurrency.entries) {
-            val b = SumStat(concurrency = mode).apply { for (v in values) update(v, 0L, 1.0) }
+            val b = SumStat(concurrency = mode).apply { for (v in WEIGHTED_VALUES) update(v, 0L, 1.0) }
             b.merge(a.read(0L))
-            // After merge: b has 2x of values' sum.
-            assertEquals(2 * values.sum(), b.read(0L).sum, 1e-9, "merge mode=$mode")
+            // After merge: b has 2x of WEIGHTED_VALUES' sum.
+            assertEquals(2 * WEIGHTED_VALUES.sum(), b.read(0L).sum, 1e-9, "merge mode=$mode")
         }
     }
 
@@ -149,7 +133,7 @@ class SummaryStatConcurrencyTest {
     fun `reset returns to initial across modes`() {
         for (mode in Concurrency.entries) {
             val s = MeanStat(concurrency = mode)
-            for (v in values) s.update(v, 0L)
+            for (v in WEIGHTED_VALUES) s.update(v, 0L)
             s.reset()
             val r = s.read(0L)
             assertEquals(0.0, r.totalWeights, "reset mode=$mode")


### PR DESCRIPTION
## What changed

- Fixed the default gamma for a spec-built EXP3. BanditFactory inlined `min(K * eta, 1)`, the formula `Exp3Bandit.defaultGamma` had already been fixed to stop using because it saturates at 1.0 for every arm count, so `playDistribution` ignored the learned weights entirely.
- Fixed CusumStat.merge and PageHinkleyStat.merge, which averaged the incoming drift against a fresh stat's zero and so halved it.
- Added the missing arm bounds checks to RegressionContextualBandit, which had none on any of its four arm-indexed entry points.
- Fixed AbstractListStats.concurrency, which reported `None` for a list of `Strict` children.
- Widened the Bayesian SMW downdate guard from `denom == 0.0` to also reject a non-finite denominator.
- Gave AccuracyStat a `numClasses` and routed both it and ConfusionMatrixStat through `asClassLabel`, so the two agree on which labels name a class.
- Extracted shared helpers for the argmax, the inverse-CDF sampler, the max-subtracting softmax, the damped-trend series, the impurity reduction, the sketch hasher guard and counter step, the spec narrowing, the throttle and sample gates, and the feedback-primary unwrap.
- Deleted dead code: an unreferenced cell operation and both its implementations, three retained template references, two write-only atomic cells on histogram update paths, an unused list-stats factory, an unused schema helper, and four stale suppressions.
- Named the magic constants and gave the repeated defaults one home each: the nanoseconds-per-second conversion, the probability floor, the quantile merge tolerance, the ArrayBins growth policy, the window slice count, the scaler target range, and the nine Hoeffding tree tunables.
- Added SpecDefaultParityTest, which asserts a default-constructed spec materialises to the same stat a default-constructed stat gives you.
- Shared the duplicated test fixtures: one feature-vector helper for fourteen files, one linear-fit fixture for four, one concurrency sweep for eleven, and the three tolerance constants the earlier pass missed because they were spelled lowercase.

## Why

Five subagents swept the library in parallel for dead code, duplication and magic constants. Most of what came back was structural, but four defects fell out of it, and each was the same shape: a fix that landed on one copy of some duplicated logic and not on its twin.

The EXP3 one is the clearest. The class-level fix was applied and documented at length, the factory kept the old formula, and the only test asserted on the arm count. So a bandit built directly learned and the same bandit built from a wire spec was a uniform random sampler. CUSUM and Page-Hinkley are the same story against RecursiveVarianceStat, which records that exact defect and its fix. AbstractListStats is the same story against AbstractStatGroup, which carries a fifteen-line note on why the answer it was giving was untrue.

That is why the parity test matters more than any single fix here. Roughly fifty spec defaults are hand-copied second declarations of a stat constructor default, and nothing compared them. The test is behavioural rather than field-by-field so it needs no reflection and catches drift in defaults added later.

AccuracyStat and ConfusionMatrixStat both compute accuracy over the same input, and `ConfusionMatrixResult.accuracy` exists so a caller can cross-check them. Accuracy compared labels on `toLong()`, which truncates, so it scored 1.5 and 1.9 as a matching class 1 and accepted any label at all; ConfusionMatrix rejected both observations. The cross-check was only meaningful on a stream that was already clean. Requiring `numClasses` is a breaking change to the constructor and to the `Accuracy` wire payload, taken deliberately: the alternative is defaulting a bound and scoring labels the caller never declared.

The Bayesian guard could not fire as written. For a positive-definite covariance the denominator is at least 1, and reaching zero needs a covariance already outside the cone, where the argument to `sqrt` goes negative and the result is NaN instead. `Link.Log.curvature` is `exp(eta)`, which reaches the same NaN by overflow with no instability at all. Either way the NaN went into the covariance and stayed there, so every later prediction was NaN with nothing in the result saying so.

One deliberate behaviour change beyond the fixes: the eight argmax loops used two different NaN conventions, seeding the running best at `-Infinity` in the bandits and at `score(0)` in the models. The second means a NaN first score wins outright and decides every later prediction, because every comparison against NaN is false. Unified on `-Infinity`, so a poisoned model answers from its surviving coordinates.

## Testing

`./gradlew build` passes, which covers all thirteen targets plus detekt plus the ABI check. The ABI dump was regenerated only for the two intended AccuracyStat and Accuracy changes; every other commit leaves it untouched.

Each of the six behaviour fixes has a test verified to fail on the pre-fix code, checked by stashing the fix and rerunning. Two of those tests needed tightening before they earned their keep: the CUSUM alarm test passed either way until the threshold was moved between the real drift and half of it, and the Bayesian prediction assertion was wrong at first because `Infinity` is the correct Poisson mean for a large linear predictor, not corruption.

The parity test carries its own guard that deliberately mis-sets one default and confirms the comparison catches it, so a sweep that had gone blind would fail rather than pass quietly.
