### PR TITLE
Share the VFDT growth engine between both trees

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -6,14 +6,24 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
-import com.eignex.kumulant.stream.Mutex
-import com.eignex.kumulant.stream.NoopMutex
-import com.eignex.kumulant.stream.PlatformMutex
-import com.eignex.kumulant.stream.guarded
-import kotlin.concurrent.Volatile
-import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.random.Random
+
+/*
+ * The classification side's binding of the shared growth engine, mirroring `RegressionTree.kt`: a
+ * node-shape SPI over the classification node hierarchy, a snapshot-shape SPI over the classification
+ * snapshot hierarchy, and a public facade that forwards to [TreeGrowth].
+ */
+
+/** The classification instantiation of the node-shape SPI. */
+internal typealias ClassificationShapeSpi = TreeShape<
+    VectorView,
+    SerializableSplit,
+    ClassificationNode,
+    ClassificationSplitNode,
+    ClassificationAuditLeaf,
+    ClassCountsResult,
+    >
 
 /**
  * Classification mirror of [RegressionTree]: online VFDT decision tree where each leaf carries
@@ -21,35 +31,36 @@ import kotlin.random.Random
  * split. Splits fire when a candidate clears the Hoeffding bound on the configured
  * [ClassificationSplitMetric] (Gini or information gain).
  *
+ * Both trees drive the same [TreeGrowth] engine, each parameterising it with its own node types.
+ *
  * Concurrency model matches [RegressionTree]: lock-free leaf updates, single split-conversion
  * lock fired only at split-decision time.
  */
 class ClassificationTree(
     private val numClasses: Int,
-    private val splitCandidates: List<SerializableSplit>,
-    private val config: ClassificationTreeConfig = ClassificationTreeConfig(),
-    private val concurrency: Concurrency = Concurrency.None,
-    private val leafArmFactory: () -> SeriesStat<ClassCountsResult> = { ClassCountsStat(numClasses, concurrency) },
+    splitCandidates: List<SerializableSplit>,
+    config: ClassificationTreeConfig = ClassificationTreeConfig(),
+    concurrency: Concurrency = Concurrency.None,
+    leafArmFactory: () -> SeriesStat<ClassCountsResult> = { ClassCountsStat(numClasses, concurrency) },
     randomSeed: Int = 0,
 ) {
     init {
         requireAtLeastTwoClasses(numClasses)
     }
 
-    private val random = Random(randomSeed)
-    private val canGrow: Boolean = splitCandidates.isNotEmpty()
-    private val splitLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
-
-    private val nbrNodes: AtomicInt = AtomicInt(1)
-
-    @Volatile
-    private var root: ClassificationNode = newLeaf(depth = 0)
+    private val growth = TreeGrowth(
+        shape = ClassificationShape(config, leafArmFactory),
+        splitCandidates = splitCandidates,
+        config = config,
+        concurrency = concurrency,
+        randomSeed = randomSeed,
+    )
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: VectorView): ClassificationLeafNode = root.findLeaf(row)
+    fun findLeaf(row: VectorView): ClassificationLeafNode = growth.root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
-    fun rootNode(): ClassificationNode = root
+    fun rootNode(): ClassificationNode = growth.root
 
     /** Argmax class at the leaf [row] resolves to. */
     fun predict(row: VectorView): Int = findLeaf(row).arm.read(0L).predict()
@@ -58,239 +69,121 @@ class ClassificationTree(
     fun probabilities(row: VectorView): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
 
     /** Number of internal + leaf nodes currently in the tree. */
-    val nodeCount: Int get() = nbrNodes.load()
+    val nodeCount: Int get() = growth.nbrNodes.load()
 
     /** Fold an observation `(row, classLabel)` into the tree, possibly growing it. */
     fun update(row: VectorView, classLabel: Int, weight: Double = 1.0) {
         if (classLabel !in 0 until numClasses) return
-        val current = root
-        val next = updateNode(current, row, classLabel, weight, depth = 0)
-        if (next !== current) root = next
+        growth.update(row, classLabel.toDouble(), weight)
     }
 
     /** Aggregate class-count snapshot at the root, walking leaves and split carryovers. */
-    fun rootSnapshot(): ClassCountsResult = root.subtreeAggregate()
+    fun rootSnapshot(): ClassCountsResult = growth.root.subtreeAggregate()
 
     /** Reset to a single fresh leaf. */
-    fun reset() {
-        splitLock.guarded {
-            nbrNodes.store(1)
-            root = newLeaf(depth = 0)
-        }
-    }
+    fun reset() = growth.reset()
 
     /** Render the tree as nested if-else text. */
-    fun prettyPrint(indent: String = ""): String = buildString { prettyPrintTo(this, root, indent) }
+    fun prettyPrint(indent: String = ""): String = growth.prettyPrint(indent)
 
     /** Structurally merge [other] into this tree; [other] is consumed. */
-    fun merge(other: ClassificationTree) {
-        splitLock.guarded {
-            root = mergeNodes(root, other.root)
-            nbrNodes.store(countNodes(root))
-        }
-    }
+    fun merge(other: ClassificationTree) = growth.mergeTree(other.growth.root)
 
     /** Snapshot merge: same rules as [merge] but the other side is an immutable result. */
-    fun mergeSnapshot(other: TreeClassificationNodeResult) {
-        splitLock.guarded {
-            root = mergeNodeWithResult(root, other)
-            nbrNodes.store(countNodes(root))
-        }
+    fun mergeSnapshot(other: TreeClassificationNodeResult) = growth.mergeSnapshot(other, ClassificationResultShape)
+}
+
+/** Reads and writes the classification node hierarchy on the growth engine's behalf. */
+private class ClassificationShape(
+    private val config: ClassificationTreeConfig,
+    private val newArm: () -> SeriesStat<ClassCountsResult>,
+) : ClassificationShapeSpi {
+
+    override fun asSplitNode(node: ClassificationNode): ClassificationSplitNode? = node as? ClassificationSplitNode
+
+    override fun asAuditLeaf(node: ClassificationNode): ClassificationAuditLeaf? = node as? ClassificationAuditLeaf
+
+    override fun leafArm(node: ClassificationNode): SeriesStat<ClassCountsResult>? =
+        (node as? ClassificationLeafNode)?.arm
+
+    override fun splitOf(node: ClassificationSplitNode): SerializableSplit = node.split
+
+    override fun posOf(node: ClassificationSplitNode): ClassificationNode = node.pos
+
+    override fun negOf(node: ClassificationSplitNode): ClassificationNode = node.neg
+
+    override fun setPos(node: ClassificationSplitNode, child: ClassificationNode) {
+        node.pos = child
     }
 
-    private fun mergeNodes(a: ClassificationNode, b: ClassificationNode): ClassificationNode {
-        if (a is ClassificationSplitNode && b is ClassificationSplitNode && a.split == b.split) {
-            a.pos = mergeNodes(a.pos, b.pos)
-            a.neg = mergeNodes(a.neg, b.neg)
-            val bCarry = b.carryover
-            if (bCarry != null) foldIntoCarryover(a, bCarry.read(0L))
-            return a
-        }
-        if (a is ClassificationLeafNode && b is ClassificationLeafNode) {
-            a.arm.merge(b.arm.read(0L))
-            return a
-        }
-        if (a is ClassificationLeafNode && b is ClassificationSplitNode) {
-            foldIntoCarryover(b, a.arm.read(0L))
-            return b
-        }
-        foldIntoCarryover(a as ClassificationSplitNode, b.subtreeAggregate())
-        return a
+    override fun setNeg(node: ClassificationSplitNode, child: ClassificationNode) {
+        node.neg = child
     }
 
-    private fun mergeNodeWithResult(a: ClassificationNode, b: TreeClassificationNodeResult): ClassificationNode {
-        if (a is ClassificationSplitNode && b is TreeClassificationSplitResult && a.split == b.split) {
-            a.pos = mergeNodeWithResult(a.pos, b.pos)
-            a.neg = mergeNodeWithResult(a.neg, b.neg)
-            val childSum = mergeCC(b.pos.value, b.neg.value)
-            val residual = subtractCC(b.value, childSum)
-            if (residual.totalWeights > 0.0) foldIntoCarryover(a, residual)
-            return a
-        }
-        if (a is ClassificationLeafNode && b is TreeClassificationLeafResult) {
-            a.arm.merge(b.value)
-            return a
-        }
-        if (a is ClassificationLeafNode && b is TreeClassificationSplitResult) {
-            val cloned = cloneFromResult(b) as ClassificationSplitNode
-            foldIntoCarryover(cloned, a.arm.read(0L))
-            return cloned
-        }
-        foldIntoCarryover(a as ClassificationSplitNode, b.value)
-        return a
+    override fun carryoverOf(node: ClassificationSplitNode): SeriesStat<ClassCountsResult>? = node.carryover
+
+    override fun setCarryover(node: ClassificationSplitNode, arm: SeriesStat<ClassCountsResult>) {
+        node.carryover = arm
     }
 
-    private fun foldIntoCarryover(node: ClassificationSplitNode, value: ClassCountsResult) {
-        if (value.totalWeights <= 0.0) return
-        val existing = node.carryover
-        if (existing != null) {
-            existing.merge(value)
-        } else {
-            val arm = leafArmFactory()
-            arm.merge(value)
-            node.carryover = arm
-        }
-    }
+    override fun candidatesOf(leaf: ClassificationAuditLeaf): List<SerializableSplit> = leaf.candidates
 
-    /**
-     * Rebuild a live subtree from a snapshot.
-     *
-     * Carried a `depth` parameter that was threaded through every recursive call and read by none of them.
-     * Removed rather than left in place, because as written it read as a live depth cap and was not one.
-     *
-     * Whether it should be one is a separate question this does not settle: `newLeaf` refuses to grow past
-     * `config.maxDepth`, and nothing here refuses to clone past it. In practice a snapshot comes from a tree
-     * that already honoured its own `maxDepth`, so the two only diverge when the configs differ - which is a
-     * behaviour decision rather than a cleanup.
-     */
-    private fun cloneFromResult(node: TreeClassificationNodeResult): ClassificationNode {
-        nbrNodes.addAndFetch(1)
-        return when (node) {
-            is TreeClassificationLeafResult -> {
-                val arm = leafArmFactory()
-                arm.merge(node.value)
-                ClassificationTerminalLeaf(arm)
-            }
+    override fun posArmsOf(leaf: ClassificationAuditLeaf): List<SeriesStat<ClassCountsResult>> = leaf.pos
 
-            is TreeClassificationSplitResult -> {
-                val pos = cloneFromResult(node.pos)
-                val neg = cloneFromResult(node.neg)
-                val childSum = mergeCC(node.pos.value, node.neg.value)
-                val residual = subtractCC(node.value, childSum)
-                val carry = if (residual.totalWeights > 0.0) leafArmFactory().also { it.merge(residual) } else null
-                ClassificationSplitNode(split = node.split, pos = pos, neg = neg, carryover = carry)
-            }
-        }
-    }
+    override fun negArmsOf(leaf: ClassificationAuditLeaf): List<SeriesStat<ClassCountsResult>> = leaf.neg
 
-    private fun countNodes(node: ClassificationNode): Int = when (node) {
-        is ClassificationSplitNode -> 1 + countNodes(node.pos) + countNodes(node.neg)
-        is ClassificationLeafNode -> 1
-    }
+    override fun ticksOf(leaf: ClassificationAuditLeaf): AtomicLong = leaf.observationsSinceLastCheck
 
-    private fun prettyPrintTo(sb: StringBuilder, node: ClassificationNode, indent: String) {
-        when (node) {
-            is ClassificationSplitNode -> {
-                sb.append(indent).append("if (").append(node.split.toString()).append(") {\n")
-                prettyPrintTo(sb, node.pos, "$indent  ")
-                sb.append(indent).append("} else {\n")
-                prettyPrintTo(sb, node.neg, "$indent  ")
-                sb.append(indent).append("}\n")
-            }
+    override fun makeSplitNode(
+        split: SerializableSplit,
+        pos: ClassificationNode,
+        neg: ClassificationNode,
+        carryover: SeriesStat<ClassCountsResult>?,
+    ): ClassificationSplitNode = ClassificationSplitNode(split, pos, neg, carryover)
 
-            is ClassificationLeafNode -> {
-                val r = node.arm.read(0L)
-                sb.append(indent).append("leaf counts=").append(r.counts.toList()).append('\n')
-            }
-        }
-    }
+    override fun makeTerminalLeaf(arm: SeriesStat<ClassCountsResult>): ClassificationNode =
+        ClassificationTerminalLeaf(arm)
 
-    private fun newLeaf(depth: Int): ClassificationLeafNode {
-        if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
-            return ClassificationTerminalLeaf(leafArmFactory())
-        }
-        val subset = splitCandidates.pickCandidates(config.mtry, random)
-        return ClassificationAuditLeaf(
-            arm = leafArmFactory(),
-            candidates = subset,
-            pos = List(subset.size) { leafArmFactory() },
-            neg = List(subset.size) { leafArmFactory() },
-        )
-    }
+    override fun makeAuditLeaf(
+        arm: SeriesStat<ClassCountsResult>,
+        candidates: List<SerializableSplit>,
+        pos: List<SeriesStat<ClassCountsResult>>,
+        neg: List<SeriesStat<ClassCountsResult>>,
+    ): ClassificationNode = ClassificationAuditLeaf(arm, candidates, pos, neg)
 
-    private fun updateNode(
-        node: ClassificationNode,
-        row: VectorView,
-        classLabel: Int,
-        weight: Double,
-        depth: Int,
-    ): ClassificationNode = when (node) {
-        is ClassificationSplitNode -> {
-            if (node.split.direction(row)) {
-                val child = node.pos
-                val next = updateNode(child, row, classLabel, weight, depth + 1)
-                if (next !== child) node.pos = next
-            } else {
-                val child = node.neg
-                val next = updateNode(child, row, classLabel, weight, depth + 1)
-                if (next !== child) node.neg = next
-            }
-            node
-        }
+    override fun emptyArm(): SeriesStat<ClassCountsResult> = newArm()
 
-        is ClassificationTerminalLeaf -> {
-            node.arm.update(classLabel.toDouble(), 0L, weight)
-            node
-        }
+    override fun mergePayload(a: ClassCountsResult, b: ClassCountsResult): ClassCountsResult = mergeCC(a, b)
 
-        is ClassificationAuditLeaf -> updateAuditLeaf(node, row, classLabel, weight, depth)
-    }
+    override fun subtractPayload(total: ClassCountsResult, part: ClassCountsResult): ClassCountsResult =
+        subtractCC(total, part)
 
-    private fun updateAuditLeaf(
-        leaf: ClassificationAuditLeaf,
-        row: VectorView,
-        classLabel: Int,
-        weight: Double,
-        depth: Int,
-    ): ClassificationNode {
-        val y = classLabel.toDouble()
-        leaf.arm.update(y, 0L, weight)
-        for ((i, split) in leaf.candidates.withIndex()) {
-            if (split.direction(row)) {
-                leaf.pos[i].update(y, 0L, weight)
-            } else {
-                leaf.neg[i].update(y, 0L, weight)
-            }
-        }
-        val ticks = leaf.observationsSinceLastCheck.addAndFetch(1L)
-        if (ticks < config.splitPeriod) return leaf
+    override fun aggregate(node: ClassificationNode): ClassCountsResult = node.subtreeAggregate()
 
-        return splitLock.guarded {
-            // Double-check inside the lock: another thread may have already audited
-            // (and reset the counter) or replaced this leaf.
-            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@guarded leaf
-            leaf.observationsSinceLastCheck.store(0L)
+    override fun rank(
+        total: ClassCountsResult,
+        pos: List<ClassCountsResult>,
+        neg: List<ClassCountsResult>,
+    ): SplitInfo = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
 
-            val total = leaf.arm.read(0L)
-            val pos = leaf.pos.map { it.read(0L) }
-            val neg = leaf.neg.map { it.read(0L) }
-            val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            // Every gate lives in shouldSplit now. Both trees spelled the three of them out, and the
-            // Hoeffding-versus-tau disjunction in particular is the kind of condition that reads correct
-            // in either copy while the two have quietly stopped meaning the same thing.
-            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded leaf
+    override fun leafLabel(arm: ClassCountsResult): String = "leaf counts=${arm.counts.toList()}"
+}
 
-            // Stash the pre-split aggregate as the new split's carryover so it shows up
-            // in subtree aggregates without burdening the hot path. New leaves start
-            // empty so prior-driven Thompson/UCB exploration behaves as it did before
-            // the split fired.
-            nbrNodes.addAndFetch(2)
-            ClassificationSplitNode(
-                split = leaf.candidates[ranked.bestIndex],
-                pos = newLeaf(depth + 1),
-                neg = newLeaf(depth + 1),
-                carryover = leaf.arm,
-            )
-        }
-    }
+/** Reads the immutable classification snapshot hierarchy on the growth engine's behalf. */
+private object ClassificationResultShape : TreeResultShape<
+    SerializableSplit,
+    TreeClassificationNodeResult,
+    TreeClassificationSplitResult,
+    ClassCountsResult,
+    > {
+    override fun asSplitResult(node: TreeClassificationNodeResult): TreeClassificationSplitResult? =
+        node as? TreeClassificationSplitResult
+
+    override fun splitOf(node: TreeClassificationSplitResult): SerializableSplit = node.split
+
+    override fun posOf(node: TreeClassificationSplitResult): TreeClassificationNodeResult = node.pos
+
+    override fun negOf(node: TreeClassificationSplitResult): TreeClassificationNodeResult = node.neg
+
+    override fun valueOf(node: TreeClassificationNodeResult): ClassCountsResult = node.value
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -6,14 +6,24 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
-import com.eignex.kumulant.stream.Mutex
-import com.eignex.kumulant.stream.NoopMutex
-import com.eignex.kumulant.stream.PlatformMutex
-import com.eignex.kumulant.stream.guarded
-import kotlin.concurrent.Volatile
-import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.random.Random
+
+/*
+ * The regression side's binding of the shared growth engine. Everything the tree does structurally lives
+ * in [TreeGrowth]; this file supplies the node-shape SPI over the regression node hierarchy and a public
+ * facade that forwards to it.
+ */
+
+/** The regression instantiation of the node-shape SPI. */
+internal typealias RegressionShapeSpi<Row> = TreeShape<
+    Row,
+    Split<Row>,
+    RegressionNode<Row>,
+    RegressionSplitNode<Row>,
+    RegressionAuditLeaf<Row>,
+    WeightedVarianceResult,
+    >
 
 /**
  * Online VFDT-style decision tree partitioning feature rows of type [Row]. Each leaf
@@ -34,229 +44,139 @@ import kotlin.random.Random
  * time. The hot update path therefore touches exactly one arm: the leaf the observation
  * routes to.
  *
- * Concurrency: leaf-arm updates run lock-free (the arms themselves honour [concurrency]).
+ * The growth algorithm itself is shared with [ClassificationTree]; both are thin facades over
+ * [TreeGrowth], which they parameterise by their own node types.
+ *
+ * Concurrency: leaf-arm updates run lock-free (the arms themselves honour `concurrency`).
  * The split-conversion path; the only one that mutates tree structure; is serialised
  * by a single per-tree lock, fired only every [RegressionTreeConfig.splitPeriod] observations per
  * audit leaf. Pointer writes on the hot path are skipped when the child reference is
  * unchanged, so the typical update is pure arm arithmetic.
  */
 class RegressionTree<Row>(
-    private val splitCandidates: List<Split<Row>>,
-    private val config: RegressionTreeConfig = RegressionTreeConfig(),
-    private val concurrency: Concurrency = Concurrency.None,
-    internal val leafArmFactory: () -> SeriesStat<WeightedVarianceResult> = { VarianceStat(concurrency) },
+    splitCandidates: List<Split<Row>>,
+    config: RegressionTreeConfig = RegressionTreeConfig(),
+    concurrency: Concurrency = Concurrency.None,
+    leafArmFactory: () -> SeriesStat<WeightedVarianceResult> = { VarianceStat(concurrency) },
     randomSeed: Int = 0,
 ) {
-    private val random = Random(randomSeed)
-    private val canGrow: Boolean = splitCandidates.isNotEmpty()
-    internal val splitLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
-
-    internal val nbrNodes: AtomicInt = AtomicInt(1)
-
-    @Volatile
-    internal var root: RegressionNode<Row> = newLeaf(depth = 0)
+    internal val growth = TreeGrowth(
+        shape = RegressionShape<Row>(config, leafArmFactory),
+        splitCandidates = splitCandidates,
+        config = config,
+        concurrency = concurrency,
+        randomSeed = randomSeed,
+    )
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: Row): RegressionLeafNode<Row> = root.findLeaf(row)
+    fun findLeaf(row: Row): RegressionLeafNode<Row> = growth.root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
-    fun rootNode(): RegressionNode<Row> = root
+    fun rootNode(): RegressionNode<Row> = growth.root
 
     /** Mean of the leaf [row] resolves to. */
     fun predict(row: Row): Double = findLeaf(row).arm.read(0L).mean
 
     /** Number of internal + leaf nodes currently in the tree. */
-    val nodeCount: Int get() = nbrNodes.load()
+    val nodeCount: Int get() = growth.nbrNodes.load()
 
     /** Fold an observation into the tree, possibly growing it. */
-    fun update(row: Row, value: Double, weight: Double = 1.0) {
-        val current = root
-        val next = updateNode(current, row, value, weight, depth = 0)
-        if (next !== current) root = next
-    }
+    fun update(row: Row, value: Double, weight: Double = 1.0) = growth.update(row, value, weight)
 
     /** Aggregate snapshot at the root; derived by walking leaves and any
      *  [RegressionSplitNode.carryover] aggregates. Under concurrent updates with active growth,
      *  pointer races at split-time can leak observations into orphaned sub-arms; this
      *  walk is therefore best-effort and may drift by a few ULPs of the configured
      *  workload under contention. Single-threaded runs are exact. */
-    fun rootSnapshot(): WeightedVarianceResult = root.subtreeAggregate()
+    fun rootSnapshot(): WeightedVarianceResult = growth.root.subtreeAggregate()
 
     /** Reset to a single fresh leaf. */
-    fun reset() {
-        splitLock.guarded {
-            nbrNodes.store(1)
-            root = newLeaf(depth = 0)
-        }
-    }
+    fun reset() = growth.reset()
 
     /** Render the tree as nested `if (split) { ... } else { ... }` text. */
-    fun prettyPrint(indent: String = ""): String = buildString { prettyPrintTo(this, root, indent) }
+    fun prettyPrint(indent: String = ""): String = growth.prettyPrint(indent)
 
     /**
      * Structurally merge [other] into this tree. [other] is consumed (its node references
-     * may be grafted into this tree) and must not be used afterwards.
-     *
-     *  - **Same split predicate**: recurse on both children; internal aggregates are
-     *    derived from leaves, so no per-split merge step is needed.
-     *  - **Both leaves**: merge arms directly.
-     *  - **Self leaf, other split**: adopt other's structure wholesale and fold self's
-     *    leaf aggregate into the adopted subtree's leftmost leaf.
-     *  - **Self split, other leaf** *or* **different splits**: keep self's structure
-     *    and fold other's aggregate (recursively combined if other is a split) into
-     *    self's leftmost leaf.
-     *
-     * The "leftmost leaf" rule preserves the merged total weight but biases the
-     * un-routable observations into a single bucket; an honest fallback when the
-     * structures don't align.
+     * may be grafted into this tree) and must not be used afterwards. See [TreeGrowth.mergeTree]
+     * for the alignment rules.
      */
-    fun merge(other: RegressionTree<Row>) {
-        splitLock.guarded {
-            root = mergeNodes(root, other.root)
-            nbrNodes.store(countNodes(root))
-        }
+    fun merge(other: RegressionTree<Row>) = growth.mergeTree(other.growth.root)
+}
+
+/** Reads and writes the regression node hierarchy on the growth engine's behalf. */
+private class RegressionShape<Row>(
+    private val config: RegressionTreeConfig,
+    private val newArm: () -> SeriesStat<WeightedVarianceResult>,
+) : RegressionShapeSpi<Row> {
+
+    override fun asSplitNode(node: RegressionNode<Row>): RegressionSplitNode<Row>? = node as? RegressionSplitNode<Row>
+
+    override fun asAuditLeaf(node: RegressionNode<Row>): RegressionAuditLeaf<Row>? = node as? RegressionAuditLeaf<Row>
+
+    override fun leafArm(node: RegressionNode<Row>): SeriesStat<WeightedVarianceResult>? =
+        (node as? RegressionLeafNode<Row>)?.arm
+
+    override fun splitOf(node: RegressionSplitNode<Row>): Split<Row> = node.split
+
+    override fun posOf(node: RegressionSplitNode<Row>): RegressionNode<Row> = node.pos
+
+    override fun negOf(node: RegressionSplitNode<Row>): RegressionNode<Row> = node.neg
+
+    override fun setPos(node: RegressionSplitNode<Row>, child: RegressionNode<Row>) {
+        node.pos = child
     }
 
-    private fun mergeNodes(a: RegressionNode<Row>, b: RegressionNode<Row>): RegressionNode<Row> {
-        if (a is RegressionSplitNode && b is RegressionSplitNode && a.split == b.split) {
-            a.pos = mergeNodes(a.pos, b.pos)
-            a.neg = mergeNodes(a.neg, b.neg)
-            val bCarry = b.carryover
-            if (bCarry != null) foldIntoCarryover(a, bCarry.read(0L))
-            return a
-        }
-        if (a is RegressionLeafNode && b is RegressionLeafNode) {
-            a.arm.merge(b.arm.read(0L))
-            return a
-        }
-        if (a is RegressionLeafNode && b is RegressionSplitNode) {
-            foldIntoCarryover(b, a.arm.read(0L))
-            return b
-        }
-        // a split + b leaf, or splits differ: keep a's structure, fold b's aggregate.
-        foldIntoCarryover(a as RegressionSplitNode, b.subtreeAggregate())
-        return a
+    override fun setNeg(node: RegressionSplitNode<Row>, child: RegressionNode<Row>) {
+        node.neg = child
     }
 
-    internal fun foldIntoCarryover(node: RegressionSplitNode<Row>, value: WeightedVarianceResult) {
-        if (value.totalWeights <= 0.0) return
-        val existing = node.carryover
-        if (existing != null) {
-            existing.merge(value)
-        } else {
-            val arm = leafArmFactory()
-            arm.merge(value)
-            node.carryover = arm
-        }
+    override fun carryoverOf(node: RegressionSplitNode<Row>): SeriesStat<WeightedVarianceResult>? = node.carryover
+
+    override fun setCarryover(node: RegressionSplitNode<Row>, arm: SeriesStat<WeightedVarianceResult>) {
+        node.carryover = arm
     }
 
-    internal fun countNodes(node: RegressionNode<Row>): Int = when (node) {
-        is RegressionSplitNode -> 1 + countNodes(node.pos) + countNodes(node.neg)
-        is RegressionLeafNode -> 1
-    }
+    override fun candidatesOf(leaf: RegressionAuditLeaf<Row>): List<Split<Row>> = leaf.candidates
 
-    private fun prettyPrintTo(sb: StringBuilder, node: RegressionNode<Row>, indent: String) {
-        when (node) {
-            is RegressionSplitNode -> {
-                sb.append(indent).append("if (").append(node.split.toString()).append(") {\n")
-                prettyPrintTo(sb, node.pos, "$indent  ")
-                sb.append(indent).append("} else {\n")
-                prettyPrintTo(sb, node.neg, "$indent  ")
-                sb.append(indent).append("}\n")
-            }
+    override fun posArmsOf(leaf: RegressionAuditLeaf<Row>): List<SeriesStat<WeightedVarianceResult>> = leaf.pos
 
-            is RegressionLeafNode -> {
-                val mean = node.arm.read(0L).mean
-                sb.append(indent).append("leaf mean=").append(mean).append('\n')
-            }
-        }
-    }
+    override fun negArmsOf(leaf: RegressionAuditLeaf<Row>): List<SeriesStat<WeightedVarianceResult>> = leaf.neg
 
-    private fun newLeaf(depth: Int): RegressionLeafNode<Row> {
-        if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
-            return RegressionTerminalLeaf(leafArmFactory())
-        }
-        val subset = splitCandidates.pickCandidates(config.mtry, random)
-        return RegressionAuditLeaf(
-            arm = leafArmFactory(),
-            candidates = subset,
-            pos = List(subset.size) { leafArmFactory() },
-            neg = List(subset.size) { leafArmFactory() },
-        )
-    }
+    override fun ticksOf(leaf: RegressionAuditLeaf<Row>): AtomicLong = leaf.observationsSinceLastCheck
 
-    private fun updateNode(
-        node: RegressionNode<Row>,
-        row: Row,
-        value: Double,
-        weight: Double,
-        depth: Int,
-    ): RegressionNode<Row> = when (node) {
-        is RegressionSplitNode -> {
-            if (node.split.direction(row)) {
-                val child = node.pos
-                val next = updateNode(child, row, value, weight, depth + 1)
-                if (next !== child) node.pos = next
-            } else {
-                val child = node.neg
-                val next = updateNode(child, row, value, weight, depth + 1)
-                if (next !== child) node.neg = next
-            }
-            node
-        }
+    override fun makeSplitNode(
+        split: Split<Row>,
+        pos: RegressionNode<Row>,
+        neg: RegressionNode<Row>,
+        carryover: SeriesStat<WeightedVarianceResult>?,
+    ): RegressionSplitNode<Row> = RegressionSplitNode(split, pos, neg, carryover)
 
-        is RegressionTerminalLeaf -> {
-            node.arm.update(value, 0L, weight)
-            node
-        }
+    override fun makeTerminalLeaf(arm: SeriesStat<WeightedVarianceResult>): RegressionNode<Row> =
+        RegressionTerminalLeaf(arm)
 
-        is RegressionAuditLeaf -> updateAuditLeaf(node, row, value, weight, depth)
-    }
+    override fun makeAuditLeaf(
+        arm: SeriesStat<WeightedVarianceResult>,
+        candidates: List<Split<Row>>,
+        pos: List<SeriesStat<WeightedVarianceResult>>,
+        neg: List<SeriesStat<WeightedVarianceResult>>,
+    ): RegressionNode<Row> = RegressionAuditLeaf(arm, candidates, pos, neg)
 
-    private fun updateAuditLeaf(
-        leaf: RegressionAuditLeaf<Row>,
-        row: Row,
-        value: Double,
-        weight: Double,
-        depth: Int,
-    ): RegressionNode<Row> {
-        leaf.arm.update(value, 0L, weight)
-        for ((i, split) in leaf.candidates.withIndex()) {
-            if (split.direction(row)) {
-                leaf.pos[i].update(value, 0L, weight)
-            } else {
-                leaf.neg[i].update(value, 0L, weight)
-            }
-        }
-        val ticks = leaf.observationsSinceLastCheck.addAndFetch(1L)
-        if (ticks < config.splitPeriod) return leaf
+    override fun emptyArm(): SeriesStat<WeightedVarianceResult> = newArm()
 
-        return splitLock.guarded {
-            // Double-check inside the lock: another thread may have already audited
-            // (and reset the counter) or replaced this leaf.
-            if (leaf.observationsSinceLastCheck.load() < config.splitPeriod) return@guarded leaf
-            leaf.observationsSinceLastCheck.store(0L)
+    override fun mergePayload(a: WeightedVarianceResult, b: WeightedVarianceResult): WeightedVarianceResult =
+        mergeWVR(a, b)
 
-            val total = leaf.arm.read(0L)
-            val pos = leaf.pos.map { it.read(0L) }
-            val neg = leaf.neg.map { it.read(0L) }
-            val ranked = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
-            // Every gate lives in shouldSplit now. Both trees spelled the three of them out, and the
-            // Hoeffding-versus-tau disjunction in particular is the kind of condition that reads correct
-            // in either copy while the two have quietly stopped meaning the same thing.
-            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded leaf
+    override fun subtractPayload(total: WeightedVarianceResult, part: WeightedVarianceResult): WeightedVarianceResult =
+        subtractWVR(total, part)
 
-            // Stash the pre-split aggregate as the new split's carryover so it shows up
-            // in subtree aggregates without burdening the hot path. New leaves start
-            // empty so prior-driven Thompson/UCB exploration behaves as it did before
-            // the split fired.
-            nbrNodes.addAndFetch(2)
-            RegressionSplitNode(
-                split = leaf.candidates[ranked.bestIndex],
-                pos = newLeaf(depth + 1),
-                neg = newLeaf(depth + 1),
-                carryover = leaf.arm,
-            )
-        }
-    }
+    override fun aggregate(node: RegressionNode<Row>): WeightedVarianceResult = node.subtreeAggregate()
+
+    override fun rank(
+        total: WeightedVarianceResult,
+        pos: List<WeightedVarianceResult>,
+        neg: List<WeightedVarianceResult>,
+    ): SplitInfo = config.metric.rank(total, pos, neg, config.minSamplesSplit, config.minSamplesLeaf)
+
+    override fun leafLabel(arm: WeightedVarianceResult): String = "leaf mean=${arm.mean}"
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowth.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowth.kt
@@ -1,0 +1,419 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
+package com.eignex.kumulant.stat.regression.tree
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.stream.Mutex
+import com.eignex.kumulant.stream.NoopMutex
+import com.eignex.kumulant.stream.PlatformMutex
+import com.eignex.kumulant.stream.guarded
+import kotlin.concurrent.Volatile
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.random.Random
+
+/*
+ * The VFDT growth engine, shared by [RegressionTree] and [ClassificationTree].
+ *
+ * The trees run one algorithm over two payload types, but their node hierarchies are public and
+ * wire-visible, so the types must stay distinct: `RegressionNode` is generic in the row type and carries
+ * weighted-variance arms, `ClassificationNode` is fixed to a dense vector row and carries class-count
+ * arms. What is shared is therefore the engine, parameterised by [TreeShape] - an internal SPI that
+ * narrows nodes, reads and writes their children, and builds new ones.
+ */
+
+/**
+ * The node-shape SPI the growth engine drives. Every member is a one-liner over one tree's node types.
+ *
+ * The narrowing members ([asSplitNode], [asAuditLeaf], [leafArm]) return null when the node is not of
+ * that kind; the engine dispatches on a chain of null checks rather than a `when` over a sealed type.
+ */
+internal interface TreeShape<Row, S : Split<Row>, N : Any, SN : N, AL : N, P : HasObservationCount> {
+
+    /** The node as a split node, or null when it is a leaf. */
+    fun asSplitNode(node: N): SN?
+
+    /** The node as an audit leaf, or null when it is a split or a terminal leaf. */
+    fun asAuditLeaf(node: N): AL?
+
+    /** The leaf's live accumulator, or null when the node is a split (splits hold no live arm). */
+    fun leafArm(node: N): SeriesStat<P>?
+
+    /** The split node's routing predicate. */
+    fun splitOf(node: SN): S
+
+    /** The child taken when the predicate holds. */
+    fun posOf(node: SN): N
+
+    /** The child taken when the predicate does not hold. */
+    fun negOf(node: SN): N
+
+    /** Repoint the true-side child. */
+    fun setPos(node: SN, child: N)
+
+    /** Repoint the false-side child. */
+    fun setNeg(node: SN, child: N)
+
+    /** The split's orphan-aggregate arm, or null when it holds none. */
+    fun carryoverOf(node: SN): SeriesStat<P>?
+
+    /** Install an orphan-aggregate arm on the split. */
+    fun setCarryover(node: SN, arm: SeriesStat<P>)
+
+    /** The candidate splits this audit leaf is evaluating. */
+    fun candidatesOf(leaf: AL): List<S>
+
+    /** Per-candidate accumulators for observations routing true. */
+    fun posArmsOf(leaf: AL): List<SeriesStat<P>>
+
+    /** Per-candidate accumulators for observations routing false. */
+    fun negArmsOf(leaf: AL): List<SeriesStat<P>>
+
+    /** The audit leaf's split-period tick counter. */
+    fun ticksOf(leaf: AL): AtomicLong
+
+    /** Build a split node. */
+    fun makeSplitNode(split: S, pos: N, neg: N, carryover: SeriesStat<P>?): SN
+
+    /** Build a leaf that will never be audited again. */
+    fun makeTerminalLeaf(arm: SeriesStat<P>): N
+
+    /** Build a leaf that audits the given candidate subset. */
+    fun makeAuditLeaf(arm: SeriesStat<P>, candidates: List<S>, pos: List<SeriesStat<P>>, neg: List<SeriesStat<P>>): N
+
+    /** A fresh, empty accumulator of the tree's payload type. */
+    fun emptyArm(): SeriesStat<P>
+
+    /** Combine two payload aggregates. */
+    fun mergePayload(a: P, b: P): P
+
+    /** Recover the other summand of a merge; the inverse of [mergePayload]. */
+    fun subtractPayload(total: P, part: P): P
+
+    /** Aggregate over every observation routed through the subtree at this node. */
+    fun aggregate(node: N): P
+
+    /** Score the candidates at a leaf under the tree's configured split criterion. */
+    fun rank(total: P, pos: List<P>, neg: List<P>): SplitInfo
+
+    /** The `prettyPrint` text for a leaf holding this aggregate, without indent or newline. */
+    fun leafLabel(arm: P): String
+}
+
+/**
+ * The snapshot-shape SPI, used only by the snapshot-merge paths.
+ *
+ * Kept separate from [TreeShape] because the snapshot hierarchies are immutable, serializable, and only
+ * ever seen over a dense vector row, while [TreeShape] describes live nodes over an arbitrary row type.
+ */
+internal interface TreeResultShape<S, R : Any, RS : R, P : HasObservationCount> {
+
+    /** The snapshot node as a split snapshot, or null when it is a leaf snapshot. */
+    fun asSplitResult(node: R): RS?
+
+    /** The split snapshot's routing predicate. */
+    fun splitOf(node: RS): S
+
+    /** The subtree snapshot taken when the predicate holds. */
+    fun posOf(node: RS): R
+
+    /** The subtree snapshot taken when the predicate does not hold. */
+    fun negOf(node: RS): R
+
+    /** The aggregate this snapshot node records for its whole subtree. */
+    fun valueOf(node: R): P
+}
+
+/**
+ * Owns one tree: its root pointer, node count, split lock, PRNG and candidate pool, and every operation
+ * that reads or rewrites its structure.
+ *
+ * Concurrency: leaf-arm updates run lock-free and honour whatever contract the arms were built with; the
+ * split-conversion path, the only one that mutates structure, is serialised by a single per-tree lock and
+ * fires only every `splitPeriod` observations per audit leaf. Pointer writes on the hot path are skipped
+ * when the child reference is unchanged.
+ */
+internal class TreeGrowth<Row, S : Split<Row>, N : Any, SN : N, AL : N, P : HasObservationCount>(
+    private val shape: TreeShape<Row, S, N, SN, AL, P>,
+    private val splitCandidates: List<S>,
+    private val config: HoeffdingTreeConfig,
+    concurrency: Concurrency,
+    randomSeed: Int,
+) {
+    private val random = Random(randomSeed)
+    private val canGrow: Boolean = splitCandidates.isNotEmpty()
+
+    /** Serialises split conversions and structural merges. */
+    val splitLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
+
+    /** Internal plus leaf nodes currently in the tree. */
+    val nbrNodes: AtomicInt = AtomicInt(1)
+
+    /** Live root. Volatile because the hot path reads it without the lock. */
+    @Volatile
+    var root: N = newLeaf(depth = 0)
+
+    /** Fold an observation into the tree, possibly growing it. */
+    fun update(row: Row, value: Double, weight: Double) {
+        val current = root
+        val next = updateNode(current, row, value, weight, depth = 0)
+        if (next !== current) root = next
+    }
+
+    /** Reset to a single fresh leaf. */
+    fun reset() {
+        splitLock.guarded {
+            nbrNodes.store(1)
+            root = newLeaf(depth = 0)
+        }
+    }
+
+    /** Render the tree as nested `if (split) { ... } else { ... }` text. */
+    fun prettyPrint(indent: String): String = buildString { printTo(this, root, indent) }
+
+    /**
+     * Structurally merge another tree's root into this one; the other side is consumed.
+     *
+     *  - **Same split predicate**: recurse on both children; internal aggregates are derived from leaves,
+     *    so no per-split merge step is needed.
+     *  - **Both leaves**: merge arms directly.
+     *  - **Self leaf, other split**: adopt the other structure wholesale and fold this leaf's aggregate
+     *    into the adopted subtree's leftmost leaf.
+     *  - **Self split, other leaf**, or **different splits**: keep this structure and fold the other
+     *    aggregate, recursively combined if it is a split, into this tree's leftmost leaf.
+     *
+     * The leftmost-leaf rule preserves the merged total weight but biases the un-routable observations
+     * into a single bucket; an honest fallback when the structures do not align.
+     */
+    fun mergeTree(other: N) {
+        splitLock.guarded {
+            root = mergeNodes(root, other)
+            nbrNodes.store(countNodes(root))
+        }
+    }
+
+    /** Snapshot merge: the same rules as [mergeTree], but the other side is an immutable snapshot. */
+    fun <R : Any, RS : R> mergeSnapshot(other: R, results: TreeResultShape<S, R, RS, P>) {
+        splitLock.guarded {
+            root = mergeNodeWithResult(root, other, results)
+            nbrNodes.store(countNodes(root))
+        }
+    }
+
+    /**
+     * A newborn leaf at [depth]: an audit leaf if the tree may still grow there, a terminal leaf if not.
+     *
+     * The node ceiling is tested as `nbrNodes.load() + 1` rather than the two nodes a split actually adds,
+     * because it is checked at each leaf birth and the sibling's own birth checks it again.
+     */
+    private fun newLeaf(depth: Int): N {
+        if (depth >= config.maxDepth || nbrNodes.load() + 1 > config.maxNodes || !canGrow) {
+            return shape.makeTerminalLeaf(shape.emptyArm())
+        }
+        val subset = splitCandidates.pickCandidates(config.mtry, random)
+        return shape.makeAuditLeaf(
+            arm = shape.emptyArm(),
+            candidates = subset,
+            pos = List(subset.size) { shape.emptyArm() },
+            neg = List(subset.size) { shape.emptyArm() },
+        )
+    }
+
+    /** Internal plus leaf nodes in the subtree at [node]. */
+    fun countNodes(node: N): Int {
+        val split = shape.asSplitNode(node) ?: return 1
+        return 1 + countNodes(shape.posOf(split)) + countNodes(shape.negOf(split))
+    }
+
+    /**
+     * Route one observation to its leaf and fold it in, returning the node that should sit in this slot
+     * afterwards - the same node, unless an audit leaf converted itself into a split.
+     */
+    private fun updateNode(node: N, row: Row, value: Double, weight: Double, depth: Int): N {
+        val split = shape.asSplitNode(node)
+        if (split != null) {
+            if (shape.splitOf(split).direction(row)) {
+                val child = shape.posOf(split)
+                val next = updateNode(child, row, value, weight, depth + 1)
+                if (next !== child) shape.setPos(split, next)
+            } else {
+                val child = shape.negOf(split)
+                val next = updateNode(child, row, value, weight, depth + 1)
+                if (next !== child) shape.setNeg(split, next)
+            }
+            return node
+        }
+        val arm = shape.leafArm(node) ?: return node
+        arm.update(value, 0L, weight)
+        val audit = shape.asAuditLeaf(node) ?: return node
+        return updateAuditLeaf(node, audit, arm, row, value, weight, depth)
+    }
+
+    /**
+     * Fold the observation into every candidate's pos/neg sub-arm, then, on the observations that land on
+     * a split-period boundary, decide whether the leaf has earned a split.
+     *
+     * The leaf's own arm was already updated by [updateNode], which is shared with the terminal-leaf path.
+     */
+    private fun updateAuditLeaf(
+        node: N,
+        leaf: AL,
+        arm: SeriesStat<P>,
+        row: Row,
+        value: Double,
+        weight: Double,
+        depth: Int,
+    ): N {
+        val candidates = shape.candidatesOf(leaf)
+        val posArms = shape.posArmsOf(leaf)
+        val negArms = shape.negArmsOf(leaf)
+        for ((i, split) in candidates.withIndex()) {
+            if (split.direction(row)) {
+                posArms[i].update(value, 0L, weight)
+            } else {
+                negArms[i].update(value, 0L, weight)
+            }
+        }
+        val ticks = shape.ticksOf(leaf)
+        if (ticks.addAndFetch(1L) < config.splitPeriod) return node
+
+        return splitLock.guarded {
+            // Double-check inside the lock: another thread may have already audited
+            // (and reset the counter) or replaced this leaf.
+            if (ticks.load() < config.splitPeriod) return@guarded node
+            ticks.store(0L)
+
+            val total = arm.read(0L)
+            val ranked = shape.rank(total, posArms.map { it.read(0L) }, negArms.map { it.read(0L) })
+            // shouldSplit holds every gate: the weight floor, a scorable winner, and the
+            // Hoeffding-versus-tau disjunction.
+            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded node
+
+            // Stash the pre-split aggregate as the new split's carryover so it shows up in subtree
+            // aggregates without burdening the hot path. New leaves start empty, so prior-driven
+            // Thompson/UCB exploration is not skewed by data the split already accounted for.
+            nbrNodes.addAndFetch(2)
+            shape.makeSplitNode(
+                split = candidates[ranked.bestIndex],
+                pos = newLeaf(depth + 1),
+                neg = newLeaf(depth + 1),
+                carryover = arm,
+            )
+        }
+    }
+
+    private fun mergeNodes(a: N, b: N): N {
+        val aArm = shape.leafArm(a)
+        if (aArm != null) {
+            val bArm = shape.leafArm(b)
+            if (bArm != null) {
+                aArm.merge(bArm.read(0L))
+                return a
+            }
+            val bSplit = shape.asSplitNode(b) ?: return a
+            foldIntoCarryover(bSplit, aArm.read(0L))
+            return b
+        }
+        val aSplit = shape.asSplitNode(a) ?: return a
+        val bSplit = shape.asSplitNode(b)
+        if (bSplit != null && shape.splitOf(aSplit) == shape.splitOf(bSplit)) {
+            shape.setPos(aSplit, mergeNodes(shape.posOf(aSplit), shape.posOf(bSplit)))
+            shape.setNeg(aSplit, mergeNodes(shape.negOf(aSplit), shape.negOf(bSplit)))
+            val bCarry = shape.carryoverOf(bSplit)
+            if (bCarry != null) foldIntoCarryover(aSplit, bCarry.read(0L))
+            return a
+        }
+        // a split + b leaf, or the splits differ: keep a's structure, fold b's aggregate.
+        foldIntoCarryover(aSplit, shape.aggregate(b))
+        return a
+    }
+
+    private fun <R : Any, RS : R> mergeNodeWithResult(a: N, b: R, results: TreeResultShape<S, R, RS, P>): N {
+        val bSplit = results.asSplitResult(b)
+        val aArm = shape.leafArm(a)
+        if (aArm != null) {
+            if (bSplit == null) {
+                aArm.merge(results.valueOf(b))
+                return a
+            }
+            val cloned = cloneFromResult(b, results)
+            val clonedSplit = shape.asSplitNode(cloned) ?: return cloned
+            foldIntoCarryover(clonedSplit, aArm.read(0L))
+            return cloned
+        }
+        val aSplit = shape.asSplitNode(a) ?: return a
+        if (bSplit != null && shape.splitOf(aSplit) == results.splitOf(bSplit)) {
+            shape.setPos(aSplit, mergeNodeWithResult(shape.posOf(aSplit), results.posOf(bSplit), results))
+            shape.setNeg(aSplit, mergeNodeWithResult(shape.negOf(aSplit), results.negOf(bSplit), results))
+            // b's value carries the full subtree aggregate; the child recursion already folded the
+            // structurally-aligned portion. Pull only the residual, what b's value holds beyond the sum
+            // of its children, into a's carryover.
+            val residual = residualOf(bSplit, results)
+            if (residual.totalWeights > 0.0) foldIntoCarryover(aSplit, residual)
+            return a
+        }
+        // a split + b leaf, or the splits differ: keep a's structure, fold b's aggregate.
+        foldIntoCarryover(aSplit, results.valueOf(b))
+        return a
+    }
+
+    /**
+     * Rebuild a live subtree from a snapshot.
+     *
+     * Deliberately unbounded by depth: [newLeaf] refuses to grow past `maxDepth`, but cloning honours the
+     * snapshot's shape whatever it is. A snapshot normally comes from a tree that already respected its own
+     * `maxDepth`, so the two only diverge when the two configs differ.
+     */
+    private fun <R : Any, RS : R> cloneFromResult(node: R, results: TreeResultShape<S, R, RS, P>): N {
+        nbrNodes.addAndFetch(1)
+        val split = results.asSplitResult(node)
+        if (split == null) {
+            val arm = shape.emptyArm()
+            arm.merge(results.valueOf(node))
+            return shape.makeTerminalLeaf(arm)
+        }
+        val pos = cloneFromResult(results.posOf(split), results)
+        val neg = cloneFromResult(results.negOf(split), results)
+        // Re-establish any orphan aggregate the snapshot encodes by comparing the recorded
+        // value against the sum of the cloned children's aggregates.
+        val residual = residualOf(split, results)
+        val carry = if (residual.totalWeights > 0.0) shape.emptyArm().also { it.merge(residual) } else null
+        return shape.makeSplitNode(results.splitOf(split), pos, neg, carry)
+    }
+
+    /** What a split snapshot's own aggregate holds beyond the sum of its two children's. */
+    private fun <R : Any, RS : R> residualOf(split: RS, results: TreeResultShape<S, R, RS, P>): P {
+        val childSum = shape.mergePayload(
+            results.valueOf(results.posOf(split)),
+            results.valueOf(results.negOf(split)),
+        )
+        return shape.subtractPayload(results.valueOf(split), childSum)
+    }
+
+    private fun foldIntoCarryover(node: SN, value: P) {
+        if (value.totalWeights <= 0.0) return
+        val existing = shape.carryoverOf(node)
+        if (existing != null) {
+            existing.merge(value)
+        } else {
+            shape.setCarryover(node, shape.emptyArm().also { it.merge(value) })
+        }
+    }
+
+    private fun printTo(sb: StringBuilder, node: N, indent: String) {
+        val split = shape.asSplitNode(node)
+        if (split == null) {
+            val arm = shape.leafArm(node) ?: return
+            sb.append(indent).append(shape.leafLabel(arm.read(0L))).append('\n')
+            return
+        }
+        sb.append(indent).append("if (").append(shape.splitOf(split).toString()).append(") {\n")
+        printTo(sb, shape.posOf(split), "$indent  ")
+        sb.append(indent).append("} else {\n")
+        printTo(sb, shape.negOf(split), "$indent  ")
+        sb.append(indent).append("}\n")
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,14 +1,10 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.koblas.VectorView
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
-import com.eignex.kumulant.stream.guarded
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorView]
@@ -101,76 +97,24 @@ fun RegressionNode<VectorView>.snapshot(): TreeNodeResult = when (this) {
  * Snapshot merge using only the immutable result. Mirrors [RegressionTree.merge] but the
  * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `VectorView`
  * only, for the same reason [snapshot] is.
+ *
+ * An extension rather than a member because it exists only at `Row = VectorView`, which a member of a
+ * generic class cannot be constrained to. The algorithm is [TreeGrowth.mergeSnapshot].
  */
 fun RegressionTree<VectorView>.mergeSnapshot(other: TreeNodeResult) {
-    splitLock.guarded {
-        root = mergeNodeWithResult(root, other)
-        nbrNodes.store(countNodes(root))
-    }
+    growth.mergeSnapshot(other, RegressionResultShape)
 }
 
-private fun RegressionTree<VectorView>.mergeNodeWithResult(
-    a: RegressionNode<VectorView>,
-    b: TreeNodeResult,
-): RegressionNode<VectorView> {
-    if (a is RegressionSplitNode && b is TreeSplitResult && a.split == b.split) {
-        a.pos = mergeNodeWithResult(a.pos, b.pos)
-        a.neg = mergeNodeWithResult(a.neg, b.neg)
-        // b.value carries the full subtree aggregate; the child recursion already
-        // folded the structurally-aligned portion. Pull only the residual; what b's
-        // value holds beyond the sum of its children; into a's carryover.
-        val childSum = mergeWVR(b.pos.value, b.neg.value)
-        val residual = subtractWVR(b.value, childSum)
-        if (residual.totalWeights > 0.0) foldIntoCarryover(a, residual)
-        return a
-    }
-    if (a is RegressionLeafNode && b is TreeLeafResult) {
-        a.arm.merge(b.value)
-        return a
-    }
-    if (a is RegressionLeafNode && b is TreeSplitResult) {
-        val cloned = cloneFromResult(b) as RegressionSplitNode
-        foldIntoCarryover(cloned, a.arm.read(0L))
-        return cloned
-    }
-    // a split + b leaf, or splits differ: keep a's structure, fold b's aggregate.
-    foldIntoCarryover(a as RegressionSplitNode, b.value)
-    return a
-}
+/** Reads the immutable regression snapshot hierarchy on the growth engine's behalf. */
+private object RegressionResultShape :
+    TreeResultShape<Split<VectorView>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
+    override fun asSplitResult(node: TreeNodeResult): TreeSplitResult? = node as? TreeSplitResult
 
-/**
- * Rebuild a live subtree from a snapshot.
- *
- * Carried a `depth` parameter that was threaded through every recursive call and read by none of them.
- * Removed rather than left in place, because as written it read as a live depth cap and was not one.
- *
- * Whether it should be one is a separate question this does not settle: `newLeaf` refuses to grow past
- * `config.maxDepth`, and nothing here refuses to clone past it. In practice a snapshot comes from a tree
- * that already honoured its own `maxDepth`, so the two only diverge when the configs differ - which is a
- * behaviour decision rather than a cleanup.
- */
-private fun RegressionTree<VectorView>.cloneFromResult(node: TreeNodeResult): RegressionNode<VectorView> {
-    nbrNodes.addAndFetch(1)
-    return when (node) {
-        is TreeLeafResult -> {
-            val arm = leafArmFactory()
-            arm.merge(node.value)
-            RegressionTerminalLeaf(arm)
-        }
+    override fun splitOf(node: TreeSplitResult): Split<VectorView> = node.split
 
-        is TreeSplitResult -> {
-            val pos = cloneFromResult(node.pos)
-            val neg = cloneFromResult(node.neg)
-            // Re-establish any orphan aggregate the snapshot encodes by comparing the
-            // recorded value against the sum of the cloned children's aggregates.
-            val childSum = mergeWVR(node.pos.value, node.neg.value)
-            val residual = subtractWVR(node.value, childSum)
-            val carry = if (residual.totalWeights > 0.0) {
-                leafArmFactory().also { it.merge(residual) }
-            } else {
-                null
-            }
-            RegressionSplitNode(split = node.split, pos = pos, neg = neg, carryover = carry)
-        }
-    }
+    override fun posOf(node: TreeSplitResult): TreeNodeResult = node.pos
+
+    override fun negOf(node: TreeSplitResult): TreeNodeResult = node.neg
+
+    override fun valueOf(node: TreeNodeResult): WeightedVarianceResult = node.value
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -1,0 +1,118 @@
+package com.eignex.kumulant.stat.regression.tree
+
+import com.eignex.koblas.VectorView
+import com.eignex.kumulant.feat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the behaviour the shared [TreeGrowth] engine must not change: the regression and classification
+ * trees grow the *same* tree from the same stream.
+ *
+ * Both are fed identical rows, with the regression target being the 0/1 class label as a Double. On binary
+ * labels the two split criteria are proportional (Bernoulli variance is exactly half the Gini impurity),
+ * so the candidate ranking is identical and both trees must reach the same structure: the same node count,
+ * the same split predicate at every internal node, and the same total weight.
+ *
+ * Nothing else in the suite compares the two trees against each other, so this is the only guard on the
+ * shared engine treating its two instantiations alike.
+ */
+class TreeGrowthParityTest {
+
+    /**
+     * Row pattern: feature 0 decides the label for three quarters of the stream, feature 1 resolves the
+     * remaining quarter. That makes feature 0 the strictly better root candidate and feature 1 the only
+     * useful candidate below it, so the grown tree is a root split, one nested split, and three leaves.
+     */
+    private val rows = listOf(
+        feat(1.0, 0.0) to 1,
+        feat(1.0, 0.0) to 1,
+        feat(0.0, 0.0) to 0,
+        feat(0.0, 1.0) to 1,
+    )
+
+    private val candidates = listOf(ThresholdSplit(0, 0.5), ThresholdSplit(1, 0.5))
+
+    private fun regressionStructure(node: RegressionNode<VectorView>): String = when (node) {
+        is RegressionSplitNode -> "(${node.split} ? ${regressionStructure(node.pos)}" +
+            " : ${regressionStructure(node.neg)})"
+
+        is RegressionLeafNode -> "leaf"
+    }
+
+    private fun classificationStructure(node: ClassificationNode): String = when (node) {
+        is ClassificationSplitNode -> "(${node.split} ? ${classificationStructure(node.pos)}" +
+            " : ${classificationStructure(node.neg)})"
+
+        is ClassificationLeafNode -> "leaf"
+    }
+
+    private fun grownPair(observations: Int): Pair<RegressionTree<VectorView>, ClassificationTree> {
+        val regression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 7)
+        val classification = ClassificationTree(
+            numClasses = 2,
+            splitCandidates = candidates,
+            randomSeed = 7,
+        )
+        repeat(observations) {
+            val (row, label) = rows[it % rows.size]
+            regression.update(row, label.toDouble())
+            classification.update(row, label)
+        }
+        return regression to classification
+    }
+
+    @Test
+    fun `both trees grow the same shape from the same stream`() {
+        val (regression, classification) = grownPair(observations = 4000)
+
+        assertEquals(5, regression.nodeCount, "regression shape:\n${regression.prettyPrint()}")
+        assertEquals(
+            regression.nodeCount,
+            classification.nodeCount,
+            "regression:\n${regression.prettyPrint()}\nclassification:\n${classification.prettyPrint()}",
+        )
+        assertEquals(
+            regressionStructure(regression.rootNode()),
+            classificationStructure(classification.rootNode()),
+            "the two engines chose different splits",
+        )
+        assertEquals(4000.0, regression.rootSnapshot().totalWeights, 1e-9)
+        assertEquals(4000.0, classification.rootSnapshot().totalWeights, 1e-9)
+    }
+
+    @Test
+    fun `neither tree splits while the candidates carry no signal`() {
+        val regression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 7)
+        val classification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 7)
+        // A constant label leaves every candidate at zero impurity reduction, so shouldSplit must refuse
+        // in both trees no matter how much weight piles up.
+        repeat(500) {
+            val row = rows[it % rows.size].first
+            regression.update(row, 1.0)
+            classification.update(row, 1)
+        }
+        assertEquals(1, regression.nodeCount)
+        assertEquals(1, classification.nodeCount)
+    }
+
+    @Test
+    fun `snapshot merge into a fresh tree reproduces the grown shape on both sides`() {
+        val (regression, classification) = grownPair(observations = 4000)
+
+        val freshRegression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 9)
+        freshRegression.mergeSnapshot(regression.rootNode().snapshot())
+
+        val freshClassification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 9)
+        freshClassification.mergeSnapshot(classification.rootNode().snapshot())
+
+        assertEquals(regression.nodeCount, freshRegression.nodeCount)
+        assertEquals(classification.nodeCount, freshClassification.nodeCount)
+        assertEquals(
+            regressionStructure(freshRegression.rootNode()),
+            classificationStructure(freshClassification.rootNode()),
+        )
+        assertEquals(4000.0, freshRegression.rootSnapshot().totalWeights, 1e-9)
+        assertEquals(4000.0, freshClassification.rootSnapshot().totalWeights, 1e-9)
+    }
+}


### PR DESCRIPTION
## What changed

- Added TreeGrowth, an internal engine holding the VFDT growth algorithm once, parameterised by two internal SPIs. TreeShape narrows and builds nodes and supplies the payload algebra; TreeResultShape covers the read-only snapshot side, which is immutable, serializable and VectorView-only.
- The engine owns the root pointer, node count, split lock, PRNG and candidate pool, and implements update, updateNode, updateAuditLeaf, newLeaf, countNodes, prettyPrint, reset, mergeTree, mergeSnapshot, cloneFromResult and foldIntoCarryover.
- RegressionTree and ClassificationTree are now facades over the engine, each supplying a private shape class of one-liners.
- Snapshot-merge now runs through one code path. It previously lived as file-private extensions for regression and as private members for classification, the same algorithm with opposite structural choices.
- Dropped `leafArmFactory`, `splitLock` and `nbrNodes` from RegressionTree's internal surface, along with `splitCandidates`, `config`, `concurrency` and `root` as properties. One internal member replaces them, `val growth`, which the VectorView-constrained extension needs.
- Added TreeGrowthParityTest, which drives a regression tree and a classification tree over identical rows and asserts they grew the same shape.

## Why

The two trees were near-parallel implementations of one algorithm. Seven methods differed only in node type and payload type, `updateAuditLeaf` being the worst at about 45 lines each including the same double-checked-locking dance and the same comment. That is the shape in which a fix lands on one tree and not the other, which this sweep already found four times elsewhere in the library.

The node hierarchies could not be merged. RegressionNode, ClassificationNode and their leaf and split subtypes are public and tracked in the ABI dump, so sharing had to happen at the algorithm level with the types left alone. The ABI dump is unchanged, which is the check that this held.

Raw line count is roughly flat: about 370 duplicated lines collapse into a 419-line engine, and the SPI indirection costs about what the copies did. The win is not size, it is that the algorithm is single-sourced. Worth saying plainly since a dedup PR that does not shrink invites the question.

The parity test leans on Bernoulli variance being exactly half the Gini impurity, so feeding the regression tree a 0/1 label as its target makes the candidate ranking provably identical to the classifier's on the same rows. Without that the two trees have no comparable ground truth to assert against.

## Testing

`./gradlew build` passes, covering all thirteen targets plus detekt plus the ABI check, verified in this repository rather than only in the worktree the change was authored in. `git status` shows no modification under `kumulant/api/`, so no public signature, type or serial name moved.

All existing tree tests pass unmodified: RegressionTreeTest, DecisionTreeRegressionStatTest, RandomForestRegressionStatTest, TreeInternalsTest, TreePosteriorsTest, TreeRegressionResultTest, SplitTest, and the classification-side tests.

The new parity test also pins that neither tree splits on a signal-free stream, and that merging a snapshot into a fresh tree reproduces the grown shape on both sides.

One thing not measured: `updateNode` now narrows through interface calls rather than a sealed `when`. The path was already dominated by virtual `SeriesStat.update` and `Split.direction` calls so this is unlikely to matter, but it was not benchmarked. Worth a kumulant-bench run if tree throughput is tracked.
