### PR TITLE
Replace the stringly-typed knn distance and unify the class-count guard

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -5,9 +5,8 @@ public abstract interface class com/eignex/kumulant/bandit/Bandit {
 }
 
 public final class com/eignex/kumulant/bandit/BanditFactoryKt {
-	public static final fun getKnnDistanceRegistry ()Ljava/util/Map;
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/contextual/ContextualBanditSpec;Lkotlin/random/Random;Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/bandit/Bandit;
-	public static final fun materialize (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;Lkotlin/random/Random;Ljava/util/Map;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
+	public static final fun materialize (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/contextual/RegressionContextualSpec;Lkotlin/random/Random;Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/univariate/BanditPolicySpec;)Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/univariate/BoltzmannSpec;Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/univariate/BoltzmannBandit;
@@ -17,7 +16,7 @@ public final class com/eignex/kumulant/bandit/BanditFactoryKt {
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/univariate/TopTwoThompsonSpec;Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit;
 	public static final fun materialize (Lcom/eignex/kumulant/bandit/univariate/UnivariateBanditSpec;Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Bandit;
 	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/contextual/ContextualBanditSpec;Lkotlin/random/Random;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/Bandit;
-	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;Lkotlin/random/Random;Ljava/util/Map;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
+	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;Lkotlin/random/Random;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
 	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/contextual/RegressionContextualSpec;Lkotlin/random/Random;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
 	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/univariate/BoltzmannSpec;Lkotlin/random/Random;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/univariate/BoltzmannBandit;
 	public static synthetic fun materialize$default (Lcom/eignex/kumulant/bandit/univariate/Exp3Spec;Lkotlin/random/Random;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/univariate/Exp3Bandit;
@@ -235,19 +234,19 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit$Com
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
 	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec$Companion;
-	public fun <init> (IIIDDLjava/lang/String;)V
-	public synthetic fun <init> (IIIDDLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIIDDLcom/eignex/kumulant/bandit/contextual/KnnDistance;)V
+	public synthetic fun <init> (IIIDDLcom/eignex/kumulant/bandit/contextual/KnnDistance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()D
 	public final fun component5 ()D
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (IIIDDLjava/lang/String;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;IIIDDLjava/lang/String;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;
+	public final fun component6 ()Lcom/eignex/kumulant/bandit/contextual/KnnDistance;
+	public final fun copy (IIIDDLcom/eignex/kumulant/bandit/contextual/KnnDistance;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;IIIDDLcom/eignex/kumulant/bandit/contextual/KnnDistance;ILjava/lang/Object;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualSpec;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColdStartScore ()D
-	public final fun getDistance ()Ljava/lang/String;
+	public final fun getDistance ()Lcom/eignex/kumulant/bandit/contextual/KnnDistance;
 	public final fun getExploration ()D
 	public final fun getK ()I
 	public final fun getMaxHistoryPerArm ()I
@@ -269,6 +268,22 @@ public final synthetic class com/eignex/kumulant/bandit/contextual/KnnContextual
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/eignex/kumulant/bandit/contextual/KnnDistance {
+	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/KnnDistance$Companion;
+}
+
+public final class com/eignex/kumulant/bandit/contextual/KnnDistance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/eignex/kumulant/bandit/contextual/KnnDistance$SquaredL2 : com/eignex/kumulant/bandit/contextual/KnnDistance {
+	public static final field INSTANCE Lcom/eignex/kumulant/bandit/contextual/KnnDistance$SquaredL2;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/eignex/kumulant/bandit/contextual/LinearRegressionSpec {

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -401,6 +401,21 @@ sealed interface com.eignex.kumulant.bandit.contextual/ContextualBanditSpec { //
     }
 }
 
+sealed interface com.eignex.kumulant.bandit.contextual/KnnDistance { // com.eignex.kumulant.bandit.contextual/KnnDistance|null[0]
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.contextual/KnnDistance.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.bandit.contextual/KnnDistance> // com.eignex.kumulant.bandit.contextual/KnnDistance.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.bandit.contextual/KnnDistance.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+
+    final object SquaredL2 : com.eignex.kumulant.bandit.contextual/KnnDistance, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2.hashCode|hashCode(){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2> // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+        final fun toString(): kotlin/String // com.eignex.kumulant.bandit.contextual/KnnDistance.SquaredL2.toString|toString(){}[0]
+    }
+}
+
 sealed interface com.eignex.kumulant.bandit.contextual/LinearRegressionSpec { // com.eignex.kumulant.bandit.contextual/LinearRegressionSpec|null[0]
     final class Bayesian : com.eignex.kumulant.bandit.contextual/LinearRegressionSpec { // com.eignex.kumulant.bandit.contextual/LinearRegressionSpec.Bayesian|null[0]
         constructor <init>(kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.bandit.contextual/LinearRegressionSpec.Bayesian.<init>|<init>(kotlin.Int;kotlin.Double){}[0]
@@ -1273,12 +1288,12 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
 }
 
 final class com.eignex.kumulant.bandit.contextual/KnnContextualSpec : com.eignex.kumulant.bandit.contextual/ContextualBanditSpec { // com.eignex.kumulant.bandit.contextual/KnnContextualSpec|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/String = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.String){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., com.eignex.kumulant.bandit.contextual/KnnDistance = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;com.eignex.kumulant.bandit.contextual.KnnDistance){}[0]
 
     final val coldStartScore // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.coldStartScore|{}coldStartScore[0]
         final fun <get-coldStartScore>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.coldStartScore.<get-coldStartScore>|<get-coldStartScore>(){}[0]
     final val distance // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.distance|{}distance[0]
-        final fun <get-distance>(): kotlin/String // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.distance.<get-distance>|<get-distance>(){}[0]
+        final fun <get-distance>(): com.eignex.kumulant.bandit.contextual/KnnDistance // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.distance.<get-distance>|<get-distance>(){}[0]
     final val exploration // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.exploration|{}exploration[0]
         final fun <get-exploration>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.exploration.<get-exploration>|<get-exploration>(){}[0]
     final val k // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.k|{}k[0]
@@ -1293,8 +1308,8 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualSpec : com.eignex
     final fun component3(): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.component4|component4(){}[0]
     final fun component5(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.component5|component5(){}[0]
-    final fun component6(): kotlin/String // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.component6|component6(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/String = ...): com.eignex.kumulant.bandit.contextual/KnnContextualSpec // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.String){}[0]
+    final fun component6(): com.eignex.kumulant.bandit.contextual/KnnDistance // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.component6|component6(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., com.eignex.kumulant.bandit.contextual/KnnDistance = ...): com.eignex.kumulant.bandit.contextual/KnnContextualSpec // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;com.eignex.kumulant.bandit.contextual.KnnDistance){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.toString|toString(){}[0]
@@ -1309,6 +1324,8 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualSpec : com.eignex
     }
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.Companion|null[0]
+        final val $childSerializers // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.Companion.$childSerializers|{}$childSerializers[0]
+
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.bandit.contextual/KnnContextualSpec> // com.eignex.kumulant.bandit.contextual/KnnContextualSpec.Companion.serializer|serializer(){}[0]
     }
 }
@@ -9183,13 +9200,11 @@ final object com.eignex.kumulant.stat.regression.tree/VarianceReduction : com.ei
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/VarianceReduction.toString|toString(){}[0]
 }
 
-final val com.eignex.kumulant.bandit/knnDistanceRegistry // com.eignex.kumulant.bandit/knnDistanceRegistry|{}knnDistanceRegistry[0]
-    final fun <get-knnDistanceRegistry>(): kotlin.collections/Map<kotlin/String, kotlin/Function2<com.eignex.koblas/VectorView, com.eignex.koblas/VectorView, kotlin/Double>> // com.eignex.kumulant.bandit/knnDistanceRegistry.<get-knnDistanceRegistry>|<get-knnDistanceRegistry>(){}[0]
 final val com.eignex.kumulant.math/SplitMix64 // com.eignex.kumulant.math/SplitMix64|{}SplitMix64[0]
     final fun <get-SplitMix64>(): com.eignex.kumulant.math/LongHasher // com.eignex.kumulant.math/SplitMix64.<get-SplitMix64>|<get-SplitMix64>(){}[0]
 
 final fun (com.eignex.kumulant.bandit.contextual/ContextualBanditSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ..., com.eignex.kumulant.core/Concurrency = ...): com.eignex.kumulant.bandit/Bandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.contextual.ContextualBanditSpec(kotlin.random.Random;com.eignex.kumulant.core.Concurrency){}[0]
-final fun (com.eignex.kumulant.bandit.contextual/KnnContextualSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ..., kotlin.collections/Map<kotlin/String, kotlin/Function2<com.eignex.koblas/VectorView, com.eignex.koblas/VectorView, kotlin/Double>> = ...): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.contextual.KnnContextualSpec(kotlin.random.Random;kotlin.collections.Map<kotlin.String,kotlin.Function2<com.eignex.koblas.VectorView,com.eignex.koblas.VectorView,kotlin.Double>>){}[0]
+final fun (com.eignex.kumulant.bandit.contextual/KnnContextualSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ...): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.contextual.KnnContextualSpec(kotlin.random.Random){}[0]
 final fun (com.eignex.kumulant.bandit.contextual/RegressionContextualSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ..., com.eignex.kumulant.core/Concurrency = ...): com.eignex.kumulant.bandit.contextual/RegressionContextualBandit<out com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.contextual.RegressionContextualSpec(kotlin.random.Random;com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.bandit.univariate/BernoulliArm.Companion).com.eignex.kumulant.bandit.univariate/warmStart(com.eignex.kumulant.stat.summary/BernoulliSumResult, kotlin/Double = ...): com.eignex.kumulant.bandit.univariate/BernoulliArm // com.eignex.kumulant.bandit.univariate/warmStart|warmStart@com.eignex.kumulant.bandit.univariate.BernoulliArm.Companion(com.eignex.kumulant.stat.summary.BernoulliSumResult;kotlin.Double){}[0]
 final fun (com.eignex.kumulant.bandit.univariate/BoltzmannSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ...): com.eignex.kumulant.bandit.univariate/BoltzmannBandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.univariate.BoltzmannSpec(kotlin.random.Random){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.VectorView
 import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec
+import com.eignex.kumulant.bandit.contextual.KnnDistance
 import com.eignex.kumulant.bandit.contextual.LinearRegressionSpec
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.contextual.RegressionContextualSpec
@@ -175,20 +176,14 @@ fun RegressionContextualSpec.materialize(
     )
 }
 
-/** Built-in distance functions referenced by [KnnContextualSpec.distance]. Extend
- *  by passing a custom map when constructing the bandit programmatically. */
-val knnDistanceRegistry: Map<String, (VectorView, VectorView) -> Double> = mapOf(
-    "squaredL2" to KnnContextualBandit.Companion::squaredL2,
-)
+/** Resolve a wire-named distance metric to the function that computes it. */
+private fun KnnDistance.resolve(): (VectorView, VectorView) -> Double = when (this) {
+    KnnDistance.SquaredL2 -> KnnContextualBandit.Companion::squaredL2
+}
 
-/** Build a live [KnnContextualBandit] from its spec, resolving the distance
- *  function via [distanceRegistry] (defaults to [knnDistanceRegistry]). */
-fun KnnContextualSpec.materialize(
-    random: Random = Random.Default,
-    distanceRegistry: Map<String, (VectorView, VectorView) -> Double> = knnDistanceRegistry,
-): KnnContextualBandit {
-    val dist = distanceRegistry[distance]
-        ?: error("Unknown KnnContextualSpec.distance '$distance'. Known: ${distanceRegistry.keys}")
+/** Build a live [KnnContextualBandit] from its spec. */
+fun KnnContextualSpec.materialize(random: Random = Random.Default): KnnContextualBandit {
+    val dist = distance.resolve()
     return KnnContextualBandit(
         nbrArms = nbrArms,
         k = k,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/ContextualBanditSpec.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/ContextualBanditSpec.kt
@@ -78,8 +78,24 @@ sealed interface LinearRegressionSpec {
     ) : LinearRegressionSpec
 }
 
-/** Spec for [KnnContextualBandit]. [distance] is a named lookup against a
- *  small built-in registry; currently `"squaredL2"` is the only stock entry. */
+/**
+ * A distance function a [KnnContextualSpec] can name on the wire.
+ *
+ * Sealed rather than a string against a registry, so an unknown metric is a compile error and the wire
+ * format admits only metrics that exist. A caller wanting a metric that is not here passes a function to
+ * the [KnnContextualBandit] constructor directly; that path cannot round-trip through the wire format,
+ * which is the reason this hierarchy is closed.
+ */
+@Serializable
+sealed interface KnnDistance {
+
+    /** Squared Euclidean distance. Skips the square root, which no ranking needs. */
+    @Serializable
+    @SerialName("SquaredL2")
+    data object SquaredL2 : KnnDistance
+}
+
+/** Spec for [KnnContextualBandit]. */
 @Serializable
 @SerialName("KnnContextual")
 data class KnnContextualSpec(
@@ -93,6 +109,6 @@ data class KnnContextualSpec(
     val coldStartScore: Double = 1.0,
     /** UCB-style exploration scale. */
     val exploration: Double = 1.0,
-    /** Name of the distance function in the factory's registry. */
-    val distance: String = "squaredL2",
+    /** Distance metric used to find neighbours. */
+    val distance: KnnDistance = KnnDistance.SquaredL2,
 ) : ContextualBanditSpec

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.stream.StreamDoubleArray
 import com.eignex.kumulant.stream.additiveMode
@@ -28,7 +29,7 @@ data class ClassCountsResult(
 ) : HasObservationCount {
 
     init {
-        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
         require(counts.size == numClasses) { "counts must have length $numClasses; got ${counts.size}" }
     }
 
@@ -94,7 +95,7 @@ class ClassCountsStat(
 ) : SeriesStat<ClassCountsResult> {
 
     init {
-        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val mode = concurrency.additiveMode()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.score
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.asClassLabel
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 
@@ -33,7 +34,7 @@ class AccuracyStat(
 ) : PairedStat<WeightedMeanResult> {
 
     init {
-        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val inner = MeanStat(concurrency)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.stream.StreamDouble
 import com.eignex.kumulant.stream.additiveMode
 import kotlinx.serialization.SerialName
@@ -30,7 +31,7 @@ data class ConfusionMatrixResult(
 ) : Result {
 
     init {
-        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
         require(counts.size == numClasses * numClasses) {
             "counts must be numClasses^2 = ${numClasses * numClasses}; got ${counts.size}"
         }
@@ -164,7 +165,7 @@ class ConfusionMatrixStat(
 ) : PairedStat<ConfusionMatrixResult> {
 
     init {
-        require(numClasses > 0) { "numClasses must be > 0; got $numClasses" }
+        requireAtLeastTwoClasses(numClasses)
     }
 
     private val mode = concurrency.additiveMode()

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -1,6 +1,8 @@
 package com.eignex.kumulant.bandit
 
+import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec
+import com.eignex.kumulant.bandit.contextual.KnnDistance
 import com.eignex.kumulant.bandit.contextual.LinearRegressionSpec
 import com.eignex.kumulant.bandit.contextual.RegressionContextualSpec
 import com.eignex.kumulant.bandit.univariate.BernoulliArm
@@ -106,6 +108,28 @@ class BanditFactoryTest {
     fun `KnnContextual spec materialises with the default distance`() {
         val b = KnnContextualSpec(nbrArms = 3).materialize(Random(0))
         assertEquals(3, b.nbrArms)
+    }
+
+    @Test
+    fun `the knn distance survives a round trip and is not a bare string`() {
+        // A sealed metric means an unknown one is a compile error, and the wire format admits only
+        // metrics that exist rather than any string at all.
+        val spec: ContextualBanditSpec = KnnContextualSpec(nbrArms = 3, distance = KnnDistance.SquaredL2)
+
+        // `json` here omits defaults, and SquaredL2 is the default, so a second encoder is needed to see
+        // the metric on the wire at all. That it round-trips under the terse encoder is the other half.
+        val verbose = Json { encodeDefaults = true }
+        val encoded = verbose.encodeToString(ContextualBanditSpec.serializer(), spec)
+        assertTrue("SquaredL2" in encoded, "the metric did not reach the wire: $encoded")
+
+        assertEquals(spec, verbose.decodeFromString(ContextualBanditSpec.serializer(), encoded))
+        assertEquals(
+            spec,
+            json.decodeFromString(
+                ContextualBanditSpec.serializer(),
+                json.encodeToString(ContextualBanditSpec.serializer(), spec),
+            ),
+        )
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
@@ -80,7 +80,10 @@ class AccuracyStatTest {
     }
 
     @Test
-    fun `a non-positive class count is refused`() {
+    fun `a class count below two is refused`() {
+        // One class is not a classification problem, and the counters used to accept it while every
+        // model required two. A binary problem is `numClasses = 2`.
         assertFailsWith<IllegalArgumentException> { AccuracyStat(numClasses = 0) }
+        assertFailsWith<IllegalArgumentException> { AccuracyStat(numClasses = 1) }
     }
 }


### PR DESCRIPTION
## What changed

- Replaced `KnnContextualSpec.distance: String` with a sealed `KnnDistance` hierarchy carrying one variant, `SquaredL2`.
- Deleted `knnDistanceRegistry` and the `distanceRegistry` parameter on `KnnContextualSpec.materialize`. The metric now resolves through an exhaustive `when`.
- Raised the class-count guard from `numClasses > 0` to `numClasses >= 2` in `ClassCounts`, `ConfusionMatrixStat` and `AccuracyStat`, which now use the shared `requireAtLeastTwoClasses`.

## Why

The distance metric was a string matched against a map with one entry, so a typo was an `IllegalStateException` at materialise time rather than a compile error, and the wire format accepted any string at all. Every sibling in that spec hierarchy is already a sealed serializable type. Closing the hierarchy also means the registry parameter can go: a caller wanting a metric that is not built in passes a function to the `KnnContextualBandit` constructor, which is the path that could never round-trip through the wire format anyway.

The class-count guard disagreed with itself. The models required at least two classes while the counters accepted one, so a single-class `ConfusionMatrixStat` was constructible and a single-class `SoftmaxRegressionStat` was not. One class is not a classification problem in either. A binary problem is `numClasses = 2`, which both sides accept.

Both are breaking. `Accuracy` and `KnnContextual` payloads change shape and the `materialize` overload loses a parameter.

## Testing

`./gradlew build` passes: all thirteen targets, detekt, and the ABI check. The ABI dump was regenerated and its delta contains only the `KnnDistance` type, the `KnnContextualSpec.distance` type change, and the removed registry and overload.

Added a round-trip test asserting the metric reaches the wire as a tagged object. It needed a second encoder to write it at all, because the shared test `Json` omits defaults and `SquaredL2` is the default; the terse encoder is asserted separately for round-trip equality. My first version of this test failed for that reason rather than because of the code.

Extended the `AccuracyStat` guard test to reject `numClasses = 1` as well as `0`.
