### PR TITLE
Count a t-digest value's weight only once the value is published

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -355,8 +355,19 @@ class TDigestStat(
                 if (claimed <= bufferCapLong) {
                     buffer.store(idx, value)
                     bufferWeights.store(idx, weight)
-                    totalWeightCell.add(weight)
+                    // Publish the value before counting its weight, not after. `drainLocked` can
+                    // strand a claim it cannot prove committed, discarding the value; if the weight
+                    // were already counted, that weight would stay in `totalWeightCell` with nothing
+                    // in the digest behind it. Reached before any successful drain, that left
+                    // `means` empty while `total` was positive, and `read` answers that state with
+                    // NaN for every quantile while still reporting the positive weight - a snapshot
+                    // that claims to have observed data it cannot answer from.
+                    //
+                    // The reverse skew this admits is benign and self-correcting: a drained value
+                    // whose weight has not landed yet makes `total` low, so a rank clamps toward
+                    // `means[0]`, which is finite and ordered.
                     commitIndex.add(1L)
+                    totalWeightCell.add(weight)
                     if (claimed == bufferCapLong) {
                         compressLock.guarded { drainLocked() }
                     }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -266,6 +266,38 @@ class ConcurrentReadInvariantsTest {
     }
 
     @Test
+    fun `TDigestStat never reports weight it cannot answer from`() {
+        // The state behind the intermittent failure of the test below: `read` fills every quantile with
+        // NaN when it has no centroids, but returned `totalWeight` unchanged, so a snapshot could claim
+        // to have observed weight while being unable to answer a single quantile. That is not staleness,
+        // which the Relaxed contract allows - it is a snapshot contradicting itself.
+        //
+        // It arose because `update` counted a value's weight before publishing the value, and
+        // `drainLocked` may strand a claim it cannot prove committed. The weight stayed; the value did
+        // not. Asserted as an invariant rather than by reproducing the interleaving, which needs a
+        // preemption long enough to exhaust drainLocked's spin budget.
+        for (level in levels) {
+            val stat = TDigestStat(concurrency = level)
+            assertReadInvariants("TDigestStat[$level] weight-vs-centroids", stat, write = { t, i ->
+                stat.update(1.0 + ((t * 13 + i * 17) % 10_000))
+            }) { r ->
+                if (r.totalWeight > 0.0) {
+                    assertTrue(
+                        r.weights.isNotEmpty(),
+                        "totalWeight=${r.totalWeight} with no centroids, so every quantile is NaN",
+                    )
+                }
+                if (r.weights.isEmpty()) {
+                    assertTrue(
+                        r.totalWeight <= 0.0,
+                        "no centroids but totalWeight=${r.totalWeight}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `TDigestStat quantiles stay ordered and finite under a concurrent reader`() {
         for (level in levels) {
             val stat = TDigestStat(concurrency = level)


### PR DESCRIPTION
## What changed

- `TDigestStat.update` now bumps `commitIndex` before `totalWeightCell`, so a value's weight is counted only once the value itself is published.
- Added `TDigestStat never reports weight it cannot answer from` to `ConcurrentReadInvariantsTest`, asserting that a snapshot with positive `totalWeight` always has at least one centroid.

## Why

`ConcurrentReadInvariantsTest > TDigestStat quantiles stay ordered and finite under a concurrent reader` failed intermittently, only inside a full `./gradlew build`. It was a real defect in the stat, not a flaky assertion.

`read` fills every quantile with `NaN` when it has no centroids, but returned `totalWeight` unchanged. So a snapshot could report positive weight while being unable to answer a single quantile. The test guards on `if (r.totalWeight > 0.0)` and then asserts finiteness, so that state fails it, correctly. This is not the staleness the Relaxed contract allows; it is a snapshot contradicting itself, which the test's own KDoc calls out as a bug at every level.

The state was reachable because `update` counted a value's weight before publishing the value. A writer preempted between those two lines has contributed weight but nothing drainable. `drainLocked` waits `SPIN_MAX` spins for the commit, then trims to what it can prove committed and resets the buffer indices, discarding the claim; the weight stays in `totalWeightCell` with nothing behind it. Reached before any successful drain, `means` is still empty while `total` is positive.

Publishing before counting makes that unreachable: an uncommitted claim now contributes neither value nor weight, and a committed one is always inside `drained`. The reverse skew this admits is benign and self-correcting. A drained value whose weight has not landed yet leaves `total` low, so a rank clamps toward `means[0]`, which is finite and ordered.

Ordering is the whole fix. No lock was added, so the Relaxed fast path keeps its cost.

## Testing

Ten consecutive `./gradlew build --rerun-tasks` runs pass, against a previously measured failure rate of roughly one in three. That leaves about a 2 percent chance of a false all-clear, so it is strong evidence rather than proof.

The regression test asserts the invariant rather than reproducing the interleaving. Triggering it on demand needs a preemption long enough to exhaust a ten thousand spin budget, which is why it only ever surfaced when a full build had every core busy. CPU load alone did not reproduce it, nor did the whole JVM suite, nor sixty four oversubscribed writers.

Worth stating plainly: the original failure message was never captured, so the diagnosis rests on the code path and on the failure signature matching exactly, plus the ten clean builds.
