### PR TITLE
Report the space-saving admission policy and its shortfall bound

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -8600,6 +8600,19 @@ public final class com/eignex/kumulant/stat/score/PitTestsKt {
 	public static final fun pitKsDistance (Lcom/eignex/kumulant/stat/quantile/SparseHistogramResult;I)D
 }
 
+public final class com/eignex/kumulant/stat/sketch/AdmissionPolicy : java/lang/Enum {
+	public static final field Classic Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
+	public static final field Companion Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy$Companion;
+	public static final field MisraGries Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
+	public static fun values ()[Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
+}
+
+public final class com/eignex/kumulant/stat/sketch/AdmissionPolicy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/eignex/kumulant/stat/sketch/BloomFilterResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/sketch/BloomFilterResult$Companion;
 	public synthetic fun <init> (II[JJLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -8729,19 +8742,24 @@ public final class com/eignex/kumulant/stat/sketch/CountMinSketchStatKt {
 
 public final class com/eignex/kumulant/stat/sketch/HeavyHittersResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult$Companion;
-	public fun <init> (I[J[J[JJ)V
+	public fun <init> (I[J[J[JJLcom/eignex/kumulant/stat/sketch/AdmissionPolicy;J)V
+	public synthetic fun <init> (I[J[J[JJLcom/eignex/kumulant/stat/sketch/AdmissionPolicy;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()[J
 	public final fun component3 ()[J
 	public final fun component4 ()[J
 	public final fun component5 ()J
-	public final fun copy (I[J[J[JJ)Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;I[J[J[JJILjava/lang/Object;)Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;
+	public final fun component6 ()Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
+	public final fun component7 ()J
+	public final fun copy (I[J[J[JJLcom/eignex/kumulant/stat/sketch/AdmissionPolicy;J)Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;I[J[J[JJLcom/eignex/kumulant/stat/sketch/AdmissionPolicy;JILjava/lang/Object;)Lcom/eignex/kumulant/stat/sketch/HeavyHittersResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCapacity ()I
 	public final fun getCounts ()[J
+	public final fun getDeficit ()J
 	public final fun getErrors ()[J
 	public final fun getKeys ()[J
+	public final fun getPolicy ()Lcom/eignex/kumulant/stat/sketch/AdmissionPolicy;
 	public final fun getTotalSeen ()J
 	public fun getTotalWeights ()D
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -74,6 +74,22 @@ final enum class com.eignex.kumulant.stat.forecast/SeasonalMode : kotlin/Enum<co
     }
 }
 
+final enum class com.eignex.kumulant.stat.sketch/AdmissionPolicy : kotlin/Enum<com.eignex.kumulant.stat.sketch/AdmissionPolicy> { // com.eignex.kumulant.stat.sketch/AdmissionPolicy|null[0]
+    enum entry Classic // com.eignex.kumulant.stat.sketch/AdmissionPolicy.Classic|null[0]
+    enum entry MisraGries // com.eignex.kumulant.stat.sketch/AdmissionPolicy.MisraGries|null[0]
+
+    final val entries // com.eignex.kumulant.stat.sketch/AdmissionPolicy.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.eignex.kumulant.stat.sketch/AdmissionPolicy> // com.eignex.kumulant.stat.sketch/AdmissionPolicy.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.eignex.kumulant.stat.sketch/AdmissionPolicy // com.eignex.kumulant.stat.sketch/AdmissionPolicy.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.eignex.kumulant.stat.sketch/AdmissionPolicy> // com.eignex.kumulant.stat.sketch/AdmissionPolicy.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.sketch/AdmissionPolicy.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.sketch/AdmissionPolicy> // com.eignex.kumulant.stat.sketch/AdmissionPolicy.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.sketch/AdmissionPolicy.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 abstract fun interface com.eignex.kumulant.bandit.contextual/Exp4Expert { // com.eignex.kumulant.bandit.contextual/Exp4Expert|null[0]
     abstract fun advise(com.eignex.koblas/VectorView, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.VectorView;kotlin.Int){}[0]
 }
@@ -7928,16 +7944,20 @@ final class com.eignex.kumulant.stat.sketch/CountMinSketchStat : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.stat.sketch/HeavyHittersResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.sketch/HeavyHittersResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/LongArray, kotlin/LongArray, kotlin/LongArray, kotlin/Long) // com.eignex.kumulant.stat.sketch/HeavyHittersResult.<init>|<init>(kotlin.Int;kotlin.LongArray;kotlin.LongArray;kotlin.LongArray;kotlin.Long){}[0]
+    constructor <init>(kotlin/Int, kotlin/LongArray, kotlin/LongArray, kotlin/LongArray, kotlin/Long, com.eignex.kumulant.stat.sketch/AdmissionPolicy = ..., kotlin/Long = ...) // com.eignex.kumulant.stat.sketch/HeavyHittersResult.<init>|<init>(kotlin.Int;kotlin.LongArray;kotlin.LongArray;kotlin.LongArray;kotlin.Long;com.eignex.kumulant.stat.sketch.AdmissionPolicy;kotlin.Long){}[0]
 
     final val capacity // com.eignex.kumulant.stat.sketch/HeavyHittersResult.capacity|{}capacity[0]
         final fun <get-capacity>(): kotlin/Int // com.eignex.kumulant.stat.sketch/HeavyHittersResult.capacity.<get-capacity>|<get-capacity>(){}[0]
     final val counts // com.eignex.kumulant.stat.sketch/HeavyHittersResult.counts|{}counts[0]
         final fun <get-counts>(): kotlin/LongArray // com.eignex.kumulant.stat.sketch/HeavyHittersResult.counts.<get-counts>|<get-counts>(){}[0]
+    final val deficit // com.eignex.kumulant.stat.sketch/HeavyHittersResult.deficit|{}deficit[0]
+        final fun <get-deficit>(): kotlin/Long // com.eignex.kumulant.stat.sketch/HeavyHittersResult.deficit.<get-deficit>|<get-deficit>(){}[0]
     final val errors // com.eignex.kumulant.stat.sketch/HeavyHittersResult.errors|{}errors[0]
         final fun <get-errors>(): kotlin/LongArray // com.eignex.kumulant.stat.sketch/HeavyHittersResult.errors.<get-errors>|<get-errors>(){}[0]
     final val keys // com.eignex.kumulant.stat.sketch/HeavyHittersResult.keys|{}keys[0]
         final fun <get-keys>(): kotlin/LongArray // com.eignex.kumulant.stat.sketch/HeavyHittersResult.keys.<get-keys>|<get-keys>(){}[0]
+    final val policy // com.eignex.kumulant.stat.sketch/HeavyHittersResult.policy|{}policy[0]
+        final fun <get-policy>(): com.eignex.kumulant.stat.sketch/AdmissionPolicy // com.eignex.kumulant.stat.sketch/HeavyHittersResult.policy.<get-policy>|<get-policy>(){}[0]
     final val totalSeen // com.eignex.kumulant.stat.sketch/HeavyHittersResult.totalSeen|{}totalSeen[0]
         final fun <get-totalSeen>(): kotlin/Long // com.eignex.kumulant.stat.sketch/HeavyHittersResult.totalSeen.<get-totalSeen>|<get-totalSeen>(){}[0]
     final val totalWeights // com.eignex.kumulant.stat.sketch/HeavyHittersResult.totalWeights|{}totalWeights[0]
@@ -7948,7 +7968,9 @@ final class com.eignex.kumulant.stat.sketch/HeavyHittersResult : com.eignex.kumu
     final fun component3(): kotlin/LongArray // com.eignex.kumulant.stat.sketch/HeavyHittersResult.component3|component3(){}[0]
     final fun component4(): kotlin/LongArray // com.eignex.kumulant.stat.sketch/HeavyHittersResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.sketch/HeavyHittersResult.component5|component5(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/LongArray = ..., kotlin/LongArray = ..., kotlin/LongArray = ..., kotlin/Long = ...): com.eignex.kumulant.stat.sketch/HeavyHittersResult // com.eignex.kumulant.stat.sketch/HeavyHittersResult.copy|copy(kotlin.Int;kotlin.LongArray;kotlin.LongArray;kotlin.LongArray;kotlin.Long){}[0]
+    final fun component6(): com.eignex.kumulant.stat.sketch/AdmissionPolicy // com.eignex.kumulant.stat.sketch/HeavyHittersResult.component6|component6(){}[0]
+    final fun component7(): kotlin/Long // com.eignex.kumulant.stat.sketch/HeavyHittersResult.component7|component7(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/LongArray = ..., kotlin/LongArray = ..., kotlin/LongArray = ..., kotlin/Long = ..., com.eignex.kumulant.stat.sketch/AdmissionPolicy = ..., kotlin/Long = ...): com.eignex.kumulant.stat.sketch/HeavyHittersResult // com.eignex.kumulant.stat.sketch/HeavyHittersResult.copy|copy(kotlin.Int;kotlin.LongArray;kotlin.LongArray;kotlin.LongArray;kotlin.Long;com.eignex.kumulant.stat.sketch.AdmissionPolicy;kotlin.Long){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.sketch/HeavyHittersResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.sketch/HeavyHittersResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.sketch/HeavyHittersResult.toString|toString(){}[0]
@@ -7963,6 +7985,8 @@ final class com.eignex.kumulant.stat.sketch/HeavyHittersResult : com.eignex.kumu
     }
 
     final object Companion { // com.eignex.kumulant.stat.sketch/HeavyHittersResult.Companion|null[0]
+        final val $childSerializers // com.eignex.kumulant.stat.sketch/HeavyHittersResult.Companion.$childSerializers|{}$childSerializers[0]
+
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.sketch/HeavyHittersResult> // com.eignex.kumulant.stat.sketch/HeavyHittersResult.Companion.serializer|serializer(){}[0]
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -12,10 +12,38 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Which admission algorithm produced a [HeavyHittersResult], and so which bound its counts carry.
+ *
+ * The two are freely mergeable - both are `(key, count, error)` triples over the same key space - so a
+ * mismatch is not refused. What it costs is tightness, and [Classic] plus [MisraGries] merges to
+ * [MisraGries], the weaker of the two, on the same weakest-member rule as
+ * [com.eignex.kumulant.schema.runtime.AbstractStatGroup.concurrency].
+ */
+@Serializable
+enum class AdmissionPolicy {
+    /** Space-Saving (Metwally et al. 2005). Counts never underestimate; [HeavyHittersResult.errors] bounds
+     *  how far each may overestimate. */
+    Classic,
+
+    /** Lock-free Misra-Gries. Counts never overestimate; [HeavyHittersResult.deficit] bounds how far any
+     *  may underestimate. */
+    MisraGries,
+}
+
+/**
  * Space-Saving heavy-hitters snapshot. [keys], [counts], [errors] are parallel arrays of
- * length <= [capacity]; for each tracked key, [counts] is the (over)estimated weighted
- * count and [errors] is the Space-Saving overestimate bound (the count is at most this
- * much above the true count). [totalSeen] is the unweighted update count.
+ * length <= [capacity]. [totalSeen] is the unweighted update count.
+ *
+ * The true weighted count of a tracked key lies in `[counts[i] - errors[i], counts[i] + deficit]`. Each
+ * bound closes one direction, and which one is slack depends on [policy]:
+ *
+ *  - Under [AdmissionPolicy.Classic] a count can only overestimate. [errors] carries the per-key bound
+ *    inherited from the evicted minimum, and [deficit] is zero.
+ *  - Under [AdmissionPolicy.MisraGries] a count can only underestimate, because it is only ever
+ *    incremented exactly or decremented in bulk. [errors] is zero - correctly, not for want of a bound -
+ *    and [deficit] carries the number of decrement rounds, which bounds the shortfall for every key.
+ *
+ * A merge that mixes the two accumulates [deficit] and degrades [policy], so both bounds stay sound.
  */
 @Serializable
 @SerialName("HeavyHittersResult")
@@ -25,10 +53,16 @@ data class HeavyHittersResult(
     val counts: LongArray,
     val errors: LongArray,
     val totalSeen: Long,
+    /** Which algorithm produced these counts, and so which direction their slack runs in. */
+    val policy: AdmissionPolicy = AdmissionPolicy.Classic,
+    /** Bulk-decrement rounds absorbed; bounds how far any count may fall below the true count. */
+    val deficit: Long = 0L,
 ) : HasObservationCount {
 
     override val totalWeights: Double get() = totalSeen.toDouble()
     override fun equals(other: Any?): Boolean = other is HeavyHittersResult &&
+        policy == other.policy &&
+        deficit == other.deficit &&
         capacity == other.capacity &&
         keys.contentEquals(other.keys) &&
         counts.contentEquals(other.counts) &&
@@ -41,6 +75,8 @@ data class HeavyHittersResult(
         h = 31 * h + counts.contentHashCode()
         h = 31 * h + errors.contentHashCode()
         h = 31 * h + totalSeen.hashCode()
+        h = 31 * h + policy.hashCode()
+        h = 31 * h + deficit.hashCode()
         return h
     }
 
@@ -49,7 +85,7 @@ data class HeavyHittersResult(
         "keys=${keys.preview()}, " +
         "counts=${counts.preview()}, " +
         "errors=${errors.preview()}, " +
-        "totalSeen=$totalSeen)"
+        "totalSeen=$totalSeen, policy=$policy, deficit=$deficit)"
 }
 
 /**
@@ -77,10 +113,10 @@ data class HeavyHittersResult(
  *
  *  - [Concurrency.Relaxed]: lock-free Misra-Gries variant. On a miss when
  *    full, all counts are decremented by one in best-effort fashion; a freed
- *    slot is claimed via CAS. Counts under this mode are **not** overestimates
- *   ; they may underestimate by the number of decrements, and the classic
- *    overestimate bound does not hold. Heavy hitters still surface; small/cold
- *    keys are bled out.
+ *    slot is claimed via CAS. Counts under this mode are **not** overestimates;
+ *    they underestimate by at most the number of decrement rounds, which
+ *    [HeavyHittersResult.deficit] reports. Heavy hitters still surface;
+ *    small/cold keys are bled out.
  */
 class SpaceSavingStat(
     /** Maximum number of distinct keys tracked; smaller capacity means looser
@@ -97,7 +133,27 @@ class SpaceSavingStat(
 
     // Noop under None/Relaxed; real under Strict/HighWrite.
     private val outerLock = concurrency.welfordLock()
-    private val useMisraGries: Boolean = concurrency == Concurrency.Relaxed
+
+    /**
+     * Classic Space-Saving needs a consistent read of the minimum slot to evict and inherit its count,
+     * which cannot be done lock-free, so [Concurrency.Relaxed] gets Misra-Gries instead.
+     */
+    private val policy: AdmissionPolicy =
+        if (concurrency == Concurrency.Relaxed) AdmissionPolicy.MisraGries else AdmissionPolicy.Classic
+    private val useMisraGries: Boolean = policy == AdmissionPolicy.MisraGries
+
+    /**
+     * Bulk-decrement rounds, plus any absorbed from a merged snapshot.
+     *
+     * On the Misra-Gries path this is the only thing bounding how far a count can fall below the truth.
+     * It lives off the hot path: a decrement round runs only when the table is full with no free slot,
+     * not on every update.
+     *
+     * Sticky across a policy change, because a `Classic` stat that has merged a Misra-Gries snapshot is
+     * carrying that snapshot's shortfall and must keep reporting it.
+     */
+    private val deficitCell = mode.newLong(0L)
+    private val absorbedMisraGries = mode.newLong(0L)
 
     private val keys = mode.newLongArray(capacity)
     private val counts = mode.newLongArray(capacity)
@@ -181,6 +237,10 @@ class SpaceSavingStat(
             //    step 2 on the next iteration accepts the resulting non-positive
             //    counts.
             for (i in 0 until capacity) counts.add(i, -1L)
+            // Every count just moved one below where the stream put it, so the shortfall bound grows by
+            // one for every key. Concurrent rounds each count themselves, which is the conservative
+            // direction: the bound may exceed the true shortfall, never fall short of it.
+            deficitCell.add(1L)
             // Loop and retry.
         }
     }
@@ -211,6 +271,14 @@ class SpaceSavingStat(
         require(values.capacity == capacity) {
             "Cannot merge HeavyHitters with capacity=${values.capacity} into $capacity"
         }
+        // A policy mismatch is not refused. Unlike a hasher mismatch, which makes two sketches'
+        // arrays incomparable, both policies produce (key, count, error) triples over the same key
+        // space - only the tightness differs. Refusing would also break the obvious topology of many
+        // Relaxed workers feeding one Strict coordinator. So the snapshot is absorbed and the bounds
+        // are widened to stay sound: the incoming shortfall is added, and the reported policy degrades
+        // to the weaker of the two.
+        if (values.policy == AdmissionPolicy.MisraGries) absorbedMisraGries.store(1L)
+        deficitCell.add(values.deficit)
         if (useMisraGries) {
             for (i in values.keys.indices) {
                 admitMisraGries(values.keys[i], values.counts[i], values.errors[i])
@@ -234,8 +302,14 @@ class SpaceSavingStat(
                 errors.store(i, 0L)
             }
             totalSeenCell.store(0L)
+            deficitCell.store(0L)
+            absorbedMisraGries.store(0L)
         }
     }
+
+    /** This stat's own policy, weakened if it has absorbed a Misra-Gries snapshot. */
+    private fun effectivePolicy(): AdmissionPolicy =
+        if (useMisraGries || absorbedMisraGries.load() != 0L) AdmissionPolicy.MisraGries else policy
 
     override fun read(timestampNanos: Long): HeavyHittersResult = outerLock.guarded {
         // Filter active slots (count > 0). Snapshot per-slot; under Relaxed a brief
@@ -263,6 +337,8 @@ class SpaceSavingStat(
             counts = outC.copyOf(cursor),
             errors = outE.copyOf(cursor),
             totalSeen = totalSeenCell.load(),
+            policy = effectivePolicy(),
+            deficit = deficitCell.load(),
         )
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingAdmissionPolicyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingAdmissionPolicyTest.kt
@@ -1,0 +1,151 @@
+package com.eignex.kumulant.stat.sketch
+
+import com.eignex.kumulant.core.Concurrency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A heavy-hitters snapshot says which algorithm produced it and bounds its counts in both directions.
+ *
+ * The stat runs classic Space-Saving under most levels and a lock-free Misra-Gries variant under
+ * [Concurrency.Relaxed], because classic's evict-and-inherit needs a consistent read of the minimum slot.
+ * The two bound their counts in opposite directions, and the snapshot used to carry neither the policy nor
+ * the Misra-Gries shortfall - so a caller could not tell which guarantee applied, and a mixed merge
+ * silently republished counts under the wrong one.
+ */
+class SpaceSavingAdmissionPolicyTest {
+
+    private fun feed(stat: SpaceSavingStat, distinctKeys: Int, perKey: Int) {
+        for (k in 0 until distinctKeys) {
+            repeat(perKey) { stat.update(k.toLong()) }
+        }
+    }
+
+    @Test
+    fun `each concurrency level reports the policy it actually runs`() {
+        val expected = mapOf(
+            Concurrency.None to AdmissionPolicy.Classic,
+            Concurrency.Strict to AdmissionPolicy.Classic,
+            Concurrency.HighWrite to AdmissionPolicy.Classic,
+            Concurrency.Relaxed to AdmissionPolicy.MisraGries,
+        )
+        val violations = mutableListOf<String>()
+        for (level in Concurrency.entries) {
+            val want = expected[level]
+            if (want == null) {
+                violations += "$level has no expectation here, so this sweep does not cover it"
+                continue
+            }
+            val stat = SpaceSavingStat(capacity = 4, concurrency = level)
+            feed(stat, distinctKeys = 3, perKey = 2)
+            val got = stat.read().policy
+            if (got != want) violations += "$level reported $got, runs $want"
+        }
+        assertEquals(emptyList(), violations.toList(), "a level misreports its admission algorithm")
+    }
+
+    @Test
+    fun `classic never underestimates so it reports no deficit`() {
+        val stat = SpaceSavingStat(capacity = 4, concurrency = Concurrency.None)
+        feed(stat, distinctKeys = 20, perKey = 3)
+
+        val r = stat.read()
+        assertEquals(AdmissionPolicy.Classic, r.policy)
+        assertEquals(0L, r.deficit, "classic inherits the evicted count, so no count can fall short")
+        assertTrue(r.errors.any { it > 0L }, "evictions should have produced a per-key overestimate bound")
+    }
+
+    @Test
+    fun `misra-gries reports the shortfall its decrements cause`() {
+        // Far more distinct keys than slots, so the table fills and decrement rounds have to run. Without
+        // a deficit the all-zero `errors` array read as "these counts are exact", which they are not.
+        val stat = SpaceSavingStat(capacity = 4, concurrency = Concurrency.Relaxed)
+        feed(stat, distinctKeys = 40, perKey = 2)
+
+        val r = stat.read()
+        assertEquals(AdmissionPolicy.MisraGries, r.policy)
+        assertTrue(r.deficit > 0L, "decrement rounds ran but the shortfall bound is still zero")
+        assertTrue(r.errors.all { it == 0L }, "misra-gries counts cannot overestimate, so errors stays zero")
+    }
+
+    @Test
+    fun `the reported bounds actually contain the true counts`() {
+        // The point of tracking the deficit. One key is fed heavily and the rest are noise, so the heavy
+        // key survives eviction; its true count must lie inside [count - error, count + deficit].
+        // The two directions are not interchangeable: `errors` is how far a count may sit ABOVE the
+        // truth, so it opens the lower bound, and `deficit` is how far it may sit BELOW, so it opens
+        // the upper one. Swapping that pair is what this assertion caught when it was first written.
+        for (level in listOf(Concurrency.None, Concurrency.Relaxed)) {
+            val stat = SpaceSavingStat(capacity = 8, concurrency = level)
+            val heavy = 7L
+            val heavyCount = 500
+            repeat(heavyCount) { stat.update(heavy) }
+            for (k in 100 until 200) stat.update(k.toLong())
+            repeat(heavyCount) { stat.update(heavy) }
+
+            val r = stat.read()
+            val idx = r.keys.indexOfFirst { it == heavy }
+            assertTrue(idx >= 0, "$level: the heavy key was evicted, so this proves nothing")
+
+            val truth = (heavyCount * 2).toLong()
+            val low = r.counts[idx] - r.errors[idx]
+            val high = r.counts[idx] + r.deficit
+            assertTrue(
+                truth in low..high,
+                "$level: true=$truth outside [$low, $high] (count=${r.counts[idx]}, " +
+                    "error=${r.errors[idx]}, deficit=${r.deficit})",
+            )
+        }
+    }
+
+    @Test
+    fun `a mixed merge is absorbed rather than refused`() {
+        // Many Relaxed workers feeding one Strict coordinator is the obvious topology, so a policy
+        // mismatch must not throw. Both sides are (key, count, error) triples over the same key space;
+        // only the tightness differs, unlike a hasher mismatch which makes the arrays incomparable.
+        val worker = SpaceSavingStat(capacity = 8, concurrency = Concurrency.Relaxed)
+        feed(worker, distinctKeys = 40, perKey = 2)
+        val snapshot = worker.read()
+        assertEquals(AdmissionPolicy.MisraGries, snapshot.policy)
+        assertTrue(snapshot.deficit > 0L, "the worker did not accumulate a shortfall, so this is vacuous")
+
+        val coordinator = SpaceSavingStat(capacity = 8, concurrency = Concurrency.Strict)
+        coordinator.update(1L)
+        coordinator.merge(snapshot)
+
+        val r = coordinator.read()
+        assertEquals(
+            AdmissionPolicy.MisraGries,
+            r.policy,
+            "a coordinator holding Misra-Gries counts must not claim the classic guarantee",
+        )
+        assertTrue(r.deficit >= snapshot.deficit, "the absorbed shortfall was dropped")
+    }
+
+    @Test
+    fun `a same-policy merge keeps the stronger guarantee`() {
+        // Guards the degradation above: it must not fire on every merge.
+        val a = SpaceSavingStat(capacity = 8, concurrency = Concurrency.None)
+        feed(a, distinctKeys = 20, perKey = 3)
+        val b = SpaceSavingStat(capacity = 8, concurrency = Concurrency.Strict)
+        b.merge(a.read())
+
+        val r = b.read()
+        assertEquals(AdmissionPolicy.Classic, r.policy, "two classic sketches merged should stay classic")
+        assertEquals(0L, r.deficit)
+    }
+
+    @Test
+    fun `reset clears the absorbed policy and shortfall`() {
+        val stat = SpaceSavingStat(capacity = 8, concurrency = Concurrency.Strict)
+        val worker = SpaceSavingStat(capacity = 8, concurrency = Concurrency.Relaxed)
+        feed(worker, distinctKeys = 40, perKey = 2)
+        stat.merge(worker.read())
+        stat.reset()
+
+        val r = stat.read()
+        assertEquals(AdmissionPolicy.Classic, r.policy, "reset should restore the stat's own policy")
+        assertEquals(0L, r.deficit, "reset should clear the absorbed shortfall")
+    }
+}


### PR DESCRIPTION
## What changed

- Added a serializable `AdmissionPolicy` enum, `Classic` or `MisraGries`, derived once from the concurrency level in place of a private boolean.
- `HeavyHittersResult` gained `policy` and `deficit`. The true weighted count of a tracked key now lies in `[counts[i] - errors[i], counts[i] + deficit]`.
- Misra-Gries counts its bulk-decrement rounds, which is what bounds the shortfall those decrements cause.
- A merge across policies is absorbed rather than refused: the incoming deficit accumulates and the reported policy degrades to the weaker of the two.
- Corrected the class and result KDoc, which described the Relaxed counts as having no usable bound.
- `equals`, `hashCode` and `toString` cover the two new fields; `reset` clears them.

## Why

The stat runs two different algorithms depending on the concurrency level, and its snapshot could not say which. Classic Space-Saving runs under None, Strict and HighWrite; a lock-free Misra-Gries variant runs under Relaxed, because classic's evict-and-inherit needs a consistent read of the minimum slot and that cannot be done lock-free.

The two bound their counts in opposite directions. Classic counts never underestimate, and `errors` carries the per-key slack inherited from the evicted minimum. Misra-Gries counts never overestimate, because they are only ever incremented exactly or decremented in bulk, so `errors` is legitimately zero there. What was missing was the bound in the other direction: nothing recorded how far a count could fall below the truth, and an all-zero `errors` array read as "these counts are exact" when they were not.

Counting the decrement rounds closes that. Each round moves every count one below where the stream put it, so the round count bounds the shortfall for every key. It sits off the hot path, since a round runs only when the table is full with no free slot rather than on every update.

A policy mismatch on merge is not refused. Unlike a hasher mismatch, which makes two sketches' arrays incomparable because a register means something different on each side, both policies produce `(key, count, error)` triples over the same key space; only the tightness differs. Refusing would also break the obvious topology of many Relaxed workers feeding one Strict coordinator. Absorbing and widening keeps both bounds sound, and degrading to the weaker policy follows the same weakest-member rule as `AbstractStatGroup.concurrency`.

## Testing

`./gradlew build` passes: all thirteen targets, detekt, and the ABI check. The ABI delta is the new enum plus the two result fields and nothing else.

Seven tests cover it, including one that feeds a known-heavy key through eviction pressure and asserts its true count actually falls inside the reported interval, at both a classic and a Relaxed level. That test earned its keep immediately: the first version of this change had the two bounds the wrong way round, and it failed with `true=1000 outside [972, 986]` rather than passing quietly. The KDoc had the same inversion.

The policy sweep is driven off `Concurrency.entries` so a level added later fails rather than going uncovered, and the degradation test is paired with a same-policy merge asserting the stronger guarantee survives.
