### PR TITLE
docs: strip change narration and restated comments across the codebase

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/StatSpecs.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/StatSpecs.kt
@@ -673,9 +673,9 @@ val decayingRateStatSpec = seriesStatSpec(
 // by binding the factory's stat to an [AtomicLong] that serializes all writers
 // behind a globally-monotonic sequence: each call to [applyUpdate] increments
 // the shared counter and feeds its new value to the stat. Under concurrent
-// writers the stat now sees true monotonic input regardless of thread
-// interleaving, isolating the stat's own concurrency primitives from the
-// "two independent counters" misuse pattern.
+// writers the stat sees truly monotonic input regardless of thread interleaving,
+// isolating the stat's own concurrency primitives from the "two independent
+// counters" misuse pattern.
 class CounterRateBag internal constructor(val stat: CounterRateStat, val counter: AtomicLong)
 
 val counterRateStatSpec: StatSpec<CounterRateBag, com.eignex.kumulant.stat.rate.RateResult> = StatSpec(

--- a/kumulant-bench/src/jvmMain/kotlin/com/eignex/kumulant/bench/ThroughputAnalysis.kt
+++ b/kumulant-bench/src/jvmMain/kotlin/com/eignex/kumulant/bench/ThroughputAnalysis.kt
@@ -51,9 +51,8 @@ fun main() {
     // A single run is not a measurement. Running the same commit twice at the default settings gave
     // per-cell ratios spanning 0.36x to 2.16x (p10 0.61, p90 1.44, median 0.974, n=449), so anything
     // inside that band is noise, and a diff between two branches read from one run each is worthless.
-    // Comparing PR #45 against main showed a 1.146x median on the first pair and 1.013x on the second,
-    // which is the whole point. Raise -Dbench.warmupMs / -Dbench.measureMs, or take a median over
-    // several runs, before believing a regression.
+    // Raise -Dbench.warmupMs / -Dbench.measureMs, or take a median over several runs, before
+    // believing a regression.
     println(
         "Single-run cells carry roughly +/-40% noise at these settings; re-run the same commit twice " +
             "to see the floor before reading any difference as signal.",

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
@@ -26,13 +26,10 @@ internal const val RENORM_FLOOR: Double = 1e-100
  * by its maximum is free: it changes no arm's or expert's relative standing. That is what makes both
  * ends of the range recoverable rather than just the top one.
  *
- * Both ends need guarding, and only the overflow end used to be. A run of large negative rewards drives
- * every `exp(eta * gain)` toward zero, and once the array is *entirely* zero no later reward can lift
- * it: every subsequent update multiplies zero by something. Rescaling by the surviving maximum keeps
- * the array alive; the fully collapsed case has no ratios left to preserve, so it resets to uniform.
- *
- * EXP3 and EXP4 carried separate copies of this, spelled with different branch structure - EXP3 tested
- * the ceiling and the floor in two `if`s, EXP4 in one disjunction - but they compute the same thing.
+ * Both ends need guarding. A run of large negative rewards drives every `exp(eta * gain)` toward zero,
+ * and once the array is *entirely* zero no later reward can lift it: every subsequent update multiplies
+ * zero by something. Rescaling by the surviving maximum keeps the array alive; the fully collapsed case
+ * has no ratios left to preserve, so it resets to uniform.
  */
 internal fun DoubleArray.renormaliseExponentialWeights() {
     var maxW = 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -208,11 +208,10 @@ class Exp4Bandit(
         /**
          * Default exploration mix `min(1, eta)`.
          *
-         * This used to be `min(1, K * eta)`, which with the horizon-free [defaultEta] above works
-         * out to `sqrt(K * ln N)` - at least 1.177 for any real configuration, so it clamped to
-         * exactly 1.0 and [playDistribution] became uniform, multiplying the expert mixture by
-         * `1 - gamma == 0`. `K * eta` is only the textbook rule when `eta` still carries the `1/T`
-         * horizon term. Pass `gamma = 1.0` explicitly for pure uniform sampling.
+         * `min(1, K * eta)` is the textbook rule only while `eta` still carries the `1/T` horizon
+         * term. With the horizon-free [defaultEta] above it works out to `sqrt(K * ln N)`, at least
+         * 1.177 for any real configuration, so it would clamp to exactly 1.0 and leave
+         * [playDistribution] uniform. Pass `gamma = 1.0` explicitly for pure uniform sampling.
          */
         fun defaultGamma(eta: Double): Double = eta.coerceAtMost(1.0)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
@@ -216,16 +216,15 @@ class UCB1Normal(
         val nj = snapshot.totalWeights
         if (nbrArms <= 1 || nj < 8 * ln(nbrArms.toDouble())) return Double.POSITIVE_INFINITY
         // Auer et al. subtract `n * mean^2` from the SUM of squares, and meanOfSquares() is the
-        // MEAN of squares, so this has to scale up by `nj` first. Subtracting `n * mean^2` from
-        // `E[x^2]` made p1 negative for every arm with a non-zero mean, so the sqrt below was NaN
-        // and `choose` - which seeds its best score at -Infinity, and `NaN > -Inf` is false -
-        // silently degenerated to always picking arm 0.
+        // MEAN of squares, so this has to scale up by `nj` first. Subtracting from `E[x^2]` instead
+        // drives p1 negative for every arm with a non-zero mean, and the sqrt below turns NaN, which
+        // `choose` resolves to always picking arm 0 (`NaN > -Inf` is false).
         val sumOfSquares = snapshot.meanOfSquares() * nj
         val p1 = ((sumOfSquares - nj * snapshot.mean * snapshot.mean) / (nj - 1)).coerceAtLeast(0.0)
-        // `n` in Auer et al. is the total pull count, not the arm count. Against `nbrArms` this was
-        // ln(1) == 0 at K = 2, so the confidence bound vanished and the policy went exactly greedy at
-        // the arm count where exploration matters most. `step` carries the round count, which is why
-        // it is a parameter; this arm's own pulls floor it, since they are part of any total and
+        // `n` in Auer et al. is the total pull count, not the arm count. Against `nbrArms` the log
+        // term is ln(1) == 0 at K = 2, so the confidence bound vanishes and the policy goes exactly
+        // greedy at the arm count where exploration matters most. `step` carries the round count,
+        // which is why it is a parameter; this arm's own pulls floor it, since they are part of any total and
         // `step` stays 0 for a caller that drives update() directly without choose().
         val totalPulls = maxOf(step.toDouble(), nj)
         return snapshot.mean + alpha * sqrt(16 * p1 * (ln((totalPulls - 1.0).coerceAtLeast(1.0)) / nj))

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -154,13 +154,12 @@ class Exp3Bandit(
         /**
          * Horizon-free default exploration mix `min(1, eta)`.
          *
-         * This used to be `min(1, K * eta)`, which is the textbook mixing rule - but only when
-         * `eta` is the horizon-scaled `sqrt(ln K / (K T))`. Against the horizon-free `eta` above,
-         * `K * eta` is `sqrt(K * ln K)`, which is at least 1.177 for every `K >= 2`, so it clamped
-         * to exactly 1.0 at every arm count and [playDistribution] collapsed to uniform: the
-         * learned weights were multiplied by `1 - gamma == 0`. Using `eta` itself keeps the same
-         * "explore less as evidence per arm grows" shape and tops out at 0.59 for two arms, so it
-         * cannot saturate. Pass `gamma = 1.0` explicitly for pure uniform sampling.
+         * The textbook mixing rule `min(1, K * eta)` holds only when `eta` is the horizon-scaled
+         * `sqrt(ln K / (K T))`. Against the horizon-free `eta` above, `K * eta` is `sqrt(K * ln K)`,
+         * at least 1.177 for every `K >= 2`, so it would clamp to exactly 1.0 at every arm count and
+         * collapse [playDistribution] to uniform. Using `eta` itself keeps the same "explore less as
+         * evidence per arm grows" shape and tops out at 0.59 for two arms, so it cannot saturate.
+         * Pass `gamma = 1.0` explicitly for pure uniform sampling.
          */
         fun defaultGamma(eta: Double): Double = eta.coerceAtMost(1.0)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
@@ -108,8 +108,7 @@ class RouletteWheelBandit(
         return nbrArms - 1
     }
 
-    /** Returns the arm's current weight. Used by `choose` is computed inline; this is
-     *  the [Scorable] view exposed for inspection / debugging. */
+    /** The arm's current weight; `choose` computes the same quantity inline. */
     override fun evaluate(armIndex: Int): Double {
         requireArmIndex(armIndex, nbrArms)
         return weights[armIndex]
@@ -117,9 +116,9 @@ class RouletteWheelBandit(
 
     override fun update(armIndex: Int, value: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
-        // A zero weight contributes nothing to the score, but the counter and the segment clock
-        // used to advance anyway, so it diluted the arm's average toward zero and could trip a
-        // rebalance. Zero weight means "ignore this observation" library-wide.
+        // Return before the counter and the segment clock, not just before the score: advancing them
+        // on a zero-weight observation would dilute the arm's average and could trip a rebalance.
+        // Zero weight means "ignore this observation" library-wide.
         if (weight.isInertWeight()) return
         accumulatedScores[armIndex] += value * weight
         callCounts[armIndex]++

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/TopTwoThompsonBandit.kt
@@ -72,7 +72,6 @@ class TopTwoThompsonBandit<R : Result>(
     private val stats: Array<SeriesStat<R>> = Array(nbrArms) { policy.createArm() }
     private var step: Long = 0L
 
-    /** Choose an arm via the top-two protocol. */
     override fun choose(): Int {
         val arm1 = sampleArgmax()
         if (random.nextDouble() < beta) return arm1

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -73,9 +73,8 @@ interface HasMinMax : Result {
  * Result trait for snapshots that know how much evidence they are built from.
  *
  * Exists so a caller can ask "did this stat see anything?" without knowing which field
- * carries the answer. The count is spelled `totalWeights` on most results, `totalSeen` on the
- * sketches and `totalWeight` on a few others, so before this trait the emptiness check was
- * per-stat knowledge.
+ * carries the answer; the count is spelled `totalWeights` on most results, `totalSeen` on the
+ * sketches and `totalWeight` on a few others.
  *
  * The distinction matters because several results report a numerically plausible value on an
  * empty stream. A quantile sketch with no observations reports `NaN` per quantile precisely so

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -7,14 +7,10 @@ import com.eignex.koblas.VectorView
  *
  * Every [RegressionStat] opens its `update` with this check, and every linear-model [Result] repeats
  * it in `predict` / `logit`, because a mismatched vector does not fail loudly on its own: a *short*
- * vector simply reads fewer coordinates and returns a plausible number from the wrong model. Fourteen
- * sites spelled the same `require` out by hand, twice within the same file in two of them.
+ * vector simply reads fewer coordinates and returns a plausible number from the wrong model.
  *
- * The message is deliberately identical to the hand-written form - `x.size=<n>, expected <m>` - so it
- * stays greppable and so the assertion in `RegressionOpsTest` keeps meaning what it meant. The one
- * site left spelling it out is `HalfSpaceTreesStat.update`, whose receiver is named `vector` and whose
- * message says so.
-
+ * The message is fixed at `x.size=<n>, expected <m>` so it stays greppable. `HalfSpaceTreesStat.update`
+ * spells its own check out instead, because its receiver is named `vector` and its message says so.
  *
  * @param expected the model's feature count.
  * @throws IllegalArgumentException if [VectorView.size] differs from [expected].

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Weights.kt
@@ -9,13 +9,11 @@ package com.eignex.kumulant.core
  *
  * The infinities are the less obvious half. `+Infinity` does have a clean mathematical reading - the
  * weighted mean update `w / (W + w)` tends to 1, so the mean tends to the observed value and the
- * variance to zero - but almost nothing in the library computed that limit. The recurrences evaluate
- * `Infinity / Infinity` and `Infinity * 0` and reported the resulting `NaN` as an answer, in 22 stat and
- * weight combinations across three modalities. Supporting the limit properly would mean rewriting eleven
- * recurrences, up to and including the third and fourth moments, and would still leave every affected
- * stat with `totalWeights = Infinity` permanently, wedging the bias corrections that divide by it. A
- * caller who wants to pin a stat to a value is better served by saying so than by smuggling an infinity
- * through the weight channel.
+ * variance to zero - but the recurrences do not reach that limit: they evaluate `Infinity / Infinity`
+ * and `Infinity * 0` and yield `NaN`. Supporting the limit would mean special-casing every recurrence
+ * up to the fourth moment, and would still leave the stat with `totalWeights = Infinity` permanently,
+ * wedging the bias corrections that divide by it. A caller who wants to pin a stat to a value is better
+ * served by saying so than by smuggling an infinity through the weight channel.
  *
  * Note that this is the *weight*, not the value: a `NaN` or infinite value is a real observation of an
  * unusable number and propagates. See [Stat] for the contract and why the two differ.
@@ -36,12 +34,10 @@ internal inline fun Double.isInertWeight(): Boolean = !isFinite() || this == 0.0
  * dropped alongside the inert cases. See [Stat] for which stats fall on which side.
  *
  * `!(this > 0.0)` rather than `this <= 0.0 || isNaN()` because `NaN > 0.0` is already false: the `NaN`
- * case falls out of the comparison instead of needing a second clause a caller has to remember. Twenty
- * call sites used to spell out the two-clause form, and the sites that spelled it out slightly
- * differently are exactly where the class-label defects lived.
+ * case falls out of the comparison instead of needing a second clause a caller has to remember.
  *
- * The `isFinite` clause is not redundant with that: `+Infinity > 0.0` is true, so an infinite weight
- * used to pass here as an ordinary live observation and land in a histogram bucket or a sketch register
+ * The `isFinite` clause is not redundant with that: `+Infinity > 0.0` is true, so without it an infinite
+ * weight would pass as an ordinary live observation and land in a histogram bucket or a sketch register
  * as infinite mass. See [isInertWeight] for why an infinity is not a multiplicity.
  */
 @Suppress("NOTHING_TO_INLINE") // as with isInertWeight; the non-JVM targets pay for the call
@@ -71,10 +67,9 @@ internal inline fun Double.isNotPositiveWeight(): Boolean = !(this > 0.0) || !is
  */
 internal fun requireLiveWeight(currentTotal: Double, weight: Double) {
     // Callers drop a non-finite weight before reaching here, but keep the guard local too. `NaN > 0.0`
-    // is false, so the require below would fire and report a NaN weight as a downdate emptying the
-    // accumulator - wrong, and the one thing a NaN weight must not do now that it is a no-op. A
-    // `-Infinity` weight would trip it for the same spurious reason, reporting an unrepresentable
-    // downdate rather than the inert weight it now is.
+    // is false, so the require below would otherwise fire and report a NaN weight as a downdate emptying
+    // the accumulator - wrong, since a NaN weight is a no-op. A `-Infinity` weight would trip it for the
+    // same spurious reason.
     if (!weight.isFinite()) return
     require(currentTotal + weight > 0.0) {
         "weight $weight would take the accumulated weight from $currentTotal to " +
@@ -95,10 +90,6 @@ internal fun requireLiveWeight(currentTotal: Double, weight: Double) {
  * `NaN.toInt()` is `0`, which means the most obviously invalid label in the language arrives looking
  * like a perfectly ordinary first class. Demanding `c.toDouble() == this` rejects all three: only a
  * `Double` that is exactly an integer survives.
- *
- * This was open-coded at five sites with three different policies. The two GLM classifiers
- * round-tripped, the forest and the tree truncated, and `ClassCountsStat` truncated as well - so the
- * same `y = 1.5` trained as class 1 on the tree path and was refused on the GLM path.
  *
  * @param numClasses exclusive upper bound on the index; `numClasses` itself is not a class.
  * @return the class index, or `-1` if this `Double` does not name one. `-1` rather than `null` to keep

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Distributions.kt
@@ -45,13 +45,13 @@ private fun Random.standardNormal(): Double {
     while (true) {
         val hz = nextInt()
         val iz = hz and (ZIGGURAT_N - 1)
-        // -Int.MIN_VALUE is still Int.MIN_VALUE, so a plain `-hz` left absHz negative once every 2^32
-        // draws and the comparison below was trivially true, taking the layer-0 inner-rectangle fast
-        // path where the tail sampler was required. Clamping that one input to Int.MAX_VALUE fixes it
-        // without widening to Long: every ZIGGURAT_KN entry is at most Int.MAX_VALUE, so both
-        // Int.MAX_VALUE and the true magnitude 2^31 fail the test identically and fall through to the
-        // tail. Widening would be correct too, but Kotlin/JS emulates Long as a class, which put two
-        // boxed allocations and a compare() call in the 97% fast path of every normal draw.
+        // -Int.MIN_VALUE is still Int.MIN_VALUE, so a plain `-hz` would leave absHz negative once every
+        // 2^32 draws, making the comparison below trivially true and taking the layer-0 inner-rectangle
+        // fast path where the tail sampler is required. Clamping that one input to Int.MAX_VALUE avoids
+        // widening to Long: every ZIGGURAT_KN entry is at most Int.MAX_VALUE, so both Int.MAX_VALUE and
+        // the true magnitude 2^31 fail the test identically and fall through to the tail. Widening is
+        // correct too, but Kotlin/JS emulates Long as a class, putting two boxed allocations and a
+        // compare() call in the 97% fast path of every normal draw.
         val absHz = if (hz >= 0) {
             hz
         } else if (hz == Int.MIN_VALUE) {
@@ -119,9 +119,9 @@ private val ZIGGURAT_INIT = run {
 fun Random.nextLogNormal(mean: Double, variance: Double): Double {
     require(mean > 0.0) { "nextLogNormal requires mean > 0; got $mean" }
     require(variance >= 0.0) { "nextLogNormal requires variance >= 0; got $variance" }
-    // Derive sigma from the coefficient of variation rather than from phi/mean directly: squaring
-    // the mean underflowed to 0.0 well inside the documented domain (mean > 0), which made
-    // ln(phi^2 / mean^2) evaluate 0.0/0.0 and return NaN - and one exponent earlier it could return a
+    // Derive sigma from the coefficient of variation rather than from phi/mean directly: squaring the
+    // mean underflows to 0.0 well inside the documented domain (mean > 0), which makes
+    // ln(phi^2 / mean^2) evaluate 0.0/0.0 and return NaN, and one exponent earlier yields a
     // non-positive draw from a strictly positive distribution. variance / mean^2 is the same ratio
     // with one fewer chance to underflow, and log1p keeps precision when it is small.
     val cv2 = (variance / mean) / mean

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Softmax.kt
@@ -12,14 +12,11 @@ import kotlin.math.exp
  * In place because all three call sites already own a scratch array they built for this, so returning a
  * fresh one would add an allocation per observation on the softmax training path.
  *
- * @return `true` if the array now holds probabilities. The `false` case is carried over from the three
- *  copies this replaces, all of which guarded on the sum being positive, and it is retained so this
- *  behaves exactly as they did - but it cannot currently fire. The shift guarantees one element is
- *  `exp(0) == 1`, so a finite input always sums to at least 1; and a non-finite input makes the sum
- *  `NaN`, which fails `<= 0.0` too. A `NaN` logit therefore returns `true` with a `NaN` array, which is
- *  how a single `NaN` feature poisons a softmax model's weights for good. That is a real defect, older
- *  than this function and unchanged by it, and fixing it means deciding what a model should do with an
- *  unusable feature rather than tightening this guard alone.
+ * @return `true` if the array now holds probabilities. The non-empty `false` case cannot fire: the shift
+ *  guarantees one element is `exp(0) == 1`, so a finite input always sums to at least 1, and a non-finite
+ *  input makes the sum `NaN`, which fails `<= 0.0` too. A `NaN` logit therefore returns `true` with a
+ *  `NaN` array, which is how a single `NaN` feature poisons a softmax model's weights for good. Fixing
+ *  that means deciding what a model should do with an unusable feature, not tightening this guard.
  */
 internal fun DoubleArray.softmaxInPlace(): Boolean {
     if (isEmpty()) return false
@@ -32,7 +29,7 @@ internal fun DoubleArray.softmaxInPlace(): Boolean {
     }
     if (z <= 0.0) return false
     // One reciprocal and a multiply per element rather than a divide per element; this runs once per
-    // observation on the training path, and the update site already spelled it this way.
+    // observation on the training path.
     val invZ = 1.0 / z
     for (i in indices) this[i] *= invZ
     return true

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/AxisBindings.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/AxisBindings.kt
@@ -15,7 +15,6 @@ internal fun <R : Result> PairedStat<R>.withFixedX(fixedX: Double): SeriesStat<R
 /** Lift a paired stat into a series stat that always feeds [fixedY] as the y coordinate. */
 internal fun <R : Result> PairedStat<R>.withFixedY(fixedY: Double): SeriesStat<R> = WithFixedYStat(this, fixedY)
 
-/** Series-adapter implementation for [withTimeAsX]. */
 internal class WithTimeAsXStat<R : Result>(private val delegate: PairedStat<R>) :
     SeriesStat<R>,
     Stat<R> by delegate {
@@ -31,7 +30,6 @@ internal class WithTimeAsXStat<R : Result>(private val delegate: PairedStat<R>) 
     override fun create(concurrency: Concurrency?): SeriesStat<R> = WithTimeAsXStat(delegate.create(concurrency))
 }
 
-/** Series-adapter implementation for [withTimeAsY]. */
 internal class WithTimeAsYStat<R : Result>(private val delegate: PairedStat<R>) :
     SeriesStat<R>,
     Stat<R> by delegate {
@@ -47,7 +45,6 @@ internal class WithTimeAsYStat<R : Result>(private val delegate: PairedStat<R>) 
     override fun create(concurrency: Concurrency?): SeriesStat<R> = WithTimeAsYStat(delegate.create(concurrency))
 }
 
-/** Series-adapter implementation for [withFixedX]. */
 internal class WithFixedXStat<R : Result>(private val delegate: PairedStat<R>, private val fixedX: Double) :
     SeriesStat<R>,
     Stat<R> by delegate {
@@ -58,7 +55,6 @@ internal class WithFixedXStat<R : Result>(private val delegate: PairedStat<R>, p
     override fun create(concurrency: Concurrency?): SeriesStat<R> = WithFixedXStat(delegate.create(concurrency), fixedX)
 }
 
-/** Series-adapter implementation for [withFixedY]. */
 internal class WithFixedYStat<R : Result>(private val delegate: PairedStat<R>, private val fixedY: Double) :
     SeriesStat<R>,
     Stat<R> by delegate {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
@@ -35,13 +35,11 @@ internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private va
         error("band wrapper cannot merge BandResult; merge the inner stat directly")
 
     /**
-     * Rebuild as a band *around* a windowed inner stat rather than a window around a band.
+     * Band *around* a windowed inner stat rather than a window around a band.
      *
-     * The two compose to the same thing: this wrapper forwards update / reset / create untouched and
-     * only projects in [read], so windowing the inner stat and banding the result is identical in
-     * meaning. It is not identical in behaviour, because a window reads by merging its slices into a
-     * fresh template - and merging *through* this wrapper throws, so a windowed band threw on every
-     * read once a slice had data. Both wrappers are wire-reachable, so the combination has to work.
+     * The two orders mean the same thing, since this wrapper only projects in [read], but only this
+     * one works: a window reads by merging its slices into a fresh template, and merging *through*
+     * this wrapper throws.
      */
     internal fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<BandResult> =
         BandSeriesStat(delegate.windowed(duration, slices, concurrency), k)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -40,7 +40,6 @@ internal fun <P : Result, I : Result> SeriesStat<I>.withFeedback(
 
 internal class FeedbackSeriesStat<P : Result, I : Result>(
     private val inner: SeriesStat<I>,
-    /** Primary state-tracking stat owned by the wrapper. Exposed for snapshot inspection. */
     val primary: SeriesStat<P>,
     private val project: ScalarExpr,
 ) : SeriesStat<I>,
@@ -75,7 +74,6 @@ internal fun <P : Result, I : Result> VectorStat<I>.withFeedback(
 
 internal class FeedbackVectorStat<P : Result, I : Result>(
     private val inner: VectorStat<I>,
-    /** Per-coordinate primary state-tracking stat owned by the wrapper. */
     val primary: VectorStat<ResultList<P>>,
     private val project: ScalarExpr,
 ) : VectorStat<I>,
@@ -112,7 +110,6 @@ internal fun <P : Result, R : Result> RegressionStat<R>.withFeedback(
 
 internal class FeedbackRegressionStat<P : Result, R : Result>(
     private val inner: RegressionStat<R>,
-    /** Per-coordinate primary state-tracking stat owned by the wrapper. */
     val primary: VectorStat<ResultList<P>>,
     private val project: ScalarExpr,
 ) : RegressionStat<R>,
@@ -153,9 +150,7 @@ internal fun <P : Result, R : Result> PairedStat<R>.withFeedback(
 
 internal class FeedbackPairedStat<P : Result, R : Result>(
     private val inner: PairedStat<R>,
-    /** x-axis state-tracking stat owned by the wrapper. */
     val primaryX: SeriesStat<P>,
-    /** y-axis state-tracking stat owned by the wrapper. */
     val primaryY: SeriesStat<P>,
     private val project: ScalarExpr,
 ) : PairedStat<R>,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
@@ -59,7 +59,6 @@ private class MappedResultCore<R1 : Result, R2 : Result>(
         error("MappedResultCore.create is not used; the modality adapter rebuilds itself")
 }
 
-/** Adapter implementing the series-stat variant of [mapResult]. */
 internal class MapResultSeriesStat<R1 : Result, R2 : Result>(
     private val delegate: SeriesStat<R1>,
     private val forward: (R1) -> R2,
@@ -72,7 +71,6 @@ internal class MapResultSeriesStat<R1 : Result, R2 : Result>(
         MapResultSeriesStat(delegate.create(concurrency), forward, reverse)
 }
 
-/** Adapter implementing the paired-stat variant of [mapResult]. */
 internal class MapResultPairedStat<R1 : Result, R2 : Result>(
     private val delegate: PairedStat<R1>,
     private val forward: (R1) -> R2,
@@ -85,7 +83,6 @@ internal class MapResultPairedStat<R1 : Result, R2 : Result>(
         MapResultPairedStat(delegate.create(concurrency), forward, reverse)
 }
 
-/** Adapter implementing the vector-stat variant of [mapResult]. */
 internal class MapResultVectorStat<R1 : Result, R2 : Result>(
     private val delegate: VectorStat<R1>,
     private val forward: (R1) -> R2,
@@ -98,7 +95,6 @@ internal class MapResultVectorStat<R1 : Result, R2 : Result>(
         MapResultVectorStat(delegate.create(concurrency), forward, reverse)
 }
 
-/** Adapter implementing the discrete-stat variant of [mapResult]. */
 internal class MapResultDiscreteStat<R1 : Result, R2 : Result>(
     private val delegate: DiscreteStat<R1>,
     private val forward: (R1) -> R2,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -67,9 +67,6 @@ internal fun <R : Result> SeriesStat<R>.foldRegression(
     project: (VectorView, Double) -> Double,
 ): RegressionStat<R> = FoldRegressionStat(this, featureSize, project)
 
-// checkEvery and checkRate now come from Sampling.kt, which owns the other four modalities' throttle
-// and sample wrappers. This file used to carry byte-identical private copies.
-
 internal class FilterRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
     private val predicate: (VectorView, Double) -> Boolean,
@@ -116,10 +113,8 @@ internal class WithWeightRegressionStat<R : Result>(
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        // Shares `orInert` with the other four adapters rather than re-testing the condition here.
-        // This site used to spell out `if (weight == 0.0)`, which covered zero but not NaN, so a NaN
-        // caller weight was replaced by the constant and became a real observation - the leaf stats
-        // honoured the no-op and this wrapper undid it.
+        // `orInert` covers NaN as well as zero, so an inert caller weight stays a no-op rather than
+        // being replaced by the constant and becoming a real observation.
         delegate.update(x, y, timestampNanos, weight.orInert(this.weight))
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -50,8 +50,8 @@ internal fun <R : Result> DiscreteStat<R>.sample(rate: Double, random: Random): 
 /**
  * Reject a throttle period that would forward nothing or everything unpredictably.
  *
- * `internal` rather than file-private because the regression modality's wrappers live over in
- * `RegressionOps.kt` and had their own byte-identical copy of this and [checkRate].
+ * `internal` rather than file-private so the regression modality's wrappers in `RegressionOps.kt`
+ * can share it.
  */
 internal fun checkEvery(every: Int) = require(every >= 1) { "throttle every must be >= 1, got $every" }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
@@ -8,7 +8,6 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
 
-/** Adapter implementing [atX]: drives a [SeriesStat] from the x coordinate of a pair. */
 internal class AtXStat<R : Result>(private val delegate: SeriesStat<R>) :
     PairedStat<R>,
     Stat<R> by delegate {
@@ -19,7 +18,6 @@ internal class AtXStat<R : Result>(private val delegate: SeriesStat<R>) :
     override fun create(concurrency: Concurrency?): PairedStat<R> = AtXStat(delegate.create(concurrency))
 }
 
-/** Adapter implementing [atY]: drives a [SeriesStat] from the y coordinate of a pair. */
 internal class AtYStat<R : Result>(private val delegate: SeriesStat<R>) :
     PairedStat<R>,
     Stat<R> by delegate {
@@ -30,7 +28,6 @@ internal class AtYStat<R : Result>(private val delegate: SeriesStat<R>) :
     override fun create(concurrency: Concurrency?): PairedStat<R> = AtYStat(delegate.create(concurrency))
 }
 
-/** Adapter implementing [atIndex]: drives a [SeriesStat] from one slot of a vector. */
 internal class AtIndexStat<R : Result>(private val delegate: SeriesStat<R>, private val index: Int) :
     VectorStat<R>,
     Stat<R> by delegate {
@@ -41,7 +38,6 @@ internal class AtIndexStat<R : Result>(private val delegate: SeriesStat<R>, priv
     override fun create(concurrency: Concurrency?): VectorStat<R> = AtIndexStat(delegate.create(concurrency), index)
 }
 
-/** Adapter implementing [atIndices]: drives a [PairedStat] from two slots of a vector. */
 internal class AtIndicesStat<R : Result>(
     private val delegate: PairedStat<R>,
     private val indexX: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -16,8 +16,7 @@ import com.eignex.kumulant.core.isInertWeight
  * An inert caller weight - exactly `0.0`, or `NaN` - is passed through unchanged rather than
  * replaced. The override sets the *magnitude* of a real observation, and neither "ignore this
  * observation" nor "no multiplicity at all" is a magnitude, so the no-op guarantees in [Stat] survive
- * the wrapper. Without this, an inert update to a `CountStat` (which is `SumStat.withWeight(1.0)`)
- * still counted, and the substituted `1.0` meant nothing downstream could tell.
+ * the wrapper.
  */
 internal fun <R : Result> SeriesStat<R>.withWeight(weight: Double): SeriesStat<R> = WithWeightStat(this, weight)
 
@@ -34,14 +33,12 @@ internal fun <R : Result> DiscreteStat<R>.withWeight(weight: Double): DiscreteSt
 )
 
 /**
- * An inert weight stays inert; see [withWeight]. Shared by every modality adapter, including
- * `WithWeightRegressionStat` over in `RegressionOps.kt`, which is why this is `internal` rather than
- * file-private: that one open-coded the condition, handled only `0.0`, and drifted from the other four.
+ * An inert weight stays inert; see [withWeight]. `internal` rather than file-private so every
+ * modality adapter shares one definition, including `WithWeightRegressionStat` in `RegressionOps.kt`.
  */
 @Suppress("NOTHING_TO_INLINE") // as with isInertWeight; the non-JVM targets pay for the call
 internal inline fun Double.orInert(replacement: Double): Double = if (isInertWeight()) this else replacement
 
-/** Adapter implementing the series variant of [withWeight]. */
 internal class WithWeightStat<R : Result>(private val delegate: SeriesStat<R>, private val weight: Double) :
     SeriesStat<R>,
     Stat<R> by delegate {
@@ -52,7 +49,6 @@ internal class WithWeightStat<R : Result>(private val delegate: SeriesStat<R>, p
     override fun create(concurrency: Concurrency?): SeriesStat<R> = WithWeightStat(delegate.create(concurrency), weight)
 }
 
-/** Adapter implementing the paired variant of [withWeight]. */
 internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat<R>, private val weight: Double) :
     PairedStat<R>,
     Stat<R> by delegate {
@@ -64,7 +60,6 @@ internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat
         WithWeightPairedStat(delegate.create(concurrency), weight)
 }
 
-/** Adapter implementing the vector variant of [withWeight]. */
 internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat<R>, private val weight: Double) :
     VectorStat<R>,
     Stat<R> by delegate {
@@ -76,7 +71,6 @@ internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat
         WithWeightVectorStat(delegate.create(concurrency), weight)
 }
 
-/** Adapter implementing the discrete variant of [withWeight]. */
 internal class WithWeightDiscreteStat<R : Result>(private val delegate: DiscreteStat<R>, private val weight: Double) :
     DiscreteStat<R>,
     Stat<R> by delegate {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -64,7 +64,6 @@ private fun <R : Result, S : Stat<R>> windowedRead(template: S, ring: SliceRing<
     return acc.read(timestampNanos)
 }
 
-/** Implementation of [SeriesStat.windowed]; see that function for behavior. */
 internal class WindowedSeriesStat<R : Result>(
     private val windowDuration: Duration,
     private val slices: Int,
@@ -87,7 +86,6 @@ internal class WindowedSeriesStat<R : Result>(
     override fun reset() = ring.reset()
 }
 
-/** Implementation of [PairedStat.windowed]; see that function for behavior. */
 internal class WindowedPairedStat<R : Result>(
     private val windowDuration: Duration,
     private val slices: Int,
@@ -110,7 +108,6 @@ internal class WindowedPairedStat<R : Result>(
     override fun reset() = ring.reset()
 }
 
-/** Implementation of [DiscreteStat.windowed]; see that function for behavior. */
 internal class WindowedDiscreteStat<R : Result>(
     private val windowDuration: Duration,
     private val slices: Int,
@@ -137,7 +134,6 @@ internal class WindowedDiscreteStat<R : Result>(
     override fun reset() = ring.reset()
 }
 
-/** Implementation of [VectorStat.windowed]; see that function for behavior. */
 internal class WindowedVectorStat<R : Result>(
     private val windowDuration: Duration,
     private val slices: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -421,10 +421,8 @@ data class In(
 ) : BoolExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Boolean {
         // `in values` is List<Double>.contains, which boxes and uses Double.equals: total-order
-        // semantics where NaN == NaN and 0.0 != -0.0. Eq and Switch compare primitives with IEEE ==,
-        // so the three exact-equality selectors disagreed - and In(X, listOf(NaN)), meant to be
-        // unsatisfiable, admitted every NaN. This node exists to flatten Eq chains, so it has to
-        // agree with Eq.
+        // semantics where NaN == NaN and 0.0 != -0.0. This node exists to flatten Eq chains, so it
+        // has to compare primitives with IEEE == the way Eq and Switch do.
         val value = of.eval(x, y, v, primary)
         for (candidate in values) if (value == candidate) return true
         return false
@@ -1005,9 +1003,7 @@ fun ScalarExpr.inRange(min: Double, max: Double): BoolExpr = InRange(this, min, 
 /**
  * Reduce the whole feature vector to one scalar with [op].
  *
- * The vector-consuming half of the AST. `VectorExpr` and this family had no Kotlin constructor at all,
- * which left [VFoldOp] a public enum with no reachable consumer and made `transformVector` and
- * `transformX` uncallable outside the module despite both being public.
+ * The vector-consuming half of the AST, and the only Kotlin-side consumer of [VFoldOp].
  */
 fun vFold(op: VFoldOp): ScalarExpr = VFold(op)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -36,11 +36,9 @@ internal sealed class AbstractListStats<R : Result, S : Stat<out R>>(
     /**
      * The weakest guarantee any entry offers, matching [AbstractStatGroup.concurrency].
      *
-     * This reported [Concurrency.None] whenever no override was passed, which was simply untrue for a
-     * list of `Strict` entries - and this property is what a caller introspects to decide whether reads
-     * need external synchronisation. `AbstractStatGroup` was fixed; the sibling class holding the same
-     * kind of children kept the old answer, so `StatGroup(schema)` and `ListStats(schema)` over the
-     * very same schema disagreed about what they guaranteed.
+     * Callers introspect this to decide whether reads need external synchronisation, so
+     * `StatGroup(schema)` and `ListStats(schema)` over the very same schema have to agree about what
+     * they guarantee.
      *
      * Computed once rather than per access: the entries are fixed at construction.
      */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -139,8 +139,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * one cast at the boundary - sealed-hierarchy exhaustiveness keeps the cast safe.
  *
  * The wrapper-spec branches narrow the wrapped `inner` spec to the expected modality
- * at runtime; on mismatch they raise the same `IllegalArgumentException` the previous
- * per-spec `materialize` overrides did.
+ * at runtime, raising `IllegalArgumentException` on mismatch.
  */
 fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concurrency.None): SeriesStat<R> {
     val out: SeriesStat<*> = when (this) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -22,12 +22,10 @@ sealed class AbstractStatGroup<S : Stat<*>>(
      * The group's effective level: the override when one was given, otherwise the *weakest* level any
      * child uses.
      *
-     * Reporting [Concurrency.None] whenever no override was passed was simply untrue for a group of
-     * `Strict` children, and this property is what a caller introspects to decide whether reads need
-     * external synchronisation. The weakest child governs, because the group can promise nothing its
-     * least-protected member does not: one [Concurrency.None] child makes the whole group unsafe to
-     * share, and one [Concurrency.Relaxed] child means a read can drift even if every sibling is
-     * exact.
+     * Callers introspect this to decide whether reads need external synchronisation, so the weakest
+     * child has to govern: the group can promise nothing its least-protected member does not. One
+     * [Concurrency.None] child makes the whole group unsafe to share, and one [Concurrency.Relaxed]
+     * child means a read can drift even if every sibling is exact.
      *
      * The declaration order of [Concurrency] happens to run weakest to strongest, so `minOfOrNull`
      * picks that child directly. [Concurrency.HighWrite] sorting last is not a claim that it is the

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStat.kt
@@ -54,6 +54,11 @@ data class GaussianScoreResult(
  * This matches the River semantics where `score_one(x)` is computed against
  * the post-update state.
  *
+ * **Use cases:** univariate anomaly scoring on a stream whose bulk is roughly
+ * Gaussian; alerting on "how many sigmas out is this?". Reach for
+ * [QuantileFilterStat] when the distribution is skewed or heavy-tailed and no
+ * Gaussianity assumption is safe.
+ *
  * **Memory:** O(1); wraps a [VarianceStat].
  *
  * **Update:** O(1) per observation.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -190,14 +190,11 @@ class HalfSpaceTreesStat(
         }
     }
 
-    // The mass arrays and the weight cell are pure accumulations, so they take
-    // additiveMode; the window counter needs CAS for addAndGet, so it takes
-    // monotonicMode. Previously all four used welfordMode(), which returns AtomicMode
-    // only for Concurrency.Relaxed and SerialMode for None, Strict and HighWrite. Since
-    // this stat has no lock over the update path, that left Strict and HighWrite doing
-    // plain non-volatile reads and writes: increments were lost outright and the counter
-    // update was not guaranteed visible to other cores, so rotateWindow fired at the
-    // wrong cadence and scores were computed against a half-built reference profile.
+    // The mass arrays and the weight cell are pure accumulations, so they take additiveMode; the
+    // window counter needs CAS for addAndGet, so it takes monotonicMode. Neither may take
+    // welfordMode: that hands Strict and HighWrite a SerialMode, and with no lock over the update
+    // path plain non-volatile cells lose increments and hide the counter from other cores, so
+    // rotateWindow fires at the wrong cadence and scores read a half-built reference profile.
     private val massMode = concurrency.additiveMode()
     private val counterMode = concurrency.monotonicMode()
     private val swapLock: Mutex = if (concurrency == Concurrency.None) NoopMutex else PlatformMutex()
@@ -298,15 +295,9 @@ class HalfSpaceTreesStat(
     }
 }
 
-/**
- * Walk [x] down one tree to its leaf, returning the leaf's index within that tree.
- *
- * The result class and the stat carried this identically - same text, same variable names - over
- * identically-named fields. Scoring routes through the result's copy and updating through the stat's,
- * so the two had to agree exactly or a mass bucket would be credited on update and read back from a
- * different one, which shows up as a score that drifts for no visible reason. The `2n+1 / 2n+2`
- * heap layout and the `- numInternal` rebase to leaf-space are the parts that must not diverge.
- */
+// Walk x down one tree to its leaf, returning the leaf's index within that tree. Shared by the stat's
+// update path and the result's score path: both must route identically, or a mass bucket credited on
+// update is read back from a different one and the score drifts for no visible reason.
 private fun routeToLeaf(
     featureIndices: IntArray,
     thresholds: DoubleArray,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
@@ -34,10 +34,11 @@ data class QuantileFilterResult(
  *
  * The threshold adapts with the stream: as new observations arrive, the
  * quantile drifts, so the same input value may flip between anomalous and
- * normal as the distribution shifts. Use [QuantileFilterStat] when you want a
- * non-parametric alternative to [GaussianScorerStat] (no Gaussianity
- * assumption) or when the metric of interest is "is `x` in the tail of what
- * we've seen?".
+ * normal as the distribution shifts.
+ *
+ * **Use cases:** tail detection on a skewed or heavy-tailed stream, where the
+ * question is "is `x` in the tail of what we've seen?". The non-parametric
+ * alternative to [GaussianScorerStat], which assumes Gaussianity.
  *
  * **Memory:** O(1 / `relativeError`); backed by a single-probability DDSketch.
  *

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -80,6 +80,11 @@ data class IsotonicCalibratorResult(
  * the only added work is the per-read PAV pass and a linear interpolation in
  * [IsotonicCalibratorResult.calibrate].
  *
+ * **Use cases:** calibrating classifier scores whose miscalibration is
+ * monotone but not sigmoid-shaped. Reach for [PlattCalibratorStat] when
+ * observations are scarce, since two fitted parameters need far less data than
+ * a per-bin histogram.
+ *
  * **Memory:** O([numBins]); three parallel `Double` arrays via
  * [ReliabilityStat].
  *

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -121,8 +121,8 @@ class IsotonicCalibratorStat(
      */
     private fun pav(values: DoubleArray, weights: DoubleArray): DoubleArray {
         val n = values.size
-        // Pools stored as parallel arrays in `out` and `wSum`; `starts` tracks the
-        // first-index covered by each pool so we can fill back at the end.
+        // Pools held as parallel arrays; poolStart records the first index each pool
+        // covers so the means can be fanned back out at the end.
         val poolMean = DoubleArray(n)
         val poolWeight = DoubleArray(n)
         val poolStart = IntArray(n)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
@@ -124,10 +124,9 @@ class ReliabilityStat(val numBins: Int, override val concurrency: Concurrency = 
         val bin = (clamped * numBins).toInt().coerceIn(0, numBins - 1)
         // Denominator first, numerators after. Combined with read() loading sumW last,
         // this keeps sumW >= sumO and sumW >= sumP for any interleaving, so a concurrent
-        // reader cannot compute an outcome rate above 1.0. With the previous order
-        // (sumW written last, loaded last) a reader could pick up an sumO increment whose
-        // matching sumW increment had not landed, and the ratio escaped [0, 1] and
-        // propagated through IsotonicCalibratorStat into a calibrated probability > 1.
+        // reader cannot pick up a sumO increment whose matching sumW increment has not landed
+        // and compute an outcome rate above 1.0, which IsotonicCalibratorStat would carry
+        // through into a calibrated probability > 1.
         sumW[bin].add(weight)
         sumP[bin].add(clamped * weight)
         sumO[bin].add(y * weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
@@ -112,19 +112,15 @@ class AdwinStat(
             if (k + 1 >= rows.size) rows.add(ArrayDeque())
             // addLast, not addFirst: `merged` came from the two OLDEST buckets of row k, and row
             // k + 1 holds buckets older still, so within that row the merged one is the newest and
-            // belongs at the back. addFirst reversed every row and left higher-k rows holding newer
-            // data than lower-k ones, so bucketsOldestToNewest() returned a scrambled order, the cut
-            // candidates were not temporal prefixes, and dropOldest() discarded recent data while
-            // keeping stale data - the window stopped being a suffix of the stream.
+            // belongs at the back. Any other placement scrambles bucketsOldestToNewest(), so the cut
+            // candidates stop being temporal prefixes and the window stops being a stream suffix.
             rows[k + 1].addLast(merged)
             k++
         }
     }
 
-    // Scratch buffer for the oldest-to-newest bucket walk, reused across updates. This used
-    // to allocate a fresh ArrayList plus backing array on every call, and the call happens at
-    // least once per observation, which made it the single largest allocator on the update
-    // path (measured at 277 B/op before this change).
+    // Scratch buffer for the oldest-to-newest bucket walk, reused across updates. The walk runs at
+    // least once per observation, so a fresh list per call dominates update-path allocation.
     private val orderedScratch: MutableList<Bucket> = ArrayList()
 
     private fun bucketsOldestToNewest(): MutableList<Bucket> {
@@ -145,9 +141,8 @@ class AdwinStat(
         val n = totalN.toDouble()
         val mean = totalSum / n
         val variance = max(0.0, totalSumSquares / n - mean * mean)
-        // Loop-invariant: depends only on deltaPrime, which is fixed for this call. It was
-        // previously recomputed for every candidate cut, so a wide window paid one `ln` per
-        // bucket for no reason.
+        // Loop-invariant: depends only on deltaPrime, so hoisting it keeps a wide window from
+        // paying one `ln` per candidate cut.
         val logTerm = ln(2.0 / deltaPrime)
         var n0 = 0L
         var sum0 = 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingMeanStat.kt
@@ -69,10 +69,10 @@ class DecayingMeanStat(
 
             sumW < 0.0 -> Double.NaN
 
-            // A NaN denominator is neither greater nor less than zero, so it used to fall into the
-            // underflow branch below and be reported as a mean of exactly 0.0 - indistinguishable
-            // from a genuine zero. The underflow branch is for a denominator that decayed to 0.0,
-            // which is a different state and the only one with a recoverable answer.
+            // A NaN denominator is neither greater nor less than zero, so without this branch it
+            // falls through to the underflow branch and reports a mean of exactly 0.0,
+            // indistinguishable from a genuine zero. The underflow branch is for a denominator that
+            // decayed to 0.0, which is a different state and the only one with a recoverable answer.
             sumW.isNaN() -> Double.NaN
 
             else -> undecayedRatio()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingVarianceStat.kt
@@ -51,8 +51,8 @@ data class DecayingVarianceResult(
  *
  * **Concurrency:** Body locked under any concurrent [Concurrency] level
  * (no-op under [Concurrency.None]). The multi-cell decay-then-Welford
- * transition cannot survive lock-free CAS; see *Why locked under Relaxed*
- * below. Exact under every level up to floating-point reorder ULPs.
+ * transition cannot survive lock-free CAS. Exact under every level up to
+ * floating-point reorder ULPs.
  */
 class DecayingVarianceStat(
     /** Time-decay schedule applied to past contributions. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
@@ -117,9 +117,9 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
             troughTs.store(values.troughTimestampNanos)
         }
         if (values.maxExcursion > maxExcursion.load()) maxExcursion.store(values.maxExcursion)
-        // currentRecovery is derived from lastValue, which this branch never touched, so a merged
-        // result mixed the incoming peak with the local last value. Adopt the incoming stat's last
-        // value when its peak won, so the pair stays internally consistent.
+        // currentRecovery is derived from lastValue, which this branch never touches, so leaving it
+        // alone would mix the incoming peak with the local last value. Adopt the incoming stat's last
+        // value when its peak wins, so the pair stays internally consistent.
         if (values.peak >= peak.load()) lastValue.store(values.peak - values.currentRecovery)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/RunLengthStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/RunLengthStat.kt
@@ -22,8 +22,7 @@ data class RunLengthResult(
      *
      * Only [RunLengthStat.merge] needs it, and it is what makes that merge correct: concatenating
      * two streams can create a run spanning the join, whose length is the left stream's *trailing*
-     * run plus the right stream's *leading* one. Merge used to add the two trailing runs, which is a
-     * length no run in the data ever had.
+     * run plus the right stream's *leading* one.
      */
     val leading: Long = current,
     /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStat.kt
@@ -79,9 +79,9 @@ class RecursiveVarianceStat(
         while (true) {
             val current = variance.load()
             // Adopt the snapshot verbatim while empty, matching HoltStat.merge and
-            // SeasonalSmoothingStat.merge. Averaging against a fresh stat's 0.0 halved the first
-            // contribution, so a roll-up that merged N worker snapshots into a new coordinator
-            // systematically understated the first one.
+            // SeasonalSmoothingStat.merge. Averaging against a fresh stat's 0.0 would halve the
+            // first contribution, so a roll-up merging N worker snapshots into a new coordinator
+            // would systematically understate the first one.
             val next = if (initialized.load() == 0L) {
                 values.variance
             } else {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -206,7 +206,7 @@ class SeasonalSmoothingStat(
                 seasons.store(i, 0.5 * (seasons.load(i) + values.seasons[i]))
             }
             // The factors just came from the incoming trace, so the phase has to come with them;
-            // keeping the local slot silently paired averaged factors with a mismatched phase.
+            // keeping the local slot would silently pair averaged factors with a mismatched phase.
             slot.store(values.currentSlot.toLong())
         }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -30,7 +30,9 @@ import kotlin.math.pow
  * [relativeError].
  *
  * **Update:** O(1) per observation; one `log`/bin-assignment + striped atomic add.
- * `NaN` has no bin of its own and falls into the zero bucket.
+ * A `NaN` weight is inert, as everywhere in the library. A `NaN` *value* is a real
+ * observation with no bin of its own, so it falls into the zero bucket; filter it
+ * upstream with `!X.isNaN()` when that is not wanted.
  *
  * **Concurrency:** Striped atomic adds on independent bins. Lock-free and
  * exact under every [Concurrency] level; increments commute, bin assignment

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/DDSketchStat.kt
@@ -30,7 +30,7 @@ import kotlin.math.pow
  * [relativeError].
  *
  * **Update:** O(1) per observation; one `log`/bin-assignment + striped atomic add.
- * `NaN` is dropped, since it has no rank to bin.
+ * `NaN` has no bin of its own and falls into the zero bucket.
  *
  * **Concurrency:** Striped atomic adds on independent bins. Lock-free and
  * exact under every [Concurrency] level; increments commute, bin assignment
@@ -74,13 +74,12 @@ class DDSketchStat(
     private val gamma: Double = (1.0 + relativeError) / (1.0 - relativeError)
     private val multiplier: Double = 1.0 / ln(gamma)
 
-    // Bin indices are clamped to the band spanned by the indexable range. Without this the
-    // index is unbounded: the bin array spans min..max observed index and allocates a cell
-    // per index in between, so a single denormal next to a single huge value forces an
-    // enormous array. Measured before this bound, from exactly two observations: 2.4 MiB at
-    // the default relativeError, 28 MiB at 0.001, and 220 MiB at 1e-4. Far enough out the
-    // index also overflows Int and the resize is skipped, silently dropping the bins that
-    // had already accumulated.
+    // Bin indices are clamped to the band spanned by the indexable range. Unclamped the index
+    // is unbounded: the bin array spans min..max observed index and allocates a cell per index
+    // in between, so a single denormal next to a single huge value forces an enormous array -
+    // 2.4 MiB at the default relativeError from two observations, 28 MiB at 0.001, 220 MiB at
+    // 1e-4. Far enough out the index overflows Int and the resize is skipped, silently dropping
+    // the bins already accumulated.
     private val minIndex: Int = ceil(ln(minIndexableValue) * multiplier).toInt()
     private val maxIndex: Int = ceil(ln(maxIndexableValue) * multiplier).toInt()
 
@@ -94,10 +93,6 @@ class DDSketchStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isNotPositiveWeight()) return
-        // NaN has no rank, so it cannot go in a bin. Previously it fell through the sign
-        // comparisons into the zero bucket and was silently counted as an observation of
-        // zero, which shifts every quantile. LinearHistogramStat already drops it.
-
         if (value > 0.0) {
             positiveBins.add(indexOf(value), weight)
         } else if (value < 0.0) {
@@ -149,22 +144,18 @@ class DDSketchStat(
         val negSnap = negativeBins.snapshot()
         val zeroSnap = zeroCount.load()
 
-        // Derive the total from the snapshot instead of loading the totalWeights cell.
-        // update() bumps that cell before it lands the bin, so a concurrent read could
-        // see a total larger than the bins account for, walk off the end of the bin list
-        // and return NaN for a high quantile. reset() has the mirror problem: it cleared
-        // the cell before the bins, so a reader could see total == 0 with populated bins
-        // and report all-zero quantiles.
+        // Derive the total from the snapshot rather than from a separate weight cell: any cell
+        // updated out of step with the bins lets a concurrent reader see a total the bins do not
+        // account for, and walk off the end of the bin list or report all-zero quantiles.
         var total = zeroSnap
         for (w in negSnap.values) total += w
         for (w in posSnap.values) total += w
 
         if (total <= 0.0) {
-            // NaN per quantile rather than 0.0. A zero-filled array is indistinguishable from a
-            // sketch that genuinely observed zeros, so an untouched sketch used to render as a
-            // p99 of 0.0 - which reads as excellent latency rather than as no data. AucStat
-            // already returned NaN in the same situation. Callers who want to branch rather
-            // than propagate NaN can check `isEmpty` on the result.
+            // NaN per quantile rather than 0.0: a zero-filled array is indistinguishable from a
+            // sketch that genuinely observed zeros, so an untouched sketch would render a p99 of
+            // 0.0, which reads as excellent latency rather than as no data. Callers who want to
+            // branch rather than propagate NaN can check `isEmpty` on the result.
             computedQuantiles.fill(Double.NaN)
             return SketchResult(
                 probabilities = probabilities,
@@ -186,9 +177,9 @@ class DDSketchStat(
                 currentRank += weight
                 if (currentRank >= targetRank) return -valueFromIndex(index)
             }
-            // Only claim the zero bucket when something actually landed in it. Adding an
-            // empty zeroSnap and testing `0.0 >= 0.0` made p0 report 0.0 on all-positive
-            // data, a value not in the stream and outside the relative-error contract.
+            // Only claim the zero bucket when something actually landed in it; an empty zeroSnap
+            // would satisfy `0.0 >= 0.0` and make p0 report 0.0 on all-positive data, a value not
+            // in the stream and outside the relative-error contract.
             if (zeroSnap > 0.0) {
                 currentRank += zeroSnap
                 if (currentRank >= targetRank) return 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
@@ -120,12 +120,10 @@ class HdrHistogramStat(
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isNotPositiveWeight()) return
         // `!(value < 0.0)`, not `value >= 0.0`: both reject a negative value, but every comparison
-        // against NaN is false, so the `>=` form rejected a NaN as though it were negative and threw.
-        // A NaN observation must not become an exception in the caller - it scales to bucket zero and
-        // corrupts this histogram like it corrupts any other accumulator. See Stat.
+        // against NaN is false, so the `>=` form would reject NaN as though it were negative and
+        // throw. A NaN observation must not become an exception in the caller. See Stat.
         require(!(value < 0.0)) { "HdrHistogramStat only supports non-negative values; got $value" }
 
-        // Scale the incoming floating-point value to an internal integer
         val internalValue = (value * multiplier).toLong()
 
         while (true) {
@@ -187,10 +185,9 @@ class HdrHistogramStat(
     override fun read(timestampNanos: Long): SparseHistogramResult {
         val state = stateRef.load()
 
-        // Snapshot every cell once, then size and fill from that snapshot. Loading the
-        // cells twice let a bucket become populated between the counting pass and the
-        // filling pass, so the fill overran the arrays sized by the first pass and read()
-        // threw IndexOutOfBoundsException from whatever thread was scraping.
+        // Snapshot every cell once, then size and fill from that snapshot. Loading the cells
+        // twice would let a bucket become populated between the counting and filling passes, so
+        // the fill overruns the arrays sized by the first pass.
         val snapshot = DoubleArray(state.counts.size) { state.counts[it].load() }
 
         var populatedCount = 0
@@ -206,7 +203,6 @@ class HdrHistogramStat(
         for (i in snapshot.indices) {
             val w = snapshot[i]
             if (w > 0.0) {
-                // Divide the internal integer boundaries back down to the original Double scale
                 lowers[cursor] = getLowerBound(i).toDouble() / multiplier
                 uppers[cursor] = getUpperBound(i).toDouble() / multiplier
                 weights[cursor] = w

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
@@ -56,13 +56,8 @@ class LinearHistogramStat(
     private val overflow = mode.newDouble(0.0)
     private val bins = ArrayBins(mode)
 
-    /**
-     * The bin a value falls in, clamped to the array.
-     *
-     * Written out twice, in `update` and in `merge`. The two have to agree exactly or a merged bucket
-     * lands somewhere a directly-observed value of the same magnitude would not, which shows up as a
-     * histogram that disagrees with itself depending on how the observations arrived.
-     */
+    // Shared by update and merge: the two paths have to agree exactly or a merged bucket lands
+    // somewhere a directly-observed value of the same magnitude would not.
     private fun binOf(value: Double): Int = ((value - lowerBound) / binWidth).toInt().coerceIn(0, binCount - 1)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/TDigestStat.kt
@@ -96,8 +96,8 @@ fun TDigestResult.toSparseHistogram(): SparseHistogramResult {
  * Updates buffer values until the internal `bufferCap` is reached, then fold them into
  * the sorted centroid list under the `k1`-difference ≤ 1 merge rule.
  *
- * **Use cases:** approximate percentile estimation with adaptive resolution
- *; tighter near the tails (0.001 / 0.999 percentiles), looser in the middle.
+ * **Use cases:** approximate percentile estimation with adaptive resolution;
+ * tighter near the tails (0.001 / 0.999 percentiles), looser in the middle.
  * Reach for this over [DDSketchStat] when you want extreme-quantile accuracy
  * without committing to a relative-error parameter, and over
  * [HdrHistogramStat] when the value range isn't known in advance.
@@ -223,19 +223,10 @@ class TDigestStat(
     private var sortIdx: IntArray = IntArray(0)
     private var sortTmp: IntArray = IntArray(0)
 
-    /**
-     * Indices `0 until bufLen` ordered by `bufVal`, without boxing.
-     *
-     * This replaced `(0 until bufLen).sortedBy { bufVal[it] }`, which materialised a
-     * `List<Integer>` of `bufLen` boxed indices plus an ArrayList and ran a comparator sort.
-     * At the default compression the buffer holds 500 entries, so every flush allocated
-     * roughly 8 KiB of boxes; amortised over the updates that filled it, TDigest measured
-     * 82 B/op on the update path.
-     *
-     * Bottom-up merge sort keyed on `bufVal`. Stable, `O(n log n)`, and allocation-free after
-     * the first call, which matters because an insertion sort would be `O(n^2)` over a
-     * 500-entry buffer and cost more than the boxing it replaces.
-     */
+    // Bottom-up merge sort of the buffer indices keyed on `bufVal`: stable, `O(n log n)`, and
+    // allocation-free after the first call. A comparator sort over an index list would box every
+    // index (~8 KiB per flush at the default compression), and an insertion sort would be `O(n^2)`
+    // over a 500-entry buffer.
     private fun sortedBufferIndices(bufVal: DoubleArray, bufLen: Int): IntArray {
         if (sortIdx.size < bufLen) {
             sortIdx = IntArray(bufLen)
@@ -356,12 +347,9 @@ class TDigestStat(
                     buffer.store(idx, value)
                     bufferWeights.store(idx, weight)
                     // Publish the value before counting its weight, not after. `drainLocked` can
-                    // strand a claim it cannot prove committed, discarding the value; if the weight
-                    // were already counted, that weight would stay in `totalWeightCell` with nothing
-                    // in the digest behind it. Reached before any successful drain, that left
-                    // `means` empty while `total` was positive, and `read` answers that state with
-                    // NaN for every quantile while still reporting the positive weight - a snapshot
-                    // that claims to have observed data it cannot answer from.
+                    // strand a claim it cannot prove committed, discarding the value; a weight
+                    // counted first would stay in `totalWeightCell` with nothing in the digest
+                    // behind it, so `read` reports positive weight with NaN for every quantile.
                     //
                     // The reverse skew this admits is benign and self-correcting: a drained value
                     // whose weight has not landed yet makes `total` low, so a rank clamps toward
@@ -432,10 +420,10 @@ class TDigestStat(
             val total = totalWeightCell.load()
             val computed = DoubleArray(probabilities.size)
             if (means.isEmpty() || total <= 0.0) {
-                // NaN per quantile rather than 0.0, matching DDSketchStat and AucStat. A
-                // zero-filled array cannot be told apart from a digest that genuinely observed
-                // zeros, so an untouched digest reported a p99 of 0.0 and read as healthy.
-                // `isEmpty` on the result is the check for callers who would rather branch.
+                // NaN per quantile rather than 0.0, matching DDSketchStat. A zero-filled array
+                // cannot be told apart from a digest that genuinely observed zeros, so an untouched
+                // digest would report a p99 of 0.0 and read as healthy. `isEmpty` on the result is
+                // the check for callers who would rather branch.
                 computed.fill(Double.NaN)
                 return@guarded TDigestResult(
                     probabilities,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
@@ -55,8 +55,6 @@ class ThresholdBucketStat(
     private val counts = mode.newDoubleArray(thresholds.size + 1)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        // bucketFor compares against each threshold, and every comparison against NaN is false, so a
-        // NaN fell through to the overflow bucket and was counted as the largest possible value.
         if (weight.isInertWeight()) return
         counts.add(bucketFor(value), weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
@@ -57,7 +57,7 @@ class CounterRateStat(
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         // Return before touching lastCounter: a zero weight contributes no delta, but advancing the
-        // high-water mark anyway destroyed the increment for good, so a later sample could never
+        // high-water mark anyway would destroy the increment for good, so no later sample could
         // recover it. NaN is dropped for the same reason it is everywhere; see Stat. Outside the
         // lock, like every other stat's inert guard - a no-op has no state to protect.
         if (weight.isInertWeight()) return
@@ -88,9 +88,9 @@ class CounterRateStat(
             treatDecreaseAsReset -> {
                 val scaledDelta = (value * weight).coerceAtLeast(0.0)
                 if (scaledDelta > 0.0) {
-                    // Re-anchoring the window without clearing the total divided every pre-reset
-                    // increment by the short post-reset duration, so a counter that advanced 105
-                    // units over 11s reported 210/s. The window and the total describe the same
+                    // Re-anchoring the window without clearing the total would divide every
+                    // pre-reset increment by the short post-reset duration: a counter advancing 105
+                    // units over 11s would report 210/s. The window and the total describe the same
                     // span, so they have to be reset together.
                     totalDelta.store(scaledDelta)
                     startTimestampNanos.store(timestampNanos)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/DecayingRateStat.kt
@@ -43,15 +43,8 @@ data class DecayingRateResult(
 class DecayingRateStat(val halfLife: Duration, override val concurrency: Concurrency = Concurrency.None) :
     SeriesStat<DecayingRateResult> by decayingRateDelegate(halfLife, concurrency)
 
-/**
- * Per-second rate scale for a half-life, via [DecayWeighting.HalfLife].
- *
- * This recomputed `ln(2) / halfLife` itself rather than reading the one place that already derives it,
- * and the copy had no validation: `inWholeNanoseconds` truncates, so a sub-nanosecond half-life gave an
- * infinite scale instead of the documented error. It only ever looked correct because the
- * `DecayingSumStat` constructed on the next line happens to throw first - an ordering the compiler does
- * not enforce and nothing recorded.
- */
+// Per-second rate scale for a half-life. Derived through DecayWeighting.HalfLife so a sub-nanosecond
+// half-life raises the documented error rather than yielding an infinite scale.
 private fun rateScale(halfLife: Duration): Double = DecayWeighting.HalfLife(halfLife).alpha * NANOS_PER_SECOND
 
 private fun decayingRateDelegate(halfLife: Duration, concurrency: Concurrency): SeriesStat<DecayingRateResult> {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
@@ -20,8 +20,8 @@ data class RateResult(val startTimestampNanos: Long, val totalValue: Double, val
     override val rate: Double
         get() {
             // Subtract in Double, not Long: a large-magnitude negative start against a positive read
-            // timestamp overflows the Long subtraction, and the guard below then read the wrapped
-            // value as a non-positive duration and silently returned 0.0.
+            // timestamp overflows the Long subtraction, and the guard below would read the wrapped
+            // value as a non-positive duration.
             val durationSeconds = (timestampNanos.toDouble() - startTimestampNanos.toDouble()) / NANOS_PER_SECOND
             if (!(durationSeconds > 0.0)) return 0.0
             return totalValue / durationSeconds

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -145,8 +145,7 @@ class GaussianNaiveBayesStat(
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
-            // See asClassLabel on why an exact integer is required. The tree classifiers used to
-            // truncate instead, so this stat and those disagreed about y = 1.5.
+            // See asClassLabel on why an exact integer is required.
             val c = y.asClassLabel(numClasses)
             if (c < 0) return@guarded
             val priorW = classWeightCell.load(c)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -93,8 +93,13 @@ data class SoftmaxRegressionResult(
  * One [OptimizerSpec] is materialised per class for the weight matrix; bias
  * is a single optimizer over `numClasses` slots.
  *
+ * **Use cases:** K-way online classification with calibrated probabilities; the
+ * discriminative counterpart to [GaussianNaiveBayesStat].
+ *
  * **Memory:** O([numClasses] * [featureSize]) for weights + per-optimizer aux state.
+ *
  * **Update:** O([numClasses] * nnz(x)) per observation.
+ *
  * **Concurrency:** Welford-locked; the optimizer aux state honours the same
  * [Concurrency] passed in.
  */
@@ -142,8 +147,7 @@ class SoftmaxRegressionStat(
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
-            // See asClassLabel on why an exact integer is required. The tree classifiers used to
-            // truncate instead, so this stat and those disagreed about y = 1.5.
+            // See asClassLabel on why an exact integer is required.
             val c = y.asClassLabel(numClasses)
             if (c < 0) return@guarded
             stepCell.addAndGet(1L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -149,9 +149,8 @@ class DiagonalRegressionStat(
             val otherPrecision = values.precision.toDoubleArray()
             // Subtract one copy of the prior, as BayesianRegressionStat.merge does with
             // H_new = H_self + H_other - H_prior. Every replica seeds its precision at
-            // priorPrecision, so pooling additively counted the prior once per replica: merging an
-            // *untrained* snapshot (precision == priorPrecision, weights == 0) pulled the trained
-            // weights toward zero and inflated the reported precision. The prior mean is zero, so it
+            // priorPrecision, so pooling additively would count the prior once per replica and let an
+            // *untrained* snapshot pull the trained weights toward zero. The prior mean is zero, so it
             // contributes nothing to the information vector and only the denominator changes.
             for (i in 0 until featureSize) {
                 val p1 = precision[i]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -117,8 +117,8 @@ data class CovarianceRegressionResult(
     override val sse: Double = 0.0,
 ) : LinearRegressionResult {
     init {
-        // Check cols too, not just rows: the message promises NxN and every consumer indexes both
-        // dimensions, so a non-square matrix used to slip through and fail later at the read site.
+        // Check cols too, not just rows: every consumer indexes both dimensions, so a non-square
+        // matrix would fail far from here, at the read site.
         require(
             covariance.rows == weights.size && covariance.cols == weights.size &&
                 covarianceL.rows == weights.size && covarianceL.cols == weights.size,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Penalty.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Penalty.kt
@@ -34,25 +34,11 @@ sealed interface Penalty {
     ) : Penalty
 }
 
-/**
- * Soft-thresholding (the proximal operator of the L1 norm): shrink [w] toward zero by [threshold],
- * stopping at zero rather than crossing it.
- *
- * This is the one operation every L1 path in the package needs, and all three hosts had their own copy:
- * [StochasticRegressionStat] as a named private function, [DiagonalRegressionStat] open-coded in its
- * proximal step, [UnivariateRegressionStat] open-coded in its `read`-time projection.
- *
- * The non-positive guard is not decoration, and it is why the three copies were not equivalent. A
- * [Penalty.L1] carries no positivity requirement on its `lambda`, so a negative one is constructible,
- * and every host derives its threshold by multiplying lambda by something positive. Without the guard
- * the `when` below reads inside out: at `w = 0` and `threshold = -t`, the first branch matches and
- * returns `+t`, so a negative lambda pushed weights *away* from zero instead of toward it. Shrinking by
- * a negative amount is not shrinking, so the guard returns [w] untouched and the penalty simply does
- * nothing, which is what the stochastic host already did.
- *
- * @param w the current coefficient.
- * @param threshold shrinkage magnitude; a non-positive value leaves [w] alone.
- */
+// Soft-thresholding (the proximal operator of the L1 norm): shrink `w` toward zero by `threshold`,
+// stopping at zero rather than crossing it. [Penalty.L1] does not require a positive `lambda`, so a
+// negative threshold is reachable; without the non-positive guard the `when` reads inside out and
+// pushes weights *away* from zero. Shrinking by a negative amount is not shrinking, so the penalty
+// does nothing instead.
 internal fun softThreshold(w: Double, threshold: Double): Double = when {
     threshold <= 0.0 -> w
     w > threshold -> w - threshold

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -102,11 +102,9 @@ class ClassCountsStat(
     private val cells: StreamDoubleArray = mode.newDoubleArray(numClasses)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        // The guard checked the NaN *value* but not the NaN *weight*, and `weight == 0.0` is false for
-        // NaN, so a NaN weight reached `cells.add` and pinned a class count to NaN permanently. A
-        // negative weight stays legal: a count cell subtracts exactly, so retracting an observation
-        // that was folded in earlier is a downdate rather than corruption. The label now goes through
-        // asClassLabel like every other classifier's, which is what rejects 1.5 as a class index.
+        // isInertWeight, not `weight == 0.0`, which is false for NaN: a NaN weight would reach
+        // `cells.add` and pin a class count to NaN permanently. A negative weight stays legal because
+        // a count cell subtracts exactly, so retracting an earlier observation is a downdate.
         if (weight.isInertWeight()) return
         val c = value.asClassLabel(numClasses)
         if (c < 0) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCounts.kt
@@ -83,13 +83,26 @@ data class ClassCountsResult(
 }
 
 /**
- * Series stat over discrete class-index inputs. `update(value, weight)` interprets
- * `value.toInt()` as the class index; out-of-range values are dropped. Each class
- * cell is an independent striped atomic adder so updates commute under any
- * [Concurrency] level.
+ * Series stat over discrete class-index inputs; the snapshot is a weighted
+ * per-class count vector. `update(value, weight)` resolves `value` to a class
+ * index via [asClassLabel], so only a `Double` that is exactly an integer in
+ * `[0, numClasses)` counts; anything else is dropped.
+ *
+ * **Use cases:** the leaf aggregate behind [ClassificationTree], and standalone
+ * wherever a weighted class histogram, majority vote, or empirical class
+ * distribution is wanted over a discrete stream.
+ *
+ * **Memory:** O([numClasses]); one adder cell per class.
+ *
+ * **Update:** O(1) per observation; one class-label resolution and a single
+ * cell add.
+ *
+ * **Concurrency:** Independent striped cells with deterministic bucket
+ * assignment. Exact under every level; increments commute and racing writers on
+ * the same class share the cell.
  */
 class ClassCountsStat(
-    /** Number of classes; `value.toInt()` must round into `[0, numClasses)`. */
+    /** Number of classes; `value` must be exactly an integer in `[0, numClasses)`. */
     val numClasses: Int,
     override val concurrency: Concurrency = Concurrency.None,
 ) : SeriesStat<ClassCountsResult> {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig.kt
@@ -6,8 +6,7 @@ import kotlinx.serialization.Serializable
  * Classification analogue of [RegressionTreeConfig]. The same tunables, but the split [metric] defaults
  * to [GiniReduction] and the criterion is a [ClassificationSplitMetric].
  *
- * Every field except [metric] is described on [HoeffdingTreeConfig]. It used to be described here too,
- * in a copy that had already lost the explanations of what `tau` and `mtry` do.
+ * Every field except [metric] is described on [HoeffdingTreeConfig].
  */
 @Serializable
 data class ClassificationTreeConfig(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -18,7 +18,7 @@ import kotlin.random.Random
  * Hoeffding bound on Gini reduction or information gain.
  *
  * Input is fed through [RegressionStat]: `x` is the feature vector, `y` is the
- * class index in `[0, numClasses)` (truncated via `toInt()`).
+ * class index in `[0, numClasses)`, resolved by [asClassLabel].
  */
 class DecisionTreeClassifierStat(
     override val featureSize: Int,
@@ -52,10 +52,8 @@ class DecisionTreeClassifierStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // Was `weight <= 0.0`, which is false for NaN, and `y.toInt()` with no validation at all - the
-        // range check happened downstream in ClassificationTree.update but the truncation did not, so
-        // y = 1.5 arrived as a legitimate class 1. A NaN weight got all the way to the leaf counts.
-        // isInertWeight, like the regression counterpart: a class count downdates exactly.
+        // isInertWeight rather than `weight <= 0.0`, which is false for NaN: a class count downdates
+        // exactly, so a negative weight is a real retraction while a NaN would pin a count for good.
         if (weight.isInertWeight()) return
         val c = y.asClassLabel(numClasses)
         if (c < 0) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -19,6 +19,25 @@ import kotlin.random.Random
  *
  * Input is fed through [RegressionStat]: `x` is the feature vector, `y` is the
  * class index in `[0, numClasses)`, resolved by [asClassLabel].
+ *
+ * **Use cases:** online classification where the decision boundary is
+ * axis-aligned and piecewise constant, and the model must grow with the stream
+ * rather than be refit. Reach for [RandomForestClassifierStat] for ensembled
+ * diversity, or [DecisionTreeRegressionStat] when the target is continuous.
+ *
+ * **Memory:** O(nodes · [splitCandidates]); a [ClassCountsStat] per node plus
+ * per-audit-leaf candidate accumulators. Bounded by
+ * [ClassificationTreeConfig.maxNodes].
+ *
+ * **Update:** O(depth) per observation; a tree walk to the destination leaf,
+ * then a leaf-arm update. Splits fire at most once every
+ * [ClassificationTreeConfig.splitPeriod] observations per audit leaf.
+ *
+ * **Concurrency:** Inherits [DecisionTreeRegressionStat]'s concurrency model,
+ * with [ClassCountsStat] leaf arms in place of variance accumulators. The update path
+ * touches exactly one leaf, so threads landing in different leaves never
+ * contend; split conversion takes a per-tree lock fired only at split
+ * decisions. See [ClassificationTree] for the full design.
  */
 class DecisionTreeClassifierStat(
     override val featureSize: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -79,8 +79,8 @@ class DecisionTreeRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // A zero-weight call still advanced the leaves' observationsSinceLastCheck and shifted the
-        // split-audit cadence; see Stat for the contract.
+        // Return before touching the tree: a zero-weight call would still advance the leaves'
+        // observationsSinceLastCheck and shift the split-audit cadence.
         if (weight.isInertWeight()) return
         tree.update(x, y, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
@@ -3,9 +3,7 @@ package com.eignex.kumulant.stat.regression.tree
 /**
  * Growth tunables common to both VFDT trees.
  *
- * [RegressionTreeConfig] and [ClassificationTreeConfig] were field-for-field identical except for the
- * split criterion, and their KDoc had already drifted apart - the classification copy lost the
- * explanations of what [tau] and [mtry] actually do. They stay separate types because each is
+ * [RegressionTreeConfig] and [ClassificationTreeConfig] stay separate types because each is
  * `@Serializable` and part of the wire format, and because [RegressionTreeConfig.metric] and
  * [ClassificationTreeConfig.metric] have different types; this interface is where the shared half is
  * described once, and it is what lets the growth logic read tunables without knowing which tree it is

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -62,14 +62,9 @@ class RandomForestClassifierStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // The weight guard used to be `weight <= 0.0`, which is false for NaN, so a NaN weight reached
-        // the leaf counts and pinned one to NaN for good - no later observation could clear it. The
-        // label guard used to truncate, so y = 1.5 trained as class 1 here while the GLM classifiers
-        // refused it. Both now go through the same helpers as every other stat.
-        //
         // isInertWeight rather than isNotPositiveWeight: a class count subtracts exactly, so a negative
         // weight is a real downdate here, exactly as it is for the regression forest. Returning before
-        // the bagging draw also matters - an inert call used to consume one Poisson draw per tree and
+        // the bagging draw also matters - an inert call that consumed one Poisson draw per tree would
         // desynchronise every later one.
         if (weight.isInertWeight()) return
         val c = y.asClassLabel(numClasses)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -21,6 +21,22 @@ import kotlin.random.Random
  * [RandomForestRegressionStat]. Same diversity tricks (Oza & Russell bagging,
  * per-leaf mtry), but per-tree leaves are [ClassCountsResult] and ensemble
  * predictions average per-class probabilities across trees.
+ *
+ * **Use cases:** online classification wanting ensembled diversity and a
+ * per-class probability estimate averaged across trees. Reach for
+ * [DecisionTreeClassifierStat] alone when a single tree suffices.
+ *
+ * **Memory:** O([nbrTrees] · single-tree memory); see
+ * [DecisionTreeClassifierStat]. Heavier but parallelisable.
+ *
+ * **Update:** O([nbrTrees] · depth) per observation; each tree's update is
+ * independent. Under [bagging] = true, each tree applies a fresh
+ * Poisson(1)-reweighted version of the update.
+ *
+ * **Concurrency:** Inherits [DecisionTreeClassifierStat]'s per-tree
+ * concurrency model. Trees are updated sequentially within a single
+ * `update()` call (no inner parallelism); concurrent callers each contend for
+ * each tree's split lock independently.
  */
 class RandomForestClassifierStat(
     override val featureSize: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -79,9 +79,8 @@ class RandomForestRegressionStat(
 
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // Return before drawing from baggingRng: a zero-weight call used to consume one draw per
-        // tree, desynchronising every later bagging draw and changing the forest's predictions. The
-        // classifier already guards this.
+        // Return before drawing from baggingRng: an inert call that consumed one draw per tree would
+        // desynchronise every later bagging draw and change the forest's predictions.
         if (weight.isInertWeight()) return
         if (!bagging) {
             for (t in trees) t.update(x, y, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -10,11 +10,10 @@ import kotlin.random.Random
 /**
  * Breiman's default random-subspace size: `ceil(sqrt(p))` candidates drawn per audit leaf.
  *
- * Both forests default `mtry` to this when the caller leaves it null, and both used to carry their own
- * private copy of the expression. The clamp matters at the small end - `ceil(sqrt(1))` is already 1, but
- * `coerceAtLeast(1)` keeps an mtry of zero from disabling growth silently if the arithmetic is ever
- * changed - and `p <= 0` returns 0 rather than 1 because an empty candidate pool means no growth at all
- * rather than growth on one candidate that does not exist.
+ * Both forests default `mtry` to this when the caller leaves it null. The clamp matters at the small end
+ * - `ceil(sqrt(1))` is already 1, but `coerceAtLeast(1)` keeps an mtry of zero from disabling growth
+ * silently if the arithmetic is ever changed - and `p <= 0` returns 0 rather than 1 because an empty
+ * candidate pool means no growth at all rather than growth on one candidate that does not exist.
  *
  * @param p size of the tree's full candidate-split pool.
  */
@@ -31,8 +30,6 @@ internal fun defaultMtry(p: Int): Int = if (p <= 0) 0 else ceil(sqrt(p.toDouble(
  * [delta] is decayed by [decay] raised to [depth] before use: a deeper leaf sees less of the stream, so
  * holding confidence fixed would let it split on proportionally thinner evidence. An empty leaf returns
  * an infinite bound, so no margin can ever clear it and the leaf cannot split on no data.
- *
- * Both trees carried a byte-identical private copy of this.
  *
  * @param delta confidence threshold before depth decay.
  * @param n total observation weight at the leaf.
@@ -54,7 +51,7 @@ internal fun hoeffdingBound(delta: Double, n: Double, depth: Int, decay: Double)
  * offered different candidates.
  *
  * Generic in the split type because the regression tree is generic in its row type while the
- * classification tree is fixed to `VectorView`; both trees had their own copy of this.
+ * classification tree is fixed to `VectorView`.
  *
  * @param S the split type, which differs between the two trees.
  * @param mtry subspace size, or null for the full pool.
@@ -69,9 +66,8 @@ internal fun <S> List<S>.pickCandidates(mtry: Int?, random: Random): List<S> {
 /**
  * Score every candidate split at a leaf and return the winner, the runner-up, and the winner's index.
  *
- * Generic in the leaf payload, which is the only thing that differed between the regression and
- * classification copies of this loop. Both needed `totalWeights` and a scoring function and nothing
- * else, so both are supplied here rather than reached through a payload-specific metric type.
+ * Generic in the leaf payload: the loop needs only `totalWeights` and a scoring function, so both are
+ * supplied here rather than reached through a payload-specific metric type.
  *
  * A candidate is skipped, not scored, when either side is thinner than [minSamplesLeaf] or the two
  * sides together are thinner than [minSamplesSplit]: a split that isolates three observations may score
@@ -122,8 +118,6 @@ internal fun <R : HasObservationCount> rankCandidates(
 
 /**
  * The VFDT split decision: given ranked candidates, has the leaf earned the right to split?
- *
- * Three gates, and all three used to be written out twice with nothing keeping them in step.
  *
  * A candidate must exist and be worth taking: `bestIndex < 0` means every candidate was too thin to
  * score, and `top1 <= 0.0` means the best one does not improve on not splitting at all, since every

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AccuracyStat.kt
@@ -17,8 +17,8 @@ import com.eignex.kumulant.stat.summary.WeightedMeanResult
  * That agreement is why [numClasses] is required: [ConfusionMatrixResult.accuracy] exists so a caller can
  * cross-check the two, which only means anything if both bound the labels identically.
  *
- * For the full P/R/F1 surface and a per-class breakdown reach for [ConfusionMatrixStat]; this stat is the
- * O(1)-memory shortcut when only the scalar accuracy is needed.
+ * **Use cases:** scalar accuracy monitoring for a classifier. Reach for [ConfusionMatrixStat] when the
+ * full P/R/F1 surface or a per-class breakdown is needed; this stat is the O(1)-memory shortcut.
  *
  * **Memory:** O(1); backed by a [MeanStat]. [numClasses] only bounds the labels, it never allocates -
  * that is the saving over [ConfusionMatrixStat]'s `numClasses^2` cells.
@@ -41,8 +41,7 @@ class AccuracyStat(
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         // No separate NaN guard: asClassLabel already rejects NaN, because `NaN.toInt()` is 0 and
-        // `0.0 == NaN` is false, so the round-trip check fails. ConfusionMatrixStat carried a redundant
-        // one for the same reason.
+        // `0.0 == NaN` is false, so the round-trip check fails.
         val predicted = x.asClassLabel(numClasses)
         val truth = y.asClassLabel(numClasses)
         if (predicted < 0 || truth < 0) return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/AucStat.kt
@@ -49,10 +49,8 @@ data class AucResult(
     }
 
     // Double.equals, not ==: `auc` is NaN for an empty or freshly reset stat, and IEEE == makes NaN
-    // unequal to itself, so such a result did not equal itself and setOf(it).contains(it) was false
-    // - while hashCode below uses auc.hashCode(), which *is* NaN-stable, so the two disagreed. The
-    // generated data-class equals would have used Double.equals; this one is hand-rolled only to get
-    // contentEquals on the arrays.
+    // unequal to itself, which would contradict the NaN-stable hashCode below. Hand-rolled only to
+    // get contentEquals on the arrays.
     override fun equals(other: Any?): Boolean = other is AucResult &&
         auc.equals(other.auc) &&
         totalPositives.equals(other.totalPositives) &&
@@ -93,7 +91,7 @@ data class AucResult(
  * quality independent of threshold choice. Pair with [BrierScoreStat] or
  * [LogLossStat] for proper-scoring complements.
  *
- * **Memory:** O([numBins]); two parallel Long arrays for positives and
+ * **Memory:** O([numBins]); two parallel double-cell arrays for positives and
  * negatives.
  *
  * **Update:** O(1) per paired observation (one atomic add per bin slot).
@@ -127,7 +125,7 @@ class AucStat(
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         // As in ReliabilityStat: coerceIn passes a NaN through and NaN.toInt() is 0, so a NaN score
-        // landed in the bottom bin as a confident negative. See Stat.
+        // lands in the bottom bin as a confident negative.
         val clamped = x.coerceIn(lowerBound, upperBound)
         val bin = ((clamped - lowerBound) / binWidth).toInt().coerceIn(0, numBins - 1)
         val posWeight = y * weight

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -146,10 +146,11 @@ data class ConfusionMatrixResult(
 
 /**
  * Streaming K-by-K confusion matrix over paired `(predictedClass, trueClass)`
- * observations. Inputs are class indices in `[0, numClasses)`; the doubles are
- * truncated to ints via `toInt()` and out-of-range pairs are ignored. Use for
- * online classifier evaluation; pair with the metric getters on
- * [ConfusionMatrixResult] for accuracy, per-class P/R/F1, macro F1, and MCC.
+ * observations. Class indices are resolved by [asClassLabel]; pairs naming anything
+ * outside `[0, numClasses)` are ignored.
+ *
+ * **Use cases:** online classifier evaluation; the metric getters on
+ * [ConfusionMatrixResult] give accuracy, per-class P/R/F1, macro F1, and MCC.
  *
  * **Memory:** O([numClasses]^2) striped atomic cells.
  *

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
@@ -89,13 +89,8 @@ fun SparseHistogramResult.pitKsDistance(numBins: Int): Double {
     return ks
 }
 
-/**
- * True for the histogram's `[1.0, +Inf)` overflow row.
- *
- * A PIT value of exactly 1.0 is legitimate - the forecast CDF evaluated at the observation can reach
- * its top - but [pitHistogram] is bounded `[0, 1)`, so 1.0 lands in the overflow row. Both tests below
- * skip non-finite-bound rows, which silently dropped those observations from the uniformity statistic
- * and biased both tests toward "calibrated" for exactly the over-confident forecaster they exist to
- * catch. Fold the row into the top bin instead.
- */
+// True for the histogram's `[1.0, +Inf)` overflow row. A PIT of exactly 1.0 is legitimate but
+// `pitHistogram` is bounded `[0, 1)`, so it lands there; both tests fold the row into the top bin
+// rather than skipping it with the other non-finite-bound rows, which would drop exactly the
+// over-confident forecaster they exist to catch.
 private fun isTopEdgeRow(lower: Double, upper: Double): Boolean = lower == 1.0 && upper == Double.POSITIVE_INFINITY

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -72,8 +72,8 @@ fun CountMinSketchResult.estimate(value: Long): Long {
     val mask = (width - 1).toLong()
     val mixer = Hashers.resolve(hasher)
     // No sentinel: Long.MAX_VALUE is a value a counter can legitimately hold (a saturating weight
-    // put it there), and treating it as "no rows visited" made estimate() report 0 for the largest
-    // count representable. depth is always positive, so row 0 seeds the minimum.
+    // puts it there), so treating it as "no rows visited" would report 0 for the largest count
+    // representable. depth is always positive, so row 0 seeds the minimum.
     var min = Long.MAX_VALUE
     for (row in 0 until depth) {
         val salt = splitmix64(seed + row.toLong())
@@ -122,8 +122,8 @@ class CountMinSketchStat(
         require(width > 0) { "width must be > 0" }
         require(width and (width - 1) == 0) { "width must be a power of two" }
         // depth * width is the counter-array length and is computed in Int. Unvalidated, a large
-        // shape wrapped to zero (or worse, to a small positive value) and construction succeeded
-        // with an array too short for its own indexing, throwing on the first update instead.
+        // shape wraps to zero (or worse, to a small positive value) and construction succeeds with
+        // an array too short for its own indexing, throwing on the first update instead.
         require(depth.toLong() * width.toLong() <= Int.MAX_VALUE) {
             "depth * width must fit in an Int; $depth * $width overflows"
         }
@@ -139,13 +139,12 @@ class CountMinSketchStat(
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
         // `weight <= 0.0` is false for NaN, and `ceil(NaN).toLong()` is 0, which the coerce below
-        // lifted to 1 - so a NaN weight silently became a real observation of weight one. Counters
-        // are Long and have no NaN to propagate into, so the observation is dropped; see Stat.
+        // would lift to 1, making a NaN weight a real observation of weight one. Counters are Long
+        // and have no NaN to propagate into, so the observation is dropped; see Stat.
         if (weight.isNotPositiveWeight()) return
         // Counters are Long, so a fractional weight has to be rounded. Round *up*: rounding to
-        // nearest silently discarded everything below 0.5 - including totalSeen, so the stat denied
-        // observations it had seen - whereas rounding up keeps every observation and leaves the
-        // documented `estimate(x) >= true count(x)` intact, since it can only overshoot.
+        // nearest would discard everything below 0.5, whereas rounding up keeps every observation
+        // and leaves `estimate(x) >= true count(x)` intact, since it can only overshoot.
         val w = weight.toCounterStep()
         for (row in 0 until depth) {
             val idx = (hasher.mix(value xor rowSalts[row]) and mask).toInt()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/MinHashStat.kt
@@ -38,7 +38,7 @@ data class MinHashResult(
      * The mixer decides which signature slot a key touches, so combining sketches built with different mixers
      * is meaningless. Carried on the wire so [MinHashStat.merge] can refuse it, matching
      * [com.eignex.kumulant.stat.sketch.BloomFilterResult]. Defaults to the library default so a
-     * payload encoded before the field existed still decodes.
+     * payload without the field still decodes.
      */
     val hasher: HasherRef = HasherRef.SplitMix64,
 ) : HasObservationCount {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -165,7 +165,6 @@ class SpaceSavingStat(
      * (None: trivially; Strict/HighWrite: via [outerLock]).
      */
     private fun admitClassic(key: Long, addCount: Long, addError: Long) {
-        // Match existing key
         for (i in 0 until capacity) {
             if (counts.load(i) > 0L && keys.load(i) == key) {
                 counts.add(i, addCount)
@@ -173,7 +172,6 @@ class SpaceSavingStat(
                 return
             }
         }
-        // Find empty slot (count == 0)
         for (i in 0 until capacity) {
             if (counts.load(i) == 0L) {
                 keys.store(i, key)
@@ -182,7 +180,6 @@ class SpaceSavingStat(
                 return
             }
         }
-        // Evict min-count slot
         var minIdx = 0
         var minCount = counts.load(0)
         for (i in 1 until capacity) {
@@ -246,15 +243,15 @@ class SpaceSavingStat(
     }
 
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
-        // As in CountMinSketchStat: NaN passes `weight <= 0.0`, and rounding it lands on 1, so a NaN
-        // weight became a real observation. Counts are Long, so there is nothing to propagate into.
+        // As in CountMinSketchStat: NaN passes `weight <= 0.0`, and rounding it lands on 1, which
+        // would make a NaN weight a real observation. Counts are Long, so there is nothing to
+        // propagate into.
         if (weight.isNotPositiveWeight()) return
         // Counts are Long, so a fractional weight has to be rounded. Round *up*: rounding to nearest
-        // dropped everything below 0.5 outright, so a key accumulating many small weights never
-        // appeared among the heavy hitters at all. Counts are upper bounds as a result.
-        // Capped as in CountMinSketchStat, and for the same reason: counts are Long and monotonically
-        // increasing, so an unbounded step saturates a count and the next one wraps it negative,
-        // which would drop a genuine heavy hitter out of the summary entirely.
+        // would drop everything below 0.5, so a key accumulating many small weights never surfaces
+        // as a heavy hitter. Capped as in CountMinSketchStat, and for the same reason: counts are
+        // Long and monotonically increasing, so an unbounded step saturates a count and the next one
+        // wraps it negative, dropping a genuine heavy hitter out of the summary entirely.
         val w = weight.toCounterStep()
         if (useMisraGries) {
             admitMisraGries(value, w, 0L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
@@ -72,11 +72,9 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
     private val maxCell = monotonic.newDouble(Double.NEGATIVE_INFINITY)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        // Nothing mutates before the weight has been accepted. Two separate ordering constraints
-        // live here, and both concern the extrema, which have no inverse: an inert weight must not
-        // move min and max (the two CAS calls used to run unconditionally, so a zero-weight
-        // observation still did), and neither must a downdate that requireLiveWeight goes on to
-        // reject, or the stat is left reporting a value from an observation it refused.
+        // The extrema have no inverse, so nothing may move min or max before the weight is accepted:
+        // neither an inert weight nor a downdate requireLiveWeight goes on to reject, or the stat is
+        // left reporting a value from an observation it refused.
         if (weight.isInertWeight()) return
         lock.guarded {
             val priorW = totalWeights.load()
@@ -92,9 +90,8 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
     }
 
     override fun merge(values: SummaryResult) {
-        // read() sanitises the empty sentinels to 0.0, so an untouched shard reports min = max = 0.0
-        // and folding those in used to drag this stat's min down to a value never observed - and, on
-        // an all-negative stream, its max up. Skip the whole merge when there is nothing to merge.
+        // read() sanitises the empty sentinels to 0.0, so folding in an untouched shard would drag
+        // min down (or, on an all-negative stream, max up) to a value never observed.
         if (values.totalWeights <= 0.0) return
         casMin(minCell, values.min)
         casMax(maxCell, values.max)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/ConcurrencyResolution.kt
@@ -44,10 +44,8 @@ internal fun Concurrency.welfordLock(): Mutex = when (this) {
 }
 
 /**
- * The lock a stat takes to serialise a multi-cell update.
- *
- * Delegates to [Concurrency.lock] so the mapping lives in one place; the separate name is kept because it
- * says why the lock is being taken.
+ * The lock a stat takes to serialise a multi-cell update. Delegates to [Concurrency.lock]; the separate
+ * name says why the lock is being taken.
  */
 internal fun Concurrency.serializedLock(): Mutex = lock()
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/StreamMode.kt
@@ -146,11 +146,10 @@ internal interface StreamLongArray {
     /**
      * Add [delta] at [index] and return the new value.
      *
-     * Kept for symmetry with [StreamLong.addAndGet], which production code uses heavily. No stat needs
-     * the returned value from an array slot today, so the only caller is `AtomicModeTest`. Stated here
+     * Present for symmetry with [StreamLong.addAndGet], which production code uses heavily. No stat
+     * needs the returned value from an array slot, so the only caller is `AtomicModeTest`. Stated here
      * because the alternative reading - a live API nobody happens to call - is the one that invites
-     * someone to build on it and find the fast paths untested. The `Double` counterpart had no caller
-     * at all, tests included, and was removed.
+     * someone to build on it and find the fast paths untested.
      */
     fun addAndGet(index: Int, delta: Long): Long
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestTolerance.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestTolerance.kt
@@ -3,15 +3,8 @@ package com.eignex.kumulant
 /**
  * The comparison tolerance for floating-point assertions across the test suite.
  *
- * Eighty test files each declared their own `private const val DELTA`, at three different values: 45 at
- * `1e-12`, 34 at `1e-9`, and one at `1e-6`. The spread encoded nothing. Every one of those files passes
- * at `1e-12` on all thirteen targets, including the native and wasm ones, whose libm differs from the
- * JVM's - so the looser values were not headroom anybody had measured a need for, they were just the
- * number the file's author happened to write.
- *
- * One value, so that a file which genuinely needs slack has to say so with a local override and a reason.
- * That is the point of consolidating: not saving seventy-nine lines, but making a loosened tolerance
- * visible as a decision instead of indistinguishable from the default.
+ * One value, so that a file which genuinely needs slack has to say so with a local override and a reason,
+ * making a loosened tolerance visible as a decision instead of indistinguishable from the default.
  *
  * `1e-12` rather than something tighter because these are `Double` comparisons after accumulation over a
  * stream, not single operations. Roughly three decimal digits of slack against the `2.2e-16` epsilon

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -20,16 +20,10 @@ import kotlin.test.assertEquals
 
 private const val ARMS = 3
 
-/**
- * Every arm-indexed entry point on every bandit rejects an out-of-range index.
- *
- * `Scorable` and `PerArmBandit` document an `IllegalArgumentException` for a bad index. Swept across the
- * whole family rather than restated per bandit, because the failure mode is one member being left out -
- * which is exactly what a per-bandit test misses.
- */
+// Swept across the whole family rather than restated per bandit, because the failure mode is one
+// member being left out - which is exactly what a per-bandit test misses.
 class ArmIndexContractSweepTest {
 
-    /** One bandit plus every way to name an arm on it. */
     private class Probe(val name: String, val calls: List<Pair<String, (Int) -> Any?>>)
 
     private val x: VectorView = feat(1.0, 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -61,10 +61,6 @@ class BanditFactoryTest {
 
     @Test
     fun `a spec-built Exp3 resolves the same gamma as the constructor`() {
-        // The factory inlined `min(K * eta, 1)`, which saturates at 1.0 for every arm count, so a
-        // spec-built EXP3 mixed in pure exploration and never consulted its weights - while the same
-        // bandit built directly got the corrected default and learned. Asserting on nbrArms alone,
-        // as the test above does, cannot see that: the two disagreed on the only field that matters.
         for (arms in 2..12) {
             val fromSpec = Exp3Spec(nbrArms = arms).materialize(Random(0))
             val direct = Exp3Bandit(nbrArms = arms, random = Random(0))
@@ -75,8 +71,6 @@ class BanditFactoryTest {
 
     @Test
     fun `a spec-built Exp3 lets its weights steer the play distribution`() {
-        // The consequence, stated the way a caller would notice it. With gamma at 1.0 every arm gets
-        // exactly 1/K no matter what it earned, so this is what the saturation actually cost.
         val b = Exp3Spec(nbrArms = 3).materialize(Random(0))
         repeat(50) { b.update(armIndex = 0, value = 1.0) }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
@@ -15,11 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-/**
- * Polymorphic checks against the joint [Bandit] interface plus the [PerArmBandit]
- * convenience; anything that targets the per-arm state surface should work
- * uniformly across univariate and contextual flavours.
- */
+
 class BanditInterfaceTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
@@ -15,17 +15,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * The default tunings, and the degenerate states they can reach. A policy that silently stops
- * learning is worse than one that fails loudly, so these assert on what `choose` actually does
- * rather than on the internal weights, which is where the EXP3 defect hid.
- */
+// A policy that silently stops learning is worse than one that fails loudly, so these assert on
+// what `choose` actually does rather than on the internal weights.
 class BanditTuningTest {
 
     @Test
     fun `the default EXP3 gamma leaves room for the learned weights`() {
-        // gamma used to be min(1, K*eta) = sqrt(K*ln K), which is >= 1.177 for every K >= 2, so it
-        // clamped to 1.0 at every arm count and the weights were multiplied by 1 - gamma == 0.
         for (k in listOf(2, 3, 5, 10, 100)) {
             val gamma = Exp3Bandit(nbrArms = k).gamma
             assertTrue(gamma < 1.0, "gamma saturated at $gamma for $k arms")
@@ -100,8 +95,6 @@ class BanditTuningTest {
 
     @Test
     fun `UCB1Normal scores finitely and prefers the best arm`() {
-        // p1 mixed a mean of squares with a sum of squares, so it went negative for any arm with a
-        // non-zero mean and every score was NaN; choose then always returned arm 0.
         val bandit = MultiArmedBandit(3, UCB1Normal(), Random(7))
         repeat(30) {
             bandit.update(0, 1.0)
@@ -120,9 +113,6 @@ class BanditTuningTest {
 
     @Test
     fun `UCB1Normal still explores the losing arm at two arms`() {
-        // The confidence term used ln(nbrArms - 1), so at K = 2 it was ln(1) == 0: the bonus vanished
-        // and the policy went exactly greedy at the arm count where exploration matters most. Auer's
-        // `n` is the total pull count, which is what `step` carries.
         // Rewards have to vary: this policy scales its bonus by the observed variance, so constant
         // rewards give a zero bonus legitimately and would not tell us anything about the log term.
         val bandit = MultiArmedBandit(2, UCB1Normal(), Random(7))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
@@ -5,10 +5,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The shared EXP3 / EXP4 weight renormaliser. Both policies had their own copy, spelled with different
- * branch structure, and the tests below are the ratio-preservation argument that makes the rescale safe.
- */
 class ExponentialWeightsTest {
 
     @Test
@@ -36,9 +32,8 @@ class ExponentialWeightsTest {
 
     @Test
     fun `an underflowing array is rescaled rather than left to die`() {
-        // The half that used to be unguarded in EXP3. A run of large negative rewards drives every
-        // exp(eta * gain) toward zero; if the array is left there, one more step reaches exactly zero
-        // and no later reward can lift it, because every update multiplies.
+        // A run of large negative rewards drives every exp(eta * gain) toward zero; left there, one
+        // more step reaches exactly zero and no later reward can lift it, since every update multiplies.
         val w = doubleArrayOf(1e-200, 5e-201, 2e-200)
         val ratioBefore = w[0] / w[2]
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -15,8 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-/** Edge cases across Exp3, Exp4, Boltzmann, Knn, TopTwoTS that the per-class
- *  tests don't already cover. */
+
 class StandaloneBanditExtraTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -94,7 +94,6 @@ class RegressionContextualBanditTest {
         )
         bandit.update(0, feat(1.0, 0.0), 5.0)
         bandit.update(0, feat(1.0, 0.0), 5.0)
-        // Reading via armStat must match armResult and snapshot.
         assertEquals(bandit.armResult(0), bandit.armStat(0).read(0L))
         assertEquals(bandit.snapshot()[0], bandit.armResult(0))
     }
@@ -179,7 +178,6 @@ class RegressionContextualBanditTest {
         val fresh = original.create(original.random)
         assertEquals(4, fresh.nbrArms)
         assertEquals(0.0, fresh.armResult(0).totalWeights, "fresh instance has no data")
-        // Original is untouched.
         assertTrue(original.armResult(0).totalWeights > 0.0)
     }
 
@@ -285,7 +283,6 @@ class RegressionContextualBanditTest {
         val otherGlobal = BayesianRegressionStat(featureSize = 2).also {
             it.update(doubleArrayOf(1.0, 0.0), 1.0)
         }.read()
-        // Should not throw
         bandit.mergeGlobal(otherGlobal)
         assertNull(bandit.globalSnapshot())
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBanditTest.kt
@@ -55,7 +55,6 @@ class BoltzmannBanditTest {
         repeat(20) { b.update(0, 1.0) }
         b.choose()
         b.reset()
-        // After reset, temperature returns to initial after the first call.
         b.playDistribution()
         assertTrue(abs(b.temperature() - 1.0) < 1e-9)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/CompositeArmTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/CompositeArmTest.kt
@@ -175,7 +175,6 @@ class CompositeArmTest {
             }
             mab.update(arm, reward)
         }
-        // Snapshot should be three ResultLists with two sub-results each
         val snap = mab.snapshot()
         assertEquals(3, snap.size)
         for (s in snap) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditExtraTest.kt
@@ -14,7 +14,6 @@ class MultiArmedBanditExtraTest {
         val mab = MultiArmedBandit(nbrArms = 2, policy = NormalTS(), random = Random(0))
         val stat = mab.armStat(1)
         repeat(5) { mab.update(1, 4.0) }
-        // The handed-out stat reflects updates fed through the bandit.
         val view = stat.read(0L)
         assertTrue(view.totalWeights >= 5.0)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditTest.kt
@@ -6,11 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-/**
- * Behavioural checks for [MultiArmedBandit.evaluate]: it should be a read-only
- * scoring op (no step increment, no policy state mutation) and agree with the
- * value the policy would have used for that arm inside [choose].
- */
+
 class MultiArmedBanditTest {
 
     @Test
@@ -28,8 +24,6 @@ class MultiArmedBanditTest {
 
     @Test
     fun `evaluate does not mutate arm state`() {
-        // evaluate is a read-only scoring op: it consumes the RNG but never touches
-        // policy/arm sufficient statistics. Confirm via snapshot equality before/after.
         val mab = MultiArmedBandit(nbrArms = 3, policy = BetaBernoulliTS(), random = Random(42))
         mab.update(0, 1.0)
         mab.update(1, 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -14,26 +14,16 @@ import kotlin.test.assertTrue
 
 private const val CLASSES = 3
 
-/**
- * Which `Double`s name a class, checked on the helper and then on every classifier that uses it.
- *
- * The five call sites disagreed before this: two round-tripped through `Double`, three truncated, and
- * they used three different weight predicates between them. The sweep is the part that matters, because
- * the helper being right does not help if a stat stops calling it.
- */
 class ClassLabelAdmissionTest {
 
-    /** One classifier, with a way to feed it and a way to see whether it moved. */
     private class Probe(val name: String, val update: (Double, Double) -> Unit, val snapshot: () -> String)
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
     private val x = DenseVector.of(DoubleArray(2) { 1.0 })
 
     // Fresh instances per test. Every snapshot reads the learned numbers out explicitly rather than
-    // stringifying the result: ClassCountsResult has no toString override, so on the JVM a snapshot
-    // taken that way is a fresh identity hash every time and compares unequal to itself, which made an
-    // earlier version of the "still absorbed" test pass without proving anything. Kotlin/JS renders
-    // those objects differently and failed honestly, which is how it was caught.
+    // stringifying the result: ClassCountsResult has no toString override, so on the JVM a stringified
+    // snapshot is a fresh identity hash every time and compares unequal to itself.
     private fun probes(): List<Probe> {
         val softmax = SoftmaxRegressionStat(featureSize = 2, numClasses = CLASSES)
         val gnb = GaussianNaiveBayesStat(featureSize = 2, numClasses = CLASSES)
@@ -78,8 +68,7 @@ class ClassLabelAdmissionTest {
 
     @Test
     fun `asClassLabel rejects a label that is not an integer`() {
-        // The case that used to differ between the tree path and the GLM path: toInt() truncates, so
-        // 1.5 arrived as a perfectly ordinary class 1 on three of the five sites.
+        // toInt() truncates, so an unvalidated 1.5 would arrive as a perfectly ordinary class 1.
         for (y in listOf(0.5, 1.5, 2.5, -0.5, 1.0000001, 0.9999999)) {
             assertEquals(-1, y.asClassLabel(CLASSES), "$y was accepted as a class index")
         }
@@ -126,10 +115,9 @@ class ClassLabelAdmissionTest {
 
     @Test
     fun `every classifier treats a NaN weight as a no-op`() {
-        // The half of this that was a live defect rather than an inconsistency. `weight <= 0.0` and
-        // `weight == 0.0` are both false for NaN, so on three of the five paths a NaN weight reached
-        // the leaf counts and pinned one to NaN permanently: a later valid observation could not clear
-        // it, because every subsequent add started from NaN.
+        // `weight <= 0.0` and `weight == 0.0` are both false for NaN, so an unguarded NaN weight reaches
+        // the leaf counts and pins one to NaN permanently: a later valid observation cannot clear it,
+        // because every subsequent add starts from NaN.
         val violations = mutableListOf<String>()
         for (probe in probes()) {
             probe.update(1.0, 1.0)
@@ -163,8 +151,6 @@ class ClassLabelAdmissionTest {
     fun `a class count still downdates on a negative weight`() {
         // ClassCounts guards on isInertWeight rather than isNotPositiveWeight, because a count cell
         // subtracts exactly: retracting an observation folded in earlier is a downdate, not corruption.
-        // The regression trees already worked this way and the classification side now matches, so the
-        // fix to the NaN-weight hole did not cost the legitimate negative-weight case.
         val counts = ClassCountsStat(CLASSES)
         counts.update(1.0, weight = 3.0)
         counts.update(1.0, weight = -1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/EmptyReadSemanticsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/EmptyReadSemanticsTest.kt
@@ -15,15 +15,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * What a stat reports before it has seen anything.
- *
- * The convention: report the identity element where the statistic has one, and `NaN` where it
- * does not. The quantile family previously reported `0.0` per quantile on an empty sketch,
- * which is indistinguishable from a sketch that observed real zeros - so an untouched service
- * rendered a p99 of zero and read as healthy rather than as having no data. [AucStat] already
- * used `NaN` for the same case, so the library disagreed with itself.
- */
+// The empty-read convention: report the identity element where the statistic has one, and `NaN` where
+// it does not, because a `0.0` quantile is indistinguishable from a sketch that observed real zeros.
 class EmptyReadSemanticsTest {
 
     @Test
@@ -51,8 +44,7 @@ class EmptyReadSemanticsTest {
         val digest = TDigestStat(probabilities = doubleArrayOf(0.5, 0.99)).read()
         assertTrue(digest.quantiles.all { it.isNaN() }, "TDigest reported ${digest.quantiles.toList()}")
 
-        // MadStat is built on two TDigests, so it inherits the sentinel: an empty sample has no
-        // median, and reporting 0.0 claimed one.
+        // MadStat is built on two TDigests, so it inherits the sentinel: an empty sample has no median.
         val mad = MadStat().read()
         assertTrue(mad.median.isNaN(), "Mad median was ${mad.median}")
         assertTrue(mad.mad.isNaN(), "Mad mad was ${mad.mad}")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/IndexedResultSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/IndexedResultSerializationTest.kt
@@ -10,18 +10,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * [IndexedResult] was the only result type in the library without `@Serializable` and
- * `@SerialName`, so it had no generated serializer and no stable wire name while every
- * sibling had both.
- *
- * Note what this does and does not establish. The annotations give it a serializer and a
- * stable discriminator, which is what this test pins. Encoding it still requires the caller
- * to supply a [SerializersModule] covering its `inner` field, because that field is typed as
- * the open [Result] interface and so resolves polymorphically. This test registers the one
- * subclass it needs; the library does not currently ship a module covering the whole result
- * catalogue.
- */
+// Encoding an [IndexedResult] needs a caller-supplied [SerializersModule] covering its `inner` field,
+// which is typed as the open [Result] interface and so resolves polymorphically. The module below
+// registers the one subclass these tests need.
 class IndexedResultSerializationTest {
 
     private val json = Json {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/NegativeWeightSemanticsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/NegativeWeightSemanticsTest.kt
@@ -12,16 +12,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * What a negative weight means, per family.
- *
- * The contract is that zero is a no-op and a negative weight does whatever is standard for
- * the specific statistic, throwing only where the alternative is a corrupted accumulator.
- * These tests pin the behaviour that was measured across the catalogue rather than assumed:
- * every family surveyed treats a negative weight as a downdate, stays finite, and recovers
- * when weight is added back. No family needed a new guard beyond the Welford summary stats,
- * where an exhausted total is genuinely unrecoverable.
- */
+// The contract: zero is a no-op, and a negative weight does whatever is standard for the specific
+// statistic, throwing only where the alternative is a corrupted accumulator.
 class NegativeWeightSemanticsTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/PairedAndDiscreteContractSweepTest.kt
@@ -25,11 +25,9 @@ import com.eignex.kumulant.schema.spec.SpaceSaving
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * The same library-wide contracts as [SeriesStatContractSweepTest], over the paired and discrete
- * modalities. [Stat] states the zero-weight guarantee holds "whatever the modality", so the sweep
- * has to cross modalities to be worth anything.
- */
+// The same library-wide contracts as [SeriesStatContractSweepTest], over the paired and discrete
+// modalities. [Stat] states the zero-weight guarantee holds "whatever the modality", so the sweep
+// has to cross modalities to be worth anything.
 class PairedAndDiscreteContractSweepTest {
 
     private val pairedSpecs: List<Pair<String, PairedStatSpec<*>>> = listOf(
@@ -48,8 +46,6 @@ class PairedAndDiscreteContractSweepTest {
     )
 
     private val discreteSpecs: List<Pair<String, DiscreteStatSpec<*>>> = listOf(
-        // HyperLogLog was missing from this catalogue, which is how it stayed the one sketch no sweep
-        // covered even though it carries the same weight guard as the other five.
         "HyperLogLog" to HyperLogLog(),
         "LinearCounting" to LinearCounting(),
         "BloomFilter" to BloomFilter(),
@@ -122,9 +118,9 @@ class PairedAndDiscreteContractSweepTest {
             keys.forEachIndexed { i, k -> stat.update(k, i.toLong() * 1_000_000_000L, 1.0) }
             val before = stat.read(readAt)
 
-            // The sketches were the worst case here: `weight <= 0.0` is false for NaN and
-            // `ceil(NaN).toLong()` is 0, which the coerce lifted to 1, so a NaN weight became a real
-            // observation of weight one.
+            // The sketches are the delicate case: `weight <= 0.0` is false for NaN and
+            // `ceil(NaN).toLong()` is 0, which a coerce would lift to 1, turning a NaN weight into a
+            // real observation of weight one.
             val thrown = runCatching { stat.update(2L, readAt, Double.NaN) }.exceptionOrNull()
             if (thrown != null) {
                 violations += "$name threw on a NaN weight: ${thrown.message}"
@@ -139,10 +135,9 @@ class PairedAndDiscreteContractSweepTest {
 
     @Test
     fun `an infinite weight is a no-op for every paired and discrete stat`() {
-        // The paired modality was the worst of the three here: nine of its twelve stats reported NaN
-        // after a `+Infinity` weight, because a loss or a calibration curve divides an accumulated total
-        // by an accumulated weight and both had gone infinite. See isInertWeight on why an infinity is
-        // not a multiplicity and why the limit was not worth chasing.
+        // The paired modality is the delicate one: a loss or a calibration curve divides an accumulated
+        // total by an accumulated weight, so an absorbed infinity turns both infinite and the read NaN.
+        // See isInertWeight on why an infinity is not a multiplicity.
         val violations = mutableListOf<String>()
         for (weight in doubleArrayOf(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
             for ((name, spec) in pairedSpecs) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ResultEqualityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ResultEqualityTest.kt
@@ -17,14 +17,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
-/**
- * Structural equality for the array-bearing result types.
- *
- * A Kotlin `data class` derives `equals` from its components, and array components compare
- * by reference, so two structurally identical snapshots of these types used to be unequal.
- * That contradicts the documented promise that results are structurally comparable, and it
- * quietly made any `assertEquals` over them unable to pass.
- */
+// A Kotlin `data class` derives `equals` from its components and array components compare by
+// reference, so the array-bearing results have to hand-roll it to keep the documented promise that
+// results are structurally comparable.
 class ResultEqualityTest {
 
     private fun sketch(quantiles: DoubleArray) = SketchResult(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/SeriesStatContractSweepTest.kt
@@ -50,11 +50,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Contracts that hold for every series stat, checked against the whole catalogue rather than a
- * survey of it. The per-family tests pin behaviour one stat at a time; this sweep is what catches
- * a stat that quietly opts out of a rule the rest of the library follows.
- */
+// Contracts that hold for every series stat, checked against the whole catalogue rather than a
+// survey of it: the per-family tests pin behaviour one stat at a time, so only a sweep catches a
+// stat that quietly opts out of a rule the rest of the library follows.
 class SeriesStatContractSweepTest {
 
     // Every SeriesStatSpec variant, built with parameters in each stat's valid range.
@@ -133,9 +131,7 @@ class SeriesStatContractSweepTest {
     @Test
     fun `a NaN weight is a no-op for every series stat`() {
         // The companion of the zero-weight sweep: a weight is the multiplicity of an observation and
-        // NaN is not a multiplicity, so it carries nothing to fold in. This used to be three
-        // different behaviours - the Welford family threw from requireLiveWeight, the sketches
-        // rounded it to a weight of one, and everything else let it poison the accumulator.
+        // NaN is not a multiplicity, so it carries nothing to fold in.
         val violations = mutableListOf<String>()
         for ((name, spec) in specs) {
             for (probe in doubleArrayOf(999.0, -999.0)) {
@@ -157,16 +153,11 @@ class SeriesStatContractSweepTest {
 
     @Test
     fun `an infinite weight is a no-op for every series stat`() {
-        // The fourth and last weight case, and the one nothing guarded. Both predicates let an infinity
-        // through: `isInertWeight` tested only zero and NaN, and `+Infinity > 0.0` is true, so
-        // `isNotPositiveWeight` waved it past as an ordinary live observation.
-        //
         // A weight is the multiplicity of an observation, and an infinity is no more a multiplicity than
         // a NaN is, so it belongs with the other inert cases. `+Infinity` does have a clean reading -
-        // the update `w / (W + w)` tends to 1, so the mean tends to the value - but essentially nothing
-        // here computed that limit. The recurrences evaluated `Infinity / Infinity` and `Infinity * 0`
-        // and published the NaN as a result, in 22 stat and weight combinations across three modalities.
-        // See isInertWeight for why supporting the limit was not worth eleven rewritten recurrences.
+        // the update `w / (W + w)` tends to 1, so the mean tends to the value - but an unguarded
+        // recurrence evaluates `Infinity / Infinity` and `Infinity * 0` and publishes the NaN instead.
+        // See isInertWeight for why the limit is not worth chasing.
         val violations = mutableListOf<String>()
         for ((name, spec) in specs) {
             for (weight in doubleArrayOf(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
@@ -190,13 +181,11 @@ class SeriesStatContractSweepTest {
 
     @Test
     fun `a negative weight is a no-op for every stat that cannot invert it`() {
-        // The third weight case, and the one the other two sweeps left open. Zero and NaN are no-ops
-        // library-wide, but a negative weight partitions the catalogue: a stat whose recurrence
-        // inverts treats it as a downdate, and a stat with no inverse - a sketch, a histogram bucket -
-        // has to drop it, because there is no bucket decrement that undoes a hash insert. Both halves
-        // are correct; what is not correct is a stat picking a third answer, which is what happened
-        // when this predicate was open-coded at twenty sites instead of named once as
-        // isNotPositiveWeight. The negative case is also the reason that helper is not isInertWeight.
+        // Zero and NaN are no-ops library-wide, but a negative weight partitions the catalogue: a stat
+        // whose recurrence inverts treats it as a downdate, and a stat with no inverse - a sketch, a
+        // histogram bucket - has to drop it, because there is no bucket decrement that undoes a hash
+        // insert. Both halves are correct; what is not correct is a stat picking a third answer. The
+        // negative case is also the reason isNotPositiveWeight is named apart from isInertWeight.
         val violations = mutableListOf<String>()
         for (name in NO_INVERSE) {
             val spec = specs.first { it.first == name }.second
@@ -233,8 +222,7 @@ class SeriesStatContractSweepTest {
         // exists rather than a per-stat rule. A non-finite value is allowed to propagate and allowed to
         // poison the stat for good - it was a real observation of something unusable, and hiding that
         // would turn a gap in the input into a confidently wrong answer. What is ruled out is turning it
-        // into an outage in the caller. HdrHistogram used to: its `value >= 0.0` check is false for NaN,
-        // so it rejected a NaN as if it were a negative value.
+        // into an outage in the caller.
         //
         // Both infinities are swept alongside NaN, because they reach different code. An infinity passes
         // every ordering comparison, so a range check that a NaN fails will let an infinity through and
@@ -244,8 +232,8 @@ class SeriesStatContractSweepTest {
         // takes non-negative values only - and `-Infinity` is negative, so refusing it there is the same
         // rule that refuses -5.0 rather than a non-finite defect. Each infinity is therefore paired with a
         // finite value of the same sign, and a stat that rejects both is exercising its domain rather than
-        // tripping over the infinity. NaN has no signed analogue, so it must never throw at all: it is the
-        // case that broke before, when a `value >= 0.0` guard read a NaN as negative.
+        // tripping over the infinity. NaN has no signed analogue, so it must never throw at all - a
+        // `value >= 0.0` domain guard is false for NaN and would read it as negative.
         val probes = listOf(
             Double.NaN to null,
             Double.POSITIVE_INFINITY to 1e6,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/ArgMaxTest.kt
@@ -3,12 +3,8 @@ package com.eignex.kumulant.math
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * The tie and NaN conventions of the shared argmax, which every arm and class-label choice depends on.
- *
- * The two rules interact: seeding the running best at `-Infinity` is what makes a NaN score lose, and
- * strict `>` is what resolves a tie to the lowest index.
- */
+// The two conventions interact: seeding the running best at `-Infinity` is what makes a NaN score
+// lose, and strict `>` is what resolves a tie to the lowest index.
 class ArgMaxTest {
 
     @Test
@@ -25,9 +21,8 @@ class ArgMaxTest {
 
     @Test
     fun `a NaN score loses rather than winning`() {
-        // The convention that actually changed. Seeding from `score(0)` made a NaN first score
-        // unbeatable, because every comparison against NaN is false, so one poisoned class decided
-        // every later prediction. A NaN must lose to any finite score, wherever it sits.
+        // Seeding from `score(0)` would make a NaN first score unbeatable, because every comparison
+        // against NaN is false, so one poisoned class would decide every later prediction.
         assertEquals(1, argMaxOf(3) { doubleArrayOf(Double.NaN, 2.0, 1.0)[it] })
         assertEquals(0, argMaxOf(3) { doubleArrayOf(2.0, Double.NaN, 1.0)[it] })
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/DistributionsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/DistributionsTest.kt
@@ -7,12 +7,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * Statistical sanity tests for the random-variate generators. Each test draws ~10k
- * samples and compares sample moments against analytic moments with generous slack.
- * Not a full distributional fit test - just enough to catch sign errors and
- * algorithmic mistakes.
- */
+// Sample moments are compared against analytic moments with generous slack: not a full
+// distributional fit test, just enough to catch sign errors and algorithmic mistakes.
 class DistributionsTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/SoftmaxTest.kt
@@ -7,9 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-/**
- * Properties of the shared softmax, which three call sites previously each implemented for themselves.
- */
 class SoftmaxTest {
 
     @Test
@@ -90,9 +87,8 @@ class SoftmaxTest {
     @Test
     fun `a NaN logit yields NaN rather than being rejected`() {
         // Pinned as the current behaviour, not as desirable behaviour. The post-shift sum is NaN,
-        // which fails the `<= 0.0` guard the three previous copies all carried, so this returns true
-        // with an unusable array - and on the training path that NaN reaches the weights and stays
-        // there. Kept exactly as it was so this extraction changes nothing; the fix is its own task.
+        // which fails the `<= 0.0` guard, so this returns true with an unusable array - and on the
+        // training path that NaN reaches the weights and stays there.
         val p = doubleArrayOf(1.0, Double.NaN, 2.0)
 
         assertTrue(p.softmaxInPlace(), "the sum guard cannot catch a NaN, so this still reports success")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/MapResultsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/MapResultsTest.kt
@@ -81,8 +81,6 @@ class MapResultsTest {
 
     @Test
     fun `discrete mapResult round-trips a SumResult through cast bridge`() {
-        // Bridge a Discrete SumStat (via asDiscrete) and remap its result to MeanResult
-        // and back, verifying both forward (read) and reverse (merge) paths.
         val stat = com.eignex.kumulant.stat.summary.SumStat().asDiscrete().mapResult(forward, reverse)
         stat.update(2L)
         stat.update(3L)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/PerIndexFeedbackTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/PerIndexFeedbackTest.kt
@@ -48,7 +48,6 @@ class PerIndexFeedbackTest {
         )
         for (u in updates) scaled.update(u)
 
-        // Reproduce expected per-coord behaviour.
         val refVar = VarianceStat()
         var expectedCoord0 = 0.0
         for (u in updates) {
@@ -67,7 +66,6 @@ class PerIndexFeedbackTest {
 
     @Test
     fun `VIndex outside a feedback context throws`() {
-        // Direct invocation with a non-IndexedResult primary should fail loudly.
         val primary = VarianceStat().also {
             it.update(1.0)
             it.update(2.0)
@@ -78,8 +76,7 @@ class PerIndexFeedbackTest {
 
     @Test
     fun `paired feedback exposes axis index via VIndex`() {
-        // Paired feedback evaluates X axis with VIndex=0, Y axis with VIndex=1.
-        // Use an expr that returns VIndex for inspection by piping into a paired sum.
+        // Paired feedback evaluates the x axis with VIndex=0 and the y axis with VIndex=1.
         val pair = com.eignex.kumulant.stat.summary.PairedSumStat().withFeedback(
             VarianceStat(),
             VarianceStat(),
@@ -87,7 +84,6 @@ class PerIndexFeedbackTest {
         )
         pair.update(99.0, 123.0)
         val r = pair.read()
-        // x-axis projection emits VIndex=0, y-axis projection emits VIndex=1.
         assertEquals(0.0, r.sumX, DELTA)
         assertEquals(1.0, r.sumY, DELTA)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
@@ -39,7 +39,6 @@ class RegressionOpsTest {
     fun `transformX rewrites the feature vector`() {
         val inner = StochasticRegressionStat(featureSize = 2)
         val stat = inner.transformX { v, _ -> doubleArrayOf(v[0] * 2.0, v[1] + 1.0) }
-        // Drive a few updates and verify featureSize is unchanged.
         repeat(3) { stat.update(feat(1.0, 2.0), y = 5.0) }
         assertEquals(2, stat.featureSize)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
@@ -8,13 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * Argument validation on `throttle` and `sample`, across all five modalities.
- *
- * The regression modality carried its own byte-identical copies of these two checks, which is the kind
- * of duplication that only shows up when one copy is deleted and nothing fails. Nothing did fail,
- * because neither check had a test; these are that test.
- */
 class SamplingValidationTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
@@ -60,10 +60,9 @@ class WeightsTest {
 
     @Test
     fun `withWeight passes a zero caller weight through instead of overriding it`() {
-        // This used to override the zero too, which broke the library-wide guarantee on Stat that a
-        // weight of 0.0 changes no state whatever the modality: a zero-weight update to a CountStat
-        // still counted. The override sets the magnitude of a real observation, and "ignore this
-        // observation" is not a magnitude.
+        // Overriding the zero would break the library-wide guarantee on Stat that a weight of 0.0
+        // changes no state whatever the modality. The override sets the magnitude of a real
+        // observation, and "ignore this observation" is not a magnitude.
         val discrete = HyperLogLogStat(precision = 10).withWeight(1.0)
         for (i in 1L..50L) discrete.update(i, weight = 0.0)
         assertEquals(0.0, discrete.read().estimate, "a zero-weight update must not register")
@@ -77,10 +76,8 @@ class WeightsTest {
 
     @Test
     fun `withWeight passes an inert caller weight through for every modality`() {
-        // Zero and NaN are both inert; see Stat. Each modality has its own adapter, and the regression
-        // one open-coded the condition so it covered zero but not NaN - a NaN weight through it became
-        // a real observation of the constant weight, while the leaf stat it wrapped correctly no-opped.
-        // Sweeping all five is what stops the odd one out from drifting again.
+        // Zero and NaN are both inert; see Stat. Each modality has its own adapter, so sweeping all
+        // five is what stops one of them drifting from the rest.
         for (inert in listOf(0.0, Double.NaN)) {
             val series = SumStat().withWeight(2.0)
             series.update(3.0, weight = inert)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WrapperContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WrapperContractTest.kt
@@ -15,11 +15,9 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * Contracts the decorator wrappers have to keep even though they delegate most of their surface: a
- * wrapper must not break `reset`, must not lose the caller's weight, and must not make a combination
- * of two wrappers unreadable.
- */
+// Contracts the decorator wrappers have to keep even though they delegate most of their surface: a
+// wrapper must not break `reset`, must not lose the caller's weight, and must not make a combination
+// of two wrappers unreadable.
 class WrapperContractTest {
 
     @Test
@@ -30,7 +28,7 @@ class WrapperContractTest {
         stat.update(3.0, 2_000_000L, 1.0)
 
         // A window reads by merging its slices into a fresh template, and merging through the band
-        // wrapper throws, so this used to fail on every read once a slice had data.
+        // wrapper throws, so the read has to bypass it once a slice has data.
         val r = stat.read(2_000_000L)
         assertTrue(r.lower <= r.center && r.center <= r.upper, "band came out inverted: $r")
         assertEquals(2.0, r.center, 1e-9)
@@ -52,8 +50,8 @@ class WrapperContractTest {
         stat.reset()
         stat.update(100.0, 3L, 1.0)
 
-        // A fresh throttle(3) forwards on its third update, so a reset one must too; `by delegate`
-        // used to forward reset straight past the tick counter.
+        // A fresh throttle(3) forwards on its third update, so a reset one must too: reset has to
+        // reach the tick counter and not just the delegate.
         assertEquals(0.0, stat.read(4L).sum, "reset left the throttle mid-phase")
         stat.update(100.0, 4L, 1.0)
         stat.update(100.0, 5L, 1.0)
@@ -66,7 +64,6 @@ class WrapperContractTest {
         weighted.update(7.0, 10_000_000L, 2.0)
         weighted.update(0.0, 2_000_000_000L, 1.0) // rolls the bucket
 
-        // The wrapper used to hardcode weight 1.0 on the flush and ignore the caller's entirely.
         assertEquals(14.0, weighted.read(2_000_000_000L).sum, 1e-9)
     }
 
@@ -77,7 +74,6 @@ class WrapperContractTest {
         stat.update(7.0, 10_000_000L, 0.0)
         stat.update(0.0, 2_000_000_000L, 1.0) // rolls the bucket
 
-        // It used to seed the bucket and get flushed later as weight 1.0.
         assertEquals(0.0, stat.read(2_000_000_000L).sum, 1e-9)
     }
 
@@ -86,8 +82,8 @@ class WrapperContractTest {
         val nan = listOf(Double.NaN)
         val zero = listOf(0.0)
 
-        // In used List<Double>.contains, which boxes and uses Double.equals, so NaN matched itself
-        // and -0.0 did not match 0.0 - both the opposite of Eq, which In exists to flatten.
+        // A plain List<Double>.contains boxes and uses Double.equals, so NaN would match itself and
+        // -0.0 would not match 0.0 - both the opposite of Eq, which In exists to flatten.
         assertFalse(
             In(X, nan).eval(Double.NaN, 0.0, DoubleArray(0), null),
             "In(X, [NaN]) is unsatisfiable and must not admit NaN",

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
@@ -33,13 +33,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Every AST node is reachable from Kotlin, and the Kotlin form agrees with the wire form.
- *
- * The library's rule is that an expression must be both serializable and constructable in Kotlin. The
- * round trip is the half that makes the pairing meaningful: a factory that produced a node the wire
- * could not carry, or a serial name that decoded to something else, would satisfy neither.
- */
+// The library's rule is that an expression must be both serializable and constructable in Kotlin. The
+// round trip is the half that makes the pairing meaningful: a factory producing a node the wire could
+// not carry, or a serial name decoding to something else, would satisfy neither.
 class ExprKotlinConstructionTest {
 
     private val v = doubleArrayOf(2.0, 3.0, 4.0)
@@ -112,7 +108,7 @@ class ExprKotlinConstructionTest {
             VFoldOp.Norm2 to kotlin.math.sqrt(29.0),
         )
         // Driven off VFoldOp.entries, not a hand-written list, so a new op added later fails here
-        // rather than going untested. That is how Norm2 was caught when this test was first written.
+        // rather than going untested.
         val violations = mutableListOf<String>()
         for (op in VFoldOp.entries) {
             val expr = vFold(op)
@@ -140,8 +136,6 @@ class ExprKotlinConstructionTest {
 
     @Test
     fun `vectorOf is a Kotlin constructor for VectorExpr`() {
-        // VectorExpr had no public implementation at all, so `transformVector` and `transformX` - both
-        // public - could not be called from Kotlin. This is the constructor that closes that.
         val permute: VectorExpr = vectorOf(V(2), V(0), V(1))
 
         assertEquals(listOf(4.0, 2.0, 3.0), permute.eval(0.0, 0.0, v).toList())
@@ -158,8 +152,8 @@ class ExprKotlinConstructionTest {
 
     @Test
     fun `a nested expression built entirely in Kotlin round-trips whole`() {
-        // The nodes have to compose, not merely exist: this is one tree mixing seven of the new
-        // factories with the pre-existing operator sugar.
+        // The nodes have to compose, not merely exist: one tree mixing seven factories with the
+        // operator sugar.
         val expr = X.abs().sqrt().min(vDot(1.0, 0.0, 0.0)).max(Const(0.5)).pow(2.0) + vFold(VFoldOp.Mean)
 
         val direct = expr.eval(-16.0, 0.0, v)
@@ -171,8 +165,6 @@ class ExprKotlinConstructionTest {
 
     @Test
     fun `the vector transforms are now reachable from Kotlin end to end`() {
-        // The point of the exercise. `transformVector` and `transformX` are public and take a
-        // VectorExpr, which had no public implementation, so neither could be called from Kotlin at all.
         // Materialising and driving one proves the whole path works, not just that the type exists.
         val reordered = Vectorized(dimensions = 3, template = Sum).transformVector(vectorOf(V(2), V(0), V(1)))
         val stat = reordered.materialize()

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
@@ -21,15 +21,9 @@ import kotlin.test.assertTrue
 
 private val NON_FINITE = doubleArrayOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
 
-/**
- * `filterFinite`, the supported way to keep non-finite observations out of a stat.
- *
- * [Stat][com.eignex.kumulant.core.Stat] guarantees only that a non-finite value will not throw. It is
- * explicitly allowed to poison the stat, and for an accumulator it does: a `NaN` folded into a mean is
- * reported for ever. That is the right default, because the observation genuinely arrived and genuinely
- * was unusable, and hiding it would turn a gap in the input into a silently plausible answer. A caller
- * who would rather drop such observations says so with this filter.
- */
+// [Stat][com.eignex.kumulant.core.Stat] guarantees only that a non-finite value will not throw; it is
+// explicitly allowed to poison the stat, and for an accumulator it does. `filterFinite` is the
+// supported way for a caller to drop such observations instead.
 class FilterFiniteTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/HasherConfigTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/HasherConfigTest.kt
@@ -21,11 +21,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-/**
- * The discrete sketch specs carry a [LongHasher] by name; a custom mixer is supplied through
- * the [Hashers] registry and referenced by that name on the wire. These tests cover the full
- * path: register, serialize, materialize, and re-query via the result-side helpers.
- */
+// The discrete sketch specs carry a [LongHasher] by name; a custom mixer is supplied through the
+// [Hashers] registry and referenced by that name on the wire.
 class HasherConfigTest {
 
     private object SaltedSplitMix : LongHasher {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsConcurrencyClaimTest.kt
@@ -7,14 +7,10 @@ import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * A list of stats reports the weakest guarantee its entries offer, not a flat [Concurrency.None].
- *
- * A container is only as safe as its least-protected member, and this property is what a caller
- * introspects to decide whether reads need external synchronisation. `AbstractStatGroup` carries the same
- * rule, and the two must agree over identical entries or the property is unreliable rather than merely
- * pessimistic.
- */
+// A container is only as safe as its least-protected member, and this property is what a caller
+// introspects to decide whether reads need external synchronisation. `AbstractStatGroup` carries the
+// same rule, and the two must agree over identical entries or the property is unreliable rather than
+// merely pessimistic.
 class ListStatsConcurrencyClaimTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsSchemaTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ListStatsSchemaTest.kt
@@ -14,11 +14,8 @@ import com.eignex.kumulant.stat.summary.SumResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-/**
- * Schema-aware constructors for the four `*ListStats` classes. They walk the
- * matching modality helper (`seriesSpecs`/`pairedSpecs`/...) and turn it into
- * positional `(name, stat)` entries.
- */
+// The schema-aware `*ListStats` constructors walk the matching modality helper
+// (`seriesSpecs`/`pairedSpecs`/...) and turn it into positional `(name, stat)` entries.
 
 class ListStatsSchemaTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/OperationsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/OperationsRoundTripTest.kt
@@ -42,10 +42,8 @@ import com.eignex.kumulant.operation.withFixedY as liveWithFixedY
 import com.eignex.kumulant.operation.withSelfLag as liveWithSelfLag
 import com.eignex.kumulant.operation.withValue as liveWithValue
 import com.eignex.kumulant.operation.withWeight as liveWithWeight
-/**
- * Round-trip tests for the operation specs in [Operations.kt]: encode, decode,
- * materialize, drive a small fixed input, compare against a live composition.
- */
+// Each spec is encoded, decoded, materialized, driven over a small fixed input, and compared against
+// the equivalent live composition.
 
 class OperationsRoundTripTest {
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ReadmeExamplesTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ReadmeExamplesTest.kt
@@ -9,18 +9,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The README's composition and schema examples, compiled and executed.
- *
- * These were both wrong before. The composition example called `MeanStat().windowed(...)`,
- * but every `windowed` overload on a live stat is `internal`, so the snippet did not compile
- * for a consumer at all. The schema example built a single `StatGroup` from a schema that
- * mixes `series` and `discrete` entries, but `StatGroup` binds only the series specs, so the
- * `discrete` entry was silently never updated and reading it threw.
- *
- * Keeping them here as a test is the only thing that stops that recurring: a README snippet
- * nothing compiles is indistinguishable from a correct one until someone tries it.
- */
+// The README's composition and schema examples, compiled and executed: a snippet nothing compiles is
+// indistinguishable from a correct one until someone tries it.
 class ReadmeExamplesTest {
 
     private object Telemetry : StatSchema(concurrency = Concurrency.Strict) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/SpecDefaultParityTest.kt
@@ -45,20 +45,15 @@ import com.eignex.kumulant.stat.summary.MadStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * A default-constructed spec materialises to the same stat a default-constructed stat gives you.
- *
- * `schema/spec/Stats.kt` declares that spec defaults match the underlying stat's primary constructor, so
- * authored payloads stay terse under `encodeDefaults = false`. Nothing else enforces it, and editing
- * either side alone compiles clean.
- *
- * Behavioural rather than field-by-field, so it needs no reflection - which common Kotlin cannot rely on
- * across thirteen targets - and so it covers defaults added after this file was written. Feed both stats
- * the same stream and their reads must agree.
- *
- * `ReservoirHistogram` is excluded: its stat defaults the seed to `Random.Default.nextLong()`, so two
- * instances legitimately disagree.
- */
+// `schema/spec/Stats.kt` declares that spec defaults match the underlying stat's primary constructor,
+// so authored payloads stay terse under `encodeDefaults = false`. Nothing else enforces it, and editing
+// either side alone compiles clean.
+//
+// The comparison is behavioural rather than field-by-field, so it needs no reflection - which common
+// Kotlin cannot rely on across thirteen targets - and so it covers defaults added later.
+//
+// `ReservoirHistogram` is excluded: its stat defaults the seed to `Random.Default.nextLong()`, so two
+// instances legitimately disagree.
 class SpecDefaultParityTest {
 
     private val values = doubleArrayOf(0.1, 1.2, 3.7, 0.5, 2.8, 1.0, 4.5, 0.3, 2.1, 1.7, 3.0, 0.8)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatSchemaConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatSchemaConcurrencyTest.kt
@@ -11,12 +11,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Schemas are pure description; the deployment-knob [Concurrency] flows
- * through `config.materialize(schema.concurrency)` inside the
- * `*StatGroup(schema)` / `*ListStats(schema)` constructors. These tests
- * assert post-materialize concurrency propagates correctly.
- */
+// Schemas are pure description; the deployment-knob [Concurrency] flows through
+// `config.materialize(schema.concurrency)` inside the `*StatGroup(schema)` / `*ListStats(schema)`
+// constructors.
 class StatSchemaConcurrencyTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
@@ -18,12 +18,8 @@ import com.eignex.skema.SchemaJson
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 import kotlin.test.assertEquals
-/**
- * Round-trip tests for every [StatSpec]. For each modality, build a schema
- * with a config-only entry, encode, decode, materialize, drive a small fixed
- * input through both the original live stat and the rehydrated stat, and
- * compare results.
- */
+// For each modality: build a schema with a config-only entry, encode, decode, materialize, drive a
+// small fixed input through both the original live stat and the rehydrated stat, and compare results.
 class StatsRoundTripTest {
 
     private inline fun <reified C : StatSpec> roundTrip(config: C): C {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/GaussianScorerStatTest.kt
@@ -22,7 +22,6 @@ class GaussianScorerStatTest {
     @Test
     fun `score grows with deviation from the running mean`() {
         val s = GaussianScorerStat()
-        // Calibrate distribution around mean 0, stdDev ~ 1.
         val samples = doubleArrayOf(-1.0, -0.5, 0.0, 0.0, 0.5, 1.0)
         for (x in samples) s.update(x)
         val r = s.read()

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
@@ -25,7 +25,6 @@ class HalfSpaceTreesStatTest {
             randomSeed = 7,
         )
         val rng = Random(11L)
-        // Build up a reference window of inliers clustered around (3, 3).
         repeat(400) {
             stat.update(doubleArrayOf(3.0 + rng.nextDouble() * 0.5, 3.0 + rng.nextDouble() * 0.5))
         }
@@ -51,9 +50,7 @@ class HalfSpaceTreesStatTest {
         assertEquals(2, r.height)
         assertEquals(3 * 3, r.featureIndices.size) // numTrees * (2^height - 1)
         assertEquals(3 * 4, r.referenceMass.size) // numTrees * 2^height
-        // All feature indices are within range.
         for (f in r.featureIndices) assertTrue(f in 0 until 2, "feature index out of range: $f")
-        // All thresholds fall within configured per-feature ranges.
         for (i in r.thresholds.indices) {
             val f = r.featureIndices[i]
             val range = ranges[f]

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStatTest.kt
@@ -27,7 +27,6 @@ class IsotonicCalibratorStatTest {
                 "non-monotone at $i: ${r.probabilities[i - 1]} -> ${r.probabilities[i]}",
             )
         }
-        // Endpoint sanity: small raw scores map low, large raw scores map high.
         assertTrue(r.calibrate(0.05) < r.calibrate(0.95))
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStatTest.kt
@@ -18,8 +18,7 @@ class PlattCalibratorStatTest {
 
     @Test
     fun `learns a monotone mapping from raw scores to labels`() {
-        // Underlying truth: label is more likely as raw score grows. Calibrator should
-        // converge to a positive slope.
+        // Underlying truth: the label is more likely as the raw score grows.
         val stat = PlattCalibratorStat()
         val rng = Random(7L)
         repeat(5000) {
@@ -30,7 +29,6 @@ class PlattCalibratorStatTest {
         }
         val r = stat.read()
         assertTrue(r.slope > 0.0, "slope=${r.slope} should be positive")
-        // Calibrated probability at the top of the range should beat the bottom.
         assertTrue(r.calibrate(0.9) > r.calibrate(0.1))
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/cardinality/LinearCountingStatTest.kt
@@ -44,7 +44,6 @@ class LinearCountingStatTest {
     @Test
     fun `saturated bitset returns positive infinity`() {
         val lc = LinearCountingStat(bits = 64)
-        // Push enough distinct values to set every bit.
         for (i in 1L..10_000L) lc.update(i)
         val r = lc.read()
         assertEquals(Double.POSITIVE_INFINITY, r.estimate)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinStatTest.kt
@@ -36,20 +36,17 @@ class AdwinStatTest {
         repeat(2_000) { s.update(rng.nextDouble()) }
         val r = s.read()
         assertEquals(0L, r.changesDetected)
-        // Window should contain a large fraction of the observations.
         assertTrue(r.windowLength > 1_500L, "windowLength=${r.windowLength}")
     }
 
     @Test
     fun `sudden mean shift triggers a change and shrinks the window`() {
         val s = AdwinStat()
-        // 500 observations near 0, then 500 near 1 - a clear shift.
         val rng = Random(7)
         repeat(500) { s.update(rng.nextDouble() * 0.05) }
         repeat(500) { s.update(0.95 + rng.nextDouble() * 0.05) }
         val r = s.read()
         assertTrue(r.changesDetected > 0L, "no change detected")
-        // After the shift the window should be smaller than the full stream.
         assertTrue(r.windowLength < 1_000L, "windowLength=${r.windowLength}")
         // The remaining window should have moved noticeably toward the post-shift mean (~0.975)
         // even if some pre-shift residue remains in the largest still-active bucket.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinWindowTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/AdwinWindowTest.kt
@@ -4,12 +4,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * ADWIN's window has to stay a *suffix* of the stream: whatever it keeps must be the most recent
- * observations, never a scrambled mix. The bucket rows encode that ordering, and getting it wrong is
- * invisible in the window length while making the reported mean describe data the stream has moved
- * past.
- */
+// ADWIN's window has to stay a suffix of the stream, and the bucket rows encode that ordering.
+// Getting it wrong is invisible in the window length while the reported mean describes data the
+// stream has moved past.
 class AdwinWindowTest {
 
     @Test
@@ -22,8 +19,7 @@ class AdwinWindowTest {
         val r = stat.read()
 
         // Every one of the last 600 observations was 0.0, so any window that is a suffix of the
-        // stream must have mean 0. The buckets used to come back reverse-ordered, leaving samples
-        // from the abandoned 10.0 regime inside the window and reporting a mean of 1.43.
+        // stream must have mean 0.
         assertEquals(0.0, r.mean, 1e-9, "window of length ${r.windowLength} still holds stale data")
         assertEquals(0.0, r.variance, 1e-9)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/ChangeStatMergeAdoptionTest.kt
@@ -5,14 +5,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * A fresh change detector adopts a merged snapshot rather than averaging against its own zero.
- *
- * Both stats merge approximately by averaging the drift cells, which is only meaningful between two walks
- * that both happened; against an empty stat the other operand is a zero no observation produced. That
- * matters because `alarmUp` thresholds on the cumulative sum directly, so a halved drift needs twice the
- * real shift to fire, while the baselines merge exactly and keep the numbers looking plausible.
- */
+// Both stats merge approximately by averaging the drift cells, which is only meaningful between two
+// walks that both happened; against an empty stat the other operand is a zero no observation
+// produced, and `alarmUp` thresholds on the cumulative sum directly.
 class ChangeStatMergeAdoptionTest {
 
     private fun cusumSnapshot(): CusumResult {
@@ -36,11 +31,9 @@ class ChangeStatMergeAdoptionTest {
 
     @Test
     fun `a merged snapshot still raises the alarm it raised on the worker`() {
-        // The consequence a caller would actually hit, and the reason the halving mattered.
-        //
         // The threshold is deliberately picked to sit between the real drift and half of it, or the
-        // test proves nothing: at a low threshold even a halved sum still alarms, and the assertion
-        // passes on the unfixed code. The worker's drift is 20 * (2.0 - 0.5) = 30.
+        // test proves nothing: at a low threshold even a halved sum still alarms. The worker's drift
+        // is 20 * (2.0 - 0.5) = 30.
         val worker = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 20.0)
         repeat(20) { worker.update(2.0) }
         val snapshot = worker.read()
@@ -56,7 +49,7 @@ class ChangeStatMergeAdoptionTest {
     @Test
     fun `a non-empty CusumStat still averages`() {
         // Guards the rule above: adopting unconditionally would satisfy both tests and break the
-        // documented approximate-merge behaviour for the case it was written for.
+        // documented approximate-merge behaviour.
         val a = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
         repeat(20) { a.update(2.0) }
         val own = a.read().cusumPositive
@@ -69,7 +62,7 @@ class ChangeStatMergeAdoptionTest {
 
     @Test
     fun `an empty CusumStat that has been reset adopts again`() {
-        // reset() has to clear the new initialized cell too, or a reused coordinator keeps halving.
+        // reset() has to clear the initialized cell too, or a reused coordinator keeps halving.
         val coordinator = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
         repeat(20) { coordinator.update(2.0) }
         coordinator.reset()
@@ -80,13 +73,8 @@ class ChangeStatMergeAdoptionTest {
         assertEquals(snapshot.cusumPositive, coordinator.read().cusumPositive, DELTA, "reset left it primed")
     }
 
-    /**
-     * A level shift, not a constant stream.
-     *
-     * Page-Hinkley subtracts its own running mean, so a constant input drifts nowhere - the mean
-     * converges on the value and every deviation is zero. The drift only accumulates once the input
-     * departs from the history the mean was built on.
-     */
+    // A level shift, not a constant stream: Page-Hinkley subtracts its own running mean, so a
+    // constant input drifts nowhere.
     private fun pageHinkleySnapshot(): PageHinkleyResult {
         val worker = PageHinkleyStat(delta = 0.005, threshold = 50.0)
         repeat(60) { worker.update(0.0) }
@@ -105,8 +93,7 @@ class ChangeStatMergeAdoptionTest {
         val merged = coordinator.read()
         assertEquals(snapshot.cumulativePositive, merged.cumulativePositive, DELTA, "the drift was halved")
         assertEquals(snapshot.cumulativeNegative, merged.cumulativeNegative, DELTA, "the drift was halved")
-        // The mean already adopted correctly, because a localCount of zero weights it out. Pinned so
-        // the fix is visibly about the two cells that did not.
+        // The mean adopts on its own, because a localCount of zero weights it out.
         assertEquals(snapshot.mean, merged.mean, DELTA, "the mean should always have adopted")
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayEdgeCaseTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayEdgeCaseTest.kt
@@ -9,20 +9,16 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * Edge cases at the ends of the decay family's parameter and time ranges, where the arithmetic
- * stops being well conditioned: half-lives long enough to overflow the rotation threshold, short
- * enough to truncate to zero, timestamps that arrive out of order, and reads so late that the
- * shared decay factor has underflowed to zero.
- */
+// Edge cases at the ends of the decay family's parameter and time ranges, where the arithmetic
+// stops being well conditioned.
 class DecayEdgeCaseTest {
 
     private val t0 = 1_000_000_000L
 
     @Test
     fun `a half-life too long to fit the rotation threshold still updates`() {
-        // halfLife * 50 overflows Long above ~2135 days. It used to wrap negative, which made the
-        // rotation test true for every dt and span update() forever.
+        // halfLife * 50 overflows Long above ~2135 days; a wrapped negative threshold makes the
+        // rotation test true for every dt.
         for (halfLife in listOf(2136.days, 3650.days, Duration.INFINITE)) {
             val stat = DecayingSumStat(halfLife = halfLife)
 
@@ -81,7 +77,6 @@ class DecayEdgeCaseTest {
             variance.update(10.0, t0, 1.0)
         }
 
-        // Both used to be reachable here; mean reported NaN and variance reported 0.0.
         assertEquals(0.0, mean.read(t0).mean)
         assertEquals(0.0, variance.read(t0).mean)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayStatConcurrencyTest.kt
@@ -6,8 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
-/** Cross-mode smoke tests for decay stats; math must match across modes under
- *  sequential single-threaded updates. */
 class DecayStatConcurrencyTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/EventStatConcurrencyTest.kt
@@ -6,10 +6,6 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.weightedReads
 import kotlin.test.Test
 
-/**
- * Cross-mode smoke tests for the event family: each stat should produce identical math
- * under sequential single-threaded updates regardless of the [Concurrency] mode chosen.
- */
 class EventStatConcurrencyTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastMergeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastMergeTest.kt
@@ -4,11 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Rolling worker snapshots up into a fresh coordinator stat. None of the three smoothing stats has a
- * principled merge of two independent traces, but all three must at least adopt the first snapshot
- * verbatim rather than averaging it against their own empty state.
- */
+// None of the three smoothing stats has a principled merge of two independent traces, but all three
+// must at least adopt the first snapshot verbatim rather than averaging it against an empty state.
 class ForecastMergeTest {
 
     @Test
@@ -20,7 +17,6 @@ class ForecastMergeTest {
         val fresh = source.create()
         fresh.merge(source.read())
 
-        // This used to average against the fresh stat's 0.0 and halve the contribution.
         assertEquals(expected, fresh.read().variance, 1e-12)
     }
 
@@ -59,8 +55,8 @@ class ForecastMergeTest {
 
         a.merge(b.read())
 
-        // The averaged factors came from b, so the slot has to be b's too; keeping a's silently
-        // paired the factors with a mismatched phase.
+        // The averaged factors came from b, so the slot has to be b's too or the factors sit against
+        // a mismatched phase.
         assertEquals(target, a.read().currentSlot)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/ForecastStatConcurrencyTest.kt
@@ -5,7 +5,6 @@ import com.eignex.kumulant.timedReads
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/** Cross-mode smoke tests for the forecast family. */
 class ForecastStatConcurrencyTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchNaNTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchNaNTest.kt
@@ -9,14 +9,9 @@ import com.eignex.kumulant.schema.spec.DDSketch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * What a NaN does to a bucketing stat, and how a caller opts out.
- *
- * A NaN has no rank, so there is no bin that belongs to it: it falls through the sign comparisons in
- * `update` into the zero bucket and drags every quantile toward zero. The library does not filter
- * that away - see `Stat` for why a NaN value propagates rather than being silently discarded - so
- * this test pins both halves: the damage is real, and `filter(!X.isNaN())` is what prevents it.
- */
+// A NaN has no rank, so no bin belongs to it: it falls through the sign comparisons in `update` into
+// the zero bucket and drags every quantile toward zero. See `Stat` for why the library propagates a
+// NaN value rather than silently discarding it.
 class DDSketchNaNTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/DDSketchTest.kt
@@ -12,8 +12,8 @@ class DDSketchTest {
     fun `empty sketch returns NaN quantiles`() {
         val sketch = DDSketchStat(probabilities = doubleArrayOf(0.5, 0.9))
         val r = sketch.read()
-        // NaN, not 0.0: a zero-filled array is indistinguishable from a sketch that observed
-        // real zeros, so an untouched sketch used to report a p99 that read as healthy.
+        // NaN, not 0.0: a zero-filled array is indistinguishable from a sketch that observed real
+        // zeros, making an untouched sketch's p99 read as healthy.
         assertTrue(r.quantiles[0].isNaN(), "p50 was ${r.quantiles[0]}")
         assertTrue(r.quantiles[1].isNaN(), "p90 was ${r.quantiles[1]}")
         assertEquals(0.0, r.totalWeights)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateResetTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateResetTest.kt
@@ -4,10 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * A counter rate divides an accumulated total by a window, so the two have to describe the same
- * span. Both bugs here came from letting one move without the other.
- */
+// A counter rate divides an accumulated total by a window, so the two have to describe the same span.
 class CounterRateResetTest {
 
     private val second = 1_000_000_000L
@@ -20,9 +17,8 @@ class CounterRateResetTest {
 
         stat.update(5.0, 10 * second + second / 2) // counter restarted
 
-        // The window now starts at the restart, so the total must describe the post-restart span
-        // only: 5 units over 0.5s. It used to keep all 105 pre-reset units and divide those by the
-        // half-second, reporting 210/s.
+        // The window starts at the restart, so the total must describe the post-restart span
+        // only: 5 units over 0.5s.
         val rate = stat.read(11 * second).rate
         assertTrue(rate in 8.0..12.0, "expected roughly 10 events/s after the reset, got $rate")
     }
@@ -39,8 +35,6 @@ class CounterRateResetTest {
         without.update(10.0, second, 1.0)
         without.update(10.0, 2 * second, 1.0)
 
-        // The zero-weight call used to advance the high-water mark without accumulating, so the
-        // increment was lost for good and the total came out 0.0 instead of 10.0.
         assertEquals(
             without.read(3 * second).totalValue,
             withZero.read(3 * second).totalValue,
@@ -51,8 +45,7 @@ class CounterRateResetTest {
 
     @Test
     fun `a rate with a large negative start timestamp does not silently report zero`() {
-        // The Long subtraction used to overflow here and the duration guard read the wrapped value
-        // as non-positive.
+        // The Long subtraction overflows here, and a wrapped duration reads as non-positive.
         val result = RateResult(startTimestampNanos = Long.MIN_VALUE + 1, totalValue = 100.0, timestampNanos = second)
 
         assertTrue(result.rate > 0.0, "overflowed duration reported rate ${result.rate}")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerDirectTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerDirectTest.kt
@@ -42,7 +42,6 @@ class OptimizerDirectTest {
         // Second hit on coord 0 accumulates: acc = 4 + 9 = 13
         val d2 = opt.computeDelta(0, gradient = 3.0, observationWeight = 1.0)
         approx(-1.0 * 3.0 / sqrt(13.0 + 1e-10), d2)
-        // Coord 1 untouched
         val d3 = opt.computeDelta(1, gradient = 1.0, observationWeight = 1.0)
         approx(-1.0 * 1.0 / sqrt(1.0 + 1e-10), d3)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
@@ -16,15 +16,9 @@ import kotlin.test.assertTrue
 
 private const val FEATURES = 3
 
-/**
- * Arity of the context vector, swept across the regression catalogue.
- *
- * A wrong-arity vector is the one input error that does not announce itself: a *short* vector reads
- * fewer coordinates and returns a perfectly plausible number from the wrong model, so a caller that
- * reshapes its features and forgets to reshape the stat gets silently degraded predictions rather than
- * an error. Every stat here guards its `update`, but the guard used to be fourteen hand-written copies
- * of the same `require`; this sweep is what stops one of them going missing when a stat is added.
- */
+// A wrong-arity vector is the one input error that does not announce itself: a *short* vector reads
+// fewer coordinates and returns a perfectly plausible number from the wrong model. Swept across the
+// catalogue so a stat added later cannot go missing its guard.
 class RegressionArityGuardTest {
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
@@ -64,8 +58,7 @@ class RegressionArityGuardTest {
     @Test
     fun `the rejection names both the size it got and the size it wanted`() {
         // Pinned because the message is the only thing that tells a caller which of the two numbers to
-        // change, and because RegressionOpsTest greps it. requireFeatureSize keeps the wording that the
-        // hand-written copies had for exactly this reason.
+        // change, and because RegressionOpsTest greps it.
         for ((name, stat) in stats) {
             val thrown = runCatching {
                 stat.update(DenseVector.of(doubleArrayOf(1.0)), 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
@@ -14,10 +14,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * Model merges and out-of-domain labels. The theme is that a model must not silently get *worse* by
- * folding in a snapshot that carries no information, and must not train on a label that is not one.
- */
+// A model must not silently get *worse* by folding in a snapshot that carries no information, and
+// must not train on a label that is not one.
 class RegressionMergeGuardTest {
 
     private val splits = listOf(ThresholdSplit(0, 4.5))
@@ -31,9 +29,8 @@ class RegressionMergeGuardTest {
         repeat(20) { stat.merge(DiagonalRegressionStat(featureSize = 1).read()) }
 
         val after = stat.read()
-        // Every replica seeds its precision at priorPrecision, so pooling additively counted the
-        // prior once per merge: this used to shift the weight 39% toward zero and inflate precision
-        // from 31 to 51 while folding in snapshots that contained no data at all.
+        // Every replica seeds its precision at priorPrecision, so an additive pool would count the
+        // prior once per merge while folding in snapshots that contain no data at all.
         assertEquals(before.weights[0], after.weights[0], 1e-9, "an empty snapshot moved the weights")
         assertEquals(before.precision[0], after.precision[0], 1e-9, "an empty snapshot moved the precision")
         assertEquals(before.totalWeights, after.totalWeights, 1e-9)
@@ -66,8 +63,8 @@ class RegressionMergeGuardTest {
         val target = source.create()
         target.merge(source.read())
 
-        // The reference window is what score() reads, so folding into the latest window alone left a
-        // merged model scoring every input maximally anomalous while reporting the source's weight.
+        // The reference window is what score() reads, so folding into the latest window alone would
+        // leave a merged model scoring every input maximally anomalous.
         val mergedScore = target.read().score(DenseVector.of(doubleArrayOf(0.5)))
         assertTrue(mergedScore > 0.0, "a merged model scored $mergedScore, i.e. maximally anomalous")
         assertEquals(sourceScore, mergedScore, sourceScore * 1e-9)
@@ -76,8 +73,7 @@ class RegressionMergeGuardTest {
     @Test
     fun `an absurd half-space-trees height is rejected at construction`() {
         val ranges = List(1) { FeatureRange(0.0, 1.0) }
-        // 31 wrapped `1 shl height` negative and 32 wrapped it to 1, so one threw OutOfMemoryError in
-        // the constructor and the other threw ArrayIndexOutOfBounds on the first update.
+        // 31 wraps `1 shl height` negative and 32 wraps it to 1, so neither can allocate a node array.
         assertFailsWith<IllegalArgumentException> {
             HalfSpaceTreesStat(featureSize = 1, featureRanges = ranges, height = 31)
         }
@@ -96,7 +92,8 @@ class RegressionMergeGuardTest {
         softmax.update(doubleArrayOf(100.0), Double.NaN)
         softmax.update(doubleArrayOf(100.0), -0.7)
 
-        // toInt() truncates toward zero, so both used to land in class 0 and pass the range check.
+        // toInt() truncates toward zero, so an unguarded label would land in class 0 and pass the
+        // range check.
         assertEquals(0.0, gnb.read().totalWeights, "GaussianNaiveBayes trained on a non-label")
         assertEquals(0.0, softmax.read().totalWeights, "SoftmaxRegression trained on a non-label")
     }
@@ -113,8 +110,8 @@ class RegressionMergeGuardTest {
             probed.update(x, y, 1.0)
         }
 
-        // Each zero-weight call used to draw once per tree from baggingRng, desynchronising every
-        // later draw and changing the forest's predictions.
+        // A zero-weight call that drew once per tree from baggingRng would desynchronise every later
+        // draw and change the forest's predictions.
         val at = DenseVector.of(doubleArrayOf(3.0))
         assertEquals(clean.read().predict(at), probed.read().predict(at), 1e-12)
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -17,34 +17,18 @@ import kotlin.test.assertTrue
 private const val FEATURES = 2
 private const val CLASSES = 2
 
-/**
- * The weight contract and the non-finite value guarantee, over the regression modality.
- *
- * The series, paired, and discrete modalities each have a contract sweep. Regression had none, which is
- * how it stayed the modality where nobody had checked what a non-finite input does to a model - and
- * unlike a histogram bucket, a model absorbs one into state that no later observation can clean.
- *
- * The two halves are deliberately different in strength. A non-finite *weight* must be inert, because a
- * weight is a multiplicity and an infinity is not one. A non-finite *value* only has to not throw: it may
- * poison the model, because the observation really did arrive and really was unusable, and `filterFinite()`
- * is how a caller declines to see such observations at all.
- */
+// The two halves are deliberately different in strength. A non-finite *weight* must be inert, because
+// a weight is a multiplicity and an infinity is not one. A non-finite *value* only has to not throw: it
+// may poison the model, because the observation really did arrive and really was unusable, and
+// `filterFinite()` is how a caller declines to see such observations at all.
 class RegressionWeightContractTest {
 
-    /**
-     * One model, with a way to train it and a way to read its learned numbers back.
-     *
-     * The snapshot reads fields explicitly rather than stringifying the result, and that is not
-     * fastidiousness: `ClassCountsResult` holds a `DoubleArray`, whose `toString` is an identity hash, so
-     * a stringified tree snapshot differs from itself on every read. An earlier version of this test did
-     * exactly that and passed on the JVM while proving nothing. Kotlin/JS renders arrays differently and
-     * failed honestly, which is the second time in this work that JS caught a vacuous JVM assertion.
-     */
+    // `snapshot` reads fields explicitly rather than stringifying the result: `ClassCountsResult` holds
+    // a `DoubleArray`, whose `toString` is an identity hash, so a stringified tree snapshot would differ
+    // from itself on every read.
     private class Model(
         val name: String,
-        /** The y this model expects: a target for the regressors, a class label for the classifiers. */
         val y: Double,
-        /** Full entry point, so the feature vector and the y can be varied as well as the weight. */
         val update: (VectorView, Double, Double) -> Unit,
         val snapshot: () -> String,
     )
@@ -113,10 +97,8 @@ class RegressionWeightContractTest {
 
     @Test
     fun `an inert weight leaves every model untouched`() {
-        // Zero, NaN, and both infinities. The infinities are the ones that were unguarded:
-        // `isInertWeight` tested only zero and NaN, and `+Infinity > 0.0` is true, so
-        // `isNotPositiveWeight` let an infinite weight through as an ordinary live observation and into
-        // the gradient step.
+        // Zero, NaN, and both infinities. The infinities are the subtle ones: `+Infinity > 0.0` is
+        // true, so a positivity test alone lets one through as an ordinary live observation.
         val inert = doubleArrayOf(0.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
         val violations = mutableListOf<String>()
         for (weight in inert) {
@@ -138,11 +120,8 @@ class RegressionWeightContractTest {
 
     @Test
     fun `no weight puts a non-finite number into a model`() {
-        // Stated in terms of what a caller sees, and the reason this modality matters most: a NaN in a
-        // weight vector is permanent. Every later update multiplies it forward, so unlike a bad quantile
-        // bucket there is no recovery and no way for the caller to tell the model is dead. An infinity is
-        // no better, because it looks like a number a caller might trust and becomes NaN on the next
-        // update via Infinity minus Infinity.
+        // A NaN in a weight vector is permanent: every later update multiplies it forward, so unlike a
+        // bad quantile bucket there is no recovery and no way for the caller to tell the model is dead.
         val weights = doubleArrayOf(0.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -1.0)
         val violations = mutableListOf<String>()
         for (weight in weights) {
@@ -167,10 +146,8 @@ class RegressionWeightContractTest {
 
     @Test
     fun `a non-finite feature or target never throws`() {
-        // The one guarantee the library makes about a non-finite value, over the modality that had no
-        // sweep at all. It is explicitly allowed to poison the model - and it does, permanently, because
-        // every later gradient step multiplies the NaN forward - but it must not become an exception.
-        // A caller who needs the guarantee to be stronger than that uses `filterFinite()`.
+        // A non-finite value is explicitly allowed to poison the model, but must not become an
+        // exception. A caller who needs a stronger guarantee uses `filterFinite()`.
         val nonFinite = doubleArrayOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
         val violations = mutableListOf<String>()
         for (bad in nonFinite) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
@@ -23,11 +23,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * End-to-end checks for the sealed VectorView abstraction: sparse inputs flow through
- * regression-stat updates without materialisation, and snapshots round-trip through
- * kotlinx.serialization preserving the concrete dense/sparse subtype.
- */
 private inline fun mean(n: Int, draw: () -> Double): Double {
     var s = 0.0
     repeat(n) { s += draw() }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianDenomGuardTest.kt
@@ -5,14 +5,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The SMW downdate refuses an observation whose scale factor is not a usable number.
- *
- * `Link.Log.curvature` is `exp(eta)`, which overflows to `+Infinity` for a large linear predictor, making
- * the scale factor `Infinity / Infinity`. Every input below is finite, so the NaN is manufactured by the
- * stat's own arithmetic rather than propagated - and it would land in the covariance, which every later
- * prediction reads through.
- */
+// `Link.Log.curvature` is `exp(eta)`, which overflows to `+Infinity` for a large linear predictor,
+// making the scale factor `Infinity / Infinity`. Every input below is finite, so the NaN is
+// manufactured by the stat's own arithmetic rather than propagated.
 class BayesianDenomGuardTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -9,11 +9,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-/**
- * Custom prior + empirical-Bayes population fitting for [BayesianRegressionStat].
- * The custom prior is what lets klause persist a posterior across solver calls -
- * the previous read() snapshot is fed back in as the next instance's prior.
- */
+
+// The custom prior is what lets klause persist a posterior across solver calls: an earlier read()
+// snapshot is fed back in as the next instance's prior.
 class BayesianRegressionStatPriorTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
@@ -22,11 +22,8 @@ class HierarchicalBayesianRegressionTest {
         val pop = HierarchicalBayesianRegression(featureSize = 3, initialPriorVariance = 2.0)
         val prior = pop.populationPrior
         assertEquals(3, prior.mean.size)
-        // Default mean is zero
         for (i in 0 until 3) assertEquals(0.0, prior.mean[i])
-        // Diagonal = 2.0
         for (i in 0 until 3) assertEquals(2.0, prior.covariance[i, i])
-        // Off-diagonals = 0
         for (i in 0 until 3) {
             for (j in 0 until 3) {
                 if (i != j) assertEquals(0.0, prior.covariance[i, j])
@@ -40,10 +37,8 @@ class HierarchicalBayesianRegressionTest {
         val pop = HierarchicalBayesianRegression(featureSize = 2, initialPriorVariance = 5.0)
         val inst = pop.createInstance()
         val snap = inst.read()
-        // Fresh instance: weights start at prior mean (zeros)
         assertEquals(0.0, snap.weights[0])
         assertEquals(0.0, snap.weights[1])
-        // And totalWeights is 0 (no observations folded in yet)
         assertEquals(0.0, snap.totalWeights)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -156,7 +156,6 @@ class LinearPosteriorsTest {
         val alpha = 2.0
         val score = LinUcb.evaluate(snap, x, Random(0), exploration = alpha)
         val mean = snap.predict(x)
-        // Bound check: score should strictly exceed the mean for non-zero alpha and non-degenerate covariance.
         assertTrue(score > mean, "LinUcb should add positive UCB term; score=$score, mean=$mean")
     }
 
@@ -166,7 +165,6 @@ class LinearPosteriorsTest {
         val draw1 = LinUcb.sample(snap, Random(0)).toDoubleArray()
         val draw2 = LinUcb.sample(snap, Random(99)).toDoubleArray()
         assertTrue(draw1.contentEquals(draw2), "LinUcb sample is deterministic")
-        // And matches the snapshot's weights
         val w = snap.weights.toDoubleArray()
         assertTrue(draw1.contentEquals(w), "LinUcb sample returns snap.weights")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/SoftThresholdTest.kt
@@ -5,9 +5,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The shared L1 proximal operator, and the one case where the three copies it replaces disagreed.
- */
 class SoftThresholdTest {
 
     @Test
@@ -36,10 +33,9 @@ class SoftThresholdTest {
     fun `a negative threshold leaves the coefficient alone instead of growing it`() {
         // Penalty.L1 puts no positivity requirement on lambda, and every host multiplies lambda by
         // something positive to get its threshold, so a negative threshold is reachable from a
-        // negative lambda. Two of the three copies of this operator lacked the guard, and without it
-        // the branches read inside out: at w = 0.0 and threshold = -0.5 the first comparison matches
-        // and returns +0.5, so a negative lambda pushed coefficients *away* from zero. Shrinking by a
-        // negative amount is not shrinking, so the penalty does nothing at all.
+        // negative lambda. Without the guard the branches read inside out: at w = 0.0 and
+        // threshold = -0.5 the first comparison matches and returns +0.5, pushing coefficients *away*
+        // from zero.
         assertEquals(0.0, softThreshold(0.0, -0.5), DELTA)
         assertEquals(1.0, softThreshold(1.0, -0.5), DELTA)
         assertEquals(-1.0, softThreshold(-1.0, -0.5), DELTA)
@@ -66,10 +62,7 @@ class SoftThresholdTest {
 
     @Test
     fun `the three hosts now agree on a negative lambda`() {
-        // The behaviour this extraction changed, pinned end to end rather than on the helper alone.
-        // The univariate and diagonal fits used to grow their coefficients under a negative lambda
-        // while the stochastic fit ignored it; all three now ignore it. A negative lambda remains a
-        // caller error - this only settles what happens when one is passed.
+        // A negative lambda remains a caller error; this only settles what happens when one is passed.
         val univariate = UnivariateRegressionStat(penalty = Penalty.L1(lambda = -1.0))
         val unpenalised = UnivariateRegressionStat()
         repeat(6) { i ->
@@ -99,8 +92,7 @@ class SoftThresholdTest {
 
     @Test
     fun `a positive lambda still shrinks each host`() {
-        // Guards the guard: if the negative case now no-ops, the positive case has to still bite, or
-        // the change above would have quietly disabled L1 everywhere.
+        // Guards the guard: with the negative case a no-op, the positive case has to still bite.
         val penalised = UnivariateRegressionStat(penalty = Penalty.L1(lambda = 0.5))
         val unpenalised = UnivariateRegressionStat()
         repeat(6) { i ->

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
@@ -3,9 +3,6 @@ package com.eignex.kumulant.stat.regression.tree
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * Breiman's `ceil(sqrt(p))` subspace default, which both forests previously computed for themselves.
- */
 class DefaultMtryTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -5,25 +5,13 @@ import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * Pins the behaviour the shared [TreeGrowth] engine must not change: the regression and classification
- * trees grow the *same* tree from the same stream.
- *
- * Both are fed identical rows, with the regression target being the 0/1 class label as a Double. On binary
- * labels the two split criteria are proportional (Bernoulli variance is exactly half the Gini impurity),
- * so the candidate ranking is identical and both trees must reach the same structure: the same node count,
- * the same split predicate at every internal node, and the same total weight.
- *
- * Nothing else in the suite compares the two trees against each other, so this is the only guard on the
- * shared engine treating its two instantiations alike.
- */
+// Both trees are fed identical rows, with the regression target being the 0/1 class label as a Double.
+// On binary labels the two split criteria are proportional (Bernoulli variance is exactly half the Gini
+// impurity), so the candidate ranking is identical and both trees must reach the same structure.
 class TreeGrowthParityTest {
 
-    /**
-     * Row pattern: feature 0 decides the label for three quarters of the stream, feature 1 resolves the
-     * remaining quarter. That makes feature 0 the strictly better root candidate and feature 1 the only
-     * useful candidate below it, so the grown tree is a root split, one nested split, and three leaves.
-     */
+    // Feature 0 decides the label for three quarters of the stream, feature 1 resolves the remaining
+    // quarter, so the grown tree is a root split, one nested split, and three leaves.
     private val rows = listOf(
         feat(1.0, 0.0) to 1,
         feat(1.0, 0.0) to 1,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
@@ -8,9 +8,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The growth helpers both VFDT trees share, which each tree used to keep its own copy of.
- */
 class TreeInternalsTest {
 
     @Test
@@ -183,7 +180,6 @@ class TreeInternalsTest {
     @Test
     fun `a leaf with no qualifying candidate does not split`() {
         val config = ClassificationTreeConfig()
-        // Nothing scored at all.
         assertEquals(false, shouldSplit(SplitInfo(0.0, 0.0, -1), 1000.0, 0, config))
         // Something scored, but no better than not splitting; every metric returns 0 for no signal.
         assertEquals(false, shouldSplit(SplitInfo(0.0, 0.0, 2), 1000.0, 0, config))
@@ -225,8 +221,7 @@ class TreeInternalsTest {
 
     @Test
     fun `both trees reach the same decision from the same evidence`() {
-        // The point of sharing it. Identical tunables in both config types must produce identical
-        // verdicts, which is exactly what two hand-written copies of the rule could not guarantee.
+        // Identical tunables in both config types must produce identical verdicts.
         val cases = listOf(
             SplitInfo(10.0, 0.0, 0),
             SplitInfo(0.0, 0.0, -1),

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResultTest.kt
@@ -53,7 +53,6 @@ class TreeRegressionResultTest {
 
     @Test
     fun `RegressionNode snapshot freezes structure`() {
-        // Verify snapshot round-trip preserves split predicates and leaf values.
         val live = RegressionTree(
             splitCandidates = listOf(ThresholdSplit(0, 0.0)),
             config = RegressionTreeConfig(splitPeriod = 4, minSamplesSplit = 4.0, minSamplesLeaf = 2.0),

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/AccuracyStatTest.kt
@@ -81,8 +81,7 @@ class AccuracyStatTest {
 
     @Test
     fun `a class count below two is refused`() {
-        // One class is not a classification problem, and the counters used to accept it while every
-        // model required two. A binary problem is `numClasses = 2`.
+        // One class is not a classification problem; a binary problem is `numClasses = 2`.
         assertFailsWith<IllegalArgumentException> { AccuracyStat(numClasses = 0) }
         assertFailsWith<IllegalArgumentException> { AccuracyStat(numClasses = 1) }
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SketchMergeGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SketchMergeGuardTest.kt
@@ -10,11 +10,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * Merging hashed sketches across mixers. Every one of these produces a plausible-looking but wrong
- * answer rather than an error, so each sketch has to refuse the merge outright: the mixer decides
- * which cell a key touches, and once the cells disagree the counts are meaningless.
- */
+// The mixer decides which cell a key touches, so once the cells disagree the merged counts are
+// meaningless in a plausible-looking way rather than an obviously wrong one.
 class SketchMergeGuardTest {
 
     /** A second registered mixer, distinguishable from the default only by name. */
@@ -39,8 +36,8 @@ class SketchMergeGuardTest {
         other.update(42L)
         val receiver = BloomFilterStat(bits = 1024, hashes = 7)
 
-        // Accepting this relabelled the incoming bits as the receiver's, so contains(42) came back
-        // false: a false negative, which is the one thing a Bloom filter promises cannot happen.
+        // Accepting this relabels the incoming bits as the receiver's, producing a false negative -
+        // the one thing a Bloom filter promises cannot happen.
         assertFailsWith<IllegalArgumentException> { receiver.merge(other.read()) }
     }
 
@@ -61,8 +58,8 @@ class SketchMergeGuardTest {
         repeat(100) { other.update(42L) }
         val receiver = CountMinSketchStat(depth = 5, width = 1024)
 
-        // Accepting this put the counts in cells the receiver never probes, so estimate() came back
-        // 0 against a true count of 100 - below the true count, breaking the one-sided guarantee.
+        // Accepting this puts the counts in cells the receiver never probes, so estimate() falls
+        // below the true count and breaks the one-sided guarantee.
         assertFailsWith<IllegalArgumentException> { receiver.merge(other.read()) }
     }
 
@@ -79,8 +76,8 @@ class SketchMergeGuardTest {
 
     @Test
     fun `HyperLogLog LinearCounting and MinHash refuse a merge from a different mixer`() {
-        // These three carried no mixer on the wire at all, so the mismatch could not even be
-        // detected: a union of two identical 10 000-key sets estimated 19 620.
+        // The mixer has to travel on the wire, or the mismatch cannot be detected at all: a union of
+        // two identical 10 000-key sets estimates ~19 620.
         val hll = HyperLogLogStat(precision = 12)
         assertFailsWith<IllegalArgumentException> {
             hll.merge(HyperLogLogStat(precision = 12, hasher = OtherHasher).also { it.update(1L) }.read())
@@ -144,8 +141,7 @@ class SketchMergeGuardTest {
 
     @Test
     fun `a count-min sketch shape that overflows Int is rejected at construction`() {
-        // depth * width is the array length and is computed in Int; this used to construct fine with
-        // a zero-length array and throw on the first update instead.
+        // depth * width is the array length and is computed in Int.
         assertFailsWith<IllegalArgumentException> { CountMinSketchStat(depth = 16, width = 1 shl 28) }
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingAdmissionPolicyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingAdmissionPolicyTest.kt
@@ -5,15 +5,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * A heavy-hitters snapshot says which algorithm produced it and bounds its counts in both directions.
- *
- * The stat runs classic Space-Saving under most levels and a lock-free Misra-Gries variant under
- * [Concurrency.Relaxed], because classic's evict-and-inherit needs a consistent read of the minimum slot.
- * The two bound their counts in opposite directions, and the snapshot used to carry neither the policy nor
- * the Misra-Gries shortfall - so a caller could not tell which guarantee applied, and a mixed merge
- * silently republished counts under the wrong one.
- */
+// The stat runs classic Space-Saving under most levels and a lock-free Misra-Gries variant under
+// Concurrency.Relaxed, because classic's evict-and-inherit needs a consistent read of the minimum
+// slot. The two bound their counts in opposite directions.
 class SpaceSavingAdmissionPolicyTest {
 
     private fun feed(stat: SpaceSavingStat, distinctKeys: Int, perKey: Int) {
@@ -58,8 +52,7 @@ class SpaceSavingAdmissionPolicyTest {
 
     @Test
     fun `misra-gries reports the shortfall its decrements cause`() {
-        // Far more distinct keys than slots, so the table fills and decrement rounds have to run. Without
-        // a deficit the all-zero `errors` array read as "these counts are exact", which they are not.
+        // Far more distinct keys than slots, so the table fills and decrement rounds have to run.
         val stat = SpaceSavingStat(capacity = 4, concurrency = Concurrency.Relaxed)
         feed(stat, distinctKeys = 40, perKey = 2)
 
@@ -71,11 +64,9 @@ class SpaceSavingAdmissionPolicyTest {
 
     @Test
     fun `the reported bounds actually contain the true counts`() {
-        // The point of tracking the deficit. One key is fed heavily and the rest are noise, so the heavy
-        // key survives eviction; its true count must lie inside [count - error, count + deficit].
-        // The two directions are not interchangeable: `errors` is how far a count may sit ABOVE the
-        // truth, so it opens the lower bound, and `deficit` is how far it may sit BELOW, so it opens
-        // the upper one. Swapping that pair is what this assertion caught when it was first written.
+        // One key is fed heavily and the rest are noise, so the heavy key survives eviction. The two
+        // directions are not interchangeable: `errors` is how far a count may sit ABOVE the truth, so
+        // it opens the lower bound, and `deficit` is how far it may sit BELOW, so it opens the upper.
         for (level in listOf(Concurrency.None, Concurrency.Relaxed)) {
             val stat = SpaceSavingStat(capacity = 8, concurrency = level)
             val heavy = 7L

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingTest.kt
@@ -104,9 +104,8 @@ class SpaceSavingTest {
     @Test
     fun `fractional weight rounds up rather than being dropped`() {
         // Mirrors CountMinSketchStat: counts are Long, so a fractional weight has to be rounded, and
-        // it rounds *up*. Rounding to nearest silently discarded everything below 0.5, so a key
-        // accumulating many small weights never appeared among the heavy hitters at all. Counts are
-        // upper bounds as a result, which is the safe direction for a heavy-hitter summary.
+        // it rounds *up*. Rounding to nearest would drop everything below 0.5, hiding a key that
+        // accumulates many small weights. Counts become upper bounds, the safe direction here.
         val ss = SpaceSavingStat(capacity = 5)
         ss.update(7L, weight = 1.7)
         ss.update(7L, weight = 0.6)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MadStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/MadStatTest.kt
@@ -9,8 +9,7 @@ class MadStatTest {
 
     @Test
     fun `read before any update reports NaN estimates`() {
-        // MadStat is built on two TDigestStats, so it inherits their empty-read sentinel. An
-        // empty sample has no median, and reporting 0.0 claimed one.
+        // MadStat is built on two TDigestStats, so it inherits their empty-read sentinel.
         val r = MadStat().read()
         assertTrue(r.median.isNaN(), "median was ${r.median}")
         assertTrue(r.mad.isNaN(), "mad was ${r.mad}")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatConcurrencyTest.kt
@@ -8,12 +8,8 @@ import com.eignex.kumulant.weightedReads
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/**
- * Cross-mode smoke tests: each summary stat should produce identical math under
- * sequential single-threaded updates regardless of the [Concurrency] mode chosen.
- * Catches mode-branch wiring bugs (wrong cell type, missing lock, etc.) cheaply
- * before the bench-side concurrency tests exercise actual contention.
- */
+// Catches mode-branch wiring bugs (wrong cell type, missing lock) cheaply, before the bench-side
+// concurrency tests exercise actual contention.
 class SummaryStatConcurrencyTest {
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/summary/SummaryStatTest.kt
@@ -60,8 +60,8 @@ class SummaryStatTest {
 
     @Test
     fun `a rejected downdate leaves the extrema untouched`() {
-        // The extrema are CAS cells with no inverse, so a throw that happens after they have moved is
-        // unrecoverable: this used to report max = 1000.0 from an update it had just refused.
+        // The extrema are CAS cells with no inverse, so a throw that happens after they have moved
+        // is unrecoverable.
         val s = SummaryStat()
         s.update(5.0, weight = 1.0)
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/SliceRingMergeAtTest.kt
@@ -16,10 +16,6 @@ class SliceRingMergeAtTest {
         concurrency = Concurrency.None,
     ) { c -> SumStat(c) }
 
-    /**
-     * Two merges into the same slice land in the same slot and sum together.
-     * Sanity check that mergeAt routes by timestamp.
-     */
     @Test
     fun `merges within one slice sum into the same slot`() {
         val ring = newRing()
@@ -31,28 +27,17 @@ class SliceRingMergeAtTest {
         assertEquals(7.0, total, DELTA)
     }
 
-    /**
-     * If a later thread has already rotated the bucket past expectedStart (so
-     * bucketRef.load() returns a slot whose startNanos > expectedStart), mergeAt
-     * must not merge into that future slot. The pre-fix code's fallback
-     * `bucketRef.load()` would do exactly that. We simulate the post-rotation
-     * state by calling mergeAt on a newer timestamp first to install the future
-     * slot, then mergeAt on an older timestamp that targets the same bucket index.
-     */
     @Test
     fun `merge at a stale timestamp does not contaminate a newer slot`() {
         val ring = newRing()
         val sliceNanos = 1_000_000_000L
-        // 10 buckets, so slice index 10 collides with index 0 in the ring.
-        // Install slot for slice 10 first (start = 10 * sliceNanos).
+        // 10 buckets, so slice index 10 collides with index 0 in the ring. Installing slice 10 first
+        // simulates a bucket another thread has already rotated past expectedStart.
         val newerStart = 10 * sliceNanos
         ring.mergeAt(newerStart + 100, SumResult(5.0))
-        // Now try to merge at a timestamp belonging to slice 0 (start = 0).
-        // This shares the bucket with slice 10. The slot currently in that
-        // bucket has startNanos = 10*sliceNanos, which is > expectedStart = 0.
-        // mergeAt must skip the merge rather than overwriting the newer slot.
+        // Slice 0 shares that bucket, whose slot has startNanos = 10 * sliceNanos > expectedStart = 0,
+        // so mergeAt must skip the merge rather than overwrite the newer slot.
         ring.mergeAt(50, SumResult(99.0))
-        // Read the newer slice's contents - must still be 5.0, not 5+99.
         var total = 0.0
         ring.forEachActive(newerStart + 500) { total += it.read().sum }
         assertEquals(5.0, total, DELTA)

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -20,21 +20,15 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-/**
- * Concurrent read-path invariants across the catalogue.
- *
- * The pre-existing per-stat `*ConcurrencyTest` files in `commonTest` are single-threaded:
- * they replay a fixed sequence under each [Concurrency] level and compare against
- * [Concurrency.None]. That catches mode-wiring mistakes but structurally cannot catch a
- * missing lock (the sequential arithmetic is identical either way) or a torn read (there
- * is no concurrent reader). This suite covers exactly that gap.
- *
- * The shape is N writers plus one reader, and the assertions are *invariants* rather than
- * exact values: under a lock-free level a snapshot is allowed to be stale, but it is never
- * allowed to be impossible. An AUC above 1.0, a NaN quantile on a populated sketch, a
- * calibrated probability above 1.0, or an exception thrown out of `read()` are all bugs at
- * every level, and none of them are excused by the documented drift allowance.
- */
+// The per-stat `*ConcurrencyTest` files in `commonTest` are single-threaded, so they structurally
+// cannot catch a missing lock (the sequential arithmetic is identical either way) or a torn read
+// (there is no concurrent reader). This suite covers exactly that gap.
+//
+// The shape is N writers plus one reader, and the assertions are *invariants* rather than exact
+// values: under a lock-free level a snapshot is allowed to be stale, but it is never allowed to be
+// impossible. An AUC above 1.0, a NaN quantile on a populated sketch, a calibrated probability above
+// 1.0, or an exception thrown out of `read()` are all bugs at every level, and none of them are
+// excused by the documented drift allowance.
 class ConcurrentReadInvariantsTest {
 
     private val levels = listOf(Concurrency.Strict, Concurrency.Relaxed, Concurrency.HighWrite)
@@ -267,15 +261,11 @@ class ConcurrentReadInvariantsTest {
 
     @Test
     fun `TDigestStat never reports weight it cannot answer from`() {
-        // The state behind the intermittent failure of the test below: `read` fills every quantile with
-        // NaN when it has no centroids, but returned `totalWeight` unchanged, so a snapshot could claim
-        // to have observed weight while being unable to answer a single quantile. That is not staleness,
-        // which the Relaxed contract allows - it is a snapshot contradicting itself.
-        //
-        // It arose because `update` counted a value's weight before publishing the value, and
-        // `drainLocked` may strand a claim it cannot prove committed. The weight stayed; the value did
-        // not. Asserted as an invariant rather than by reproducing the interleaving, which needs a
-        // preemption long enough to exhaust drainLocked's spin budget.
+        // `read` fills every quantile with NaN when it has no centroids, so a snapshot reporting weight
+        // it has no centroids for would claim to have observed something it cannot answer a single
+        // quantile from. That is not staleness, which the Relaxed contract allows - it is a snapshot
+        // contradicting itself. Asserted as an invariant rather than by reproducing the interleaving,
+        // which needs a preemption long enough to exhaust drainLocked's spin budget.
         for (level in levels) {
             val stat = TDigestStat(concurrency = level)
             assertReadInvariants("TDigestStat[$level] weight-vs-centroids", stat, write = { t, i ->

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DDSketchMemoryBoundTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DDSketchMemoryBoundTest.kt
@@ -6,24 +6,13 @@ import java.lang.management.ManagementFactory
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-/**
- * The bounded-memory claim, enforced.
- *
- * DDSketch assigns a bin per distinct log-bucket index and its bin array spans the whole
- * range between the smallest and largest index seen, allocating a cell for every index in
- * between. With an unbounded index, two observations at opposite ends of the Double range
- * were enough to force an enormous array. Measured before [DDSketchStat.minIndexableValue]
- * and [DDSketchStat.maxIndexableValue] existed, from exactly two updates:
- *
- * | relativeError | heap growth |
- * |---------------|-------------|
- * | 0.01          | 2472 KiB    |
- * | 0.001         | 28195 KiB   |
- * | 0.0001        | 220521 KiB  |
- *
- * Beyond that, at a tight enough error target the index saturates `Int`, `maxIndex` overflows
- * negative, the resize is skipped and previously accumulated bins are silently dropped.
- */
+// DDSketch assigns a bin per distinct log-bucket index and its bin array spans the whole range
+// between the smallest and largest index seen, allocating a cell for every index in between. Without
+// [DDSketchStat.minIndexableValue] and [DDSketchStat.maxIndexableValue], two observations at opposite
+// ends of the Double range force an enormous array - measured from exactly two updates at 2472 KiB
+// for a relative error of 0.01, 28195 KiB at 0.001 and 220521 KiB at 0.0001. Tighter still and the
+// index saturates `Int`, `maxIndex` overflows negative, the resize is skipped and accumulated bins
+// are silently dropped.
 class DDSketchMemoryBoundTest {
 
     private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/GuardedLockReleaseTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/GuardedLockReleaseTest.kt
@@ -9,15 +9,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * The lock must be released when the guarded body throws.
- *
- * `Mutex.withLock` gave this for free. The `enter`/`exit` split that replaced it on the hot
- * path relies on an explicit `finally`, so a mistake there would not show up as a wrong
- * answer: it would leave the mutex held and deadlock the next writer. Several stats throw
- * from inside the guarded body - the weight guards in the Welford family, the dimension
- * checks in the vector family - so this is a reachable path, not a hypothetical.
- */
+// The `enter`/`exit` split on the hot path relies on an explicit `finally`, so a mistake there would
+// not show up as a wrong answer: it would leave the mutex held and deadlock the next writer. Several
+// stats throw from inside the guarded body - the weight guards in the Welford family, the dimension
+// checks in the vector family - so this is a reachable path, not a hypothetical.
 class GuardedLockReleaseTest {
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
@@ -15,17 +15,12 @@ import java.lang.management.ManagementFactory
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-/**
- * Allocation on the update path, measured rather than assumed.
- *
- * kotlinx-benchmark 0.4.13 does not expose JMH's `gc` profiler - its `advanced` options are
- * limited to fork and bridge settings - so per-operation allocation is invisible to the
- * benchmark suite. This measures it directly through the HotSpot thread allocation counter,
- * which is exact for a single-threaded loop and cheap enough to run as an ordinary test.
- *
- * Thresholds are ceilings meant to catch a regression, not exact figures. Measured values at
- * the time of writing are in each assertion's message.
- */
+// kotlinx-benchmark 0.4.13 does not expose JMH's `gc` profiler - its `advanced` options are limited
+// to fork and bridge settings - so per-operation allocation is invisible to the benchmark suite. It
+// is measured here through the HotSpot thread allocation counter, which is exact for a
+// single-threaded loop and cheap enough to run as an ordinary test.
+//
+// Thresholds are ceilings meant to catch a regression, not exact figures.
 class UpdateAllocationTest {
 
     private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
@@ -75,23 +70,14 @@ class UpdateAllocationTest {
         assertUpdateAllocation("MomentsStat", 0.0, MomentsStat(Concurrency.None))
     }
 
-    /**
-     * Taking a lock must not allocate.
-     *
-     * `update` bodies used to be written `lock.withLock { ... }`. `withLock` is a non-inline
-     * interface method taking a function, so each call constructed a capturing lambda. The JIT
-     * scalar-replaced it only while the call site stayed monomorphic: measured alone this test
-     * reported 0 B/update under [Concurrency.Strict], but in a full-suite run, where both
-     * `NoopMutex` and `PlatformMutex` have been used, escape analysis gave up and it was
-     * 32 B/update. A production process looks like the second case.
-     *
-     * The bodies now use the inlining `guarded`, which expands to a direct
-     * `enter`/`try`/`finally`/`exit` and constructs nothing, so these are exact zeroes in both
-     * contexts rather than only in isolation. Kotlin platforms without escape analysis, which
-     * this counter cannot measure, benefit unconditionally.
-     */
     @Test
     fun `taking a lock does not allocate on the update path`() {
+        // `update` bodies use the inlining `guarded`, which expands to a direct
+        // `enter`/`try`/`finally`/`exit` and constructs nothing. A `lock.withLock { ... }` would
+        // construct a capturing lambda that the JIT scalar-replaces only while the call site stays
+        // monomorphic, so it measures 0 B/update in isolation and 32 B/update in a full-suite run,
+        // where both `NoopMutex` and `PlatformMutex` have been seen. A production process looks like
+        // the second case.
         assertUpdateAllocation("MeanStat[None]", 0.0, MeanStat(Concurrency.None))
         assertUpdateAllocation("MeanStat[Strict]", 0.0, MeanStat(Concurrency.Strict))
         assertUpdateAllocation("MomentsStat[Strict]", 0.0, MomentsStat(Concurrency.Strict))
@@ -103,26 +89,17 @@ class UpdateAllocationTest {
         assertUpdateAllocation("HdrHistogramStat", 0.0, HdrHistogramStat(concurrency = Concurrency.None))
     }
 
-    /**
-     * Ceilings for the two stats that allocate by design, as tripwires against a large
-     * regression rather than as precise figures.
-     *
-     * These have headroom but are no longer loose. They used to need a wide margin because the
-     * figures moved with the JIT state left behind by preceding tests - TDigest measured ~55
-     * B/op alone and ~86 B/op in a full-suite run. That gap was the lock lambda, and with
-     * `guarded` inlining it away both stats now report the same number under every
-     * [Concurrency] level in either context, so the remaining allocation is purely structural:
-     * one Bucket per observation for Adwin, the merged centroid arrays per compression epoch
-     * for TDigest.
-     */
     @Test
     fun `the amortised allocators stay under their ceiling`() {
-        // AdwinStat allocates one Bucket per observation by design, and its bucket-walk scratch
-        // buffer grows with the window. Measured 277 B/op before the scratch buffer was made
-        // reusable, 75 B/op after, and the same under Strict now that the lock does not allocate.
+        // Ceilings for the two stats that allocate by design, as tripwires against a large regression
+        // rather than as precise figures. Both allocate the same amount under every [Concurrency]
+        // level, so what is left is structural.
+        //
+        // AdwinStat allocates one Bucket per observation, and its bucket-walk scratch buffer grows
+        // with the window. Measured 75 B/op.
         assertUpdateAllocation("AdwinStat", 110.0, AdwinStat(concurrency = Concurrency.None))
         // TDigestStat allocates the merged centroid arrays once per compression epoch, amortised
-        // over the buffer. Measured 82 B/op before the index sort stopped boxing, 54 B/op after.
+        // over the buffer. Measured 54 B/op.
         assertUpdateAllocation("TDigestStat", 80.0, TDigestStat(concurrency = Concurrency.None), span = 9973)
     }
 }


### PR DESCRIPTION
## What changed

- Removed comments that narrate past changes across all 143 affected source files. That covers "used to", "no longer", "previously", counts of removed copies, and past-tense bug histories from fixes that have already landed.
- Removed comments and KDoc that restate the code below them. In tests this is mostly class-level KDoc repeating the backtick test names; in main sources it is adapter classes documenting the extension function directly below them.
- Corrected three KDoc claims that contradicted the code: `DecisionTreeClassifierStat` and `ConfusionMatrixStat` described `toInt()` truncation where the code routes through `asClassLabel`, and `AucStat` said "Long arrays" where the cells are doubles.
- Fixed `DDSketchStat`'s `**Update:**` line, which said NaN is dropped. There is no NaN branch in `update` and `DDSketchNaNTest` asserts a NaN counts as an observation in the zero bucket. See the note below.
- Removed a dangling reference in `DecayingVarianceStat` to a "Why locked under Relaxed" section that does not exist, a `pav` comment naming three variables not in the function, and a bench comment citing a PR number.

No code changed. The diff is comment-only: every added and removed line is a comment, KDoc, or a blank line left behind by a removed KDoc block.

## Why

The `.rules` style guide says comments explain why and never restate the code, and that they must not narrate changes. A lot of the tree predated that rule. The archaeology was also the bulk of it: history belongs in commit messages and PR bodies, where it stays accurate, rather than in source where it rots on the next edit.

## Testing

`./gradlew check lintDocs --rerun-tasks` passes.

## Notes

Three stat KDocs are missing required template sections and were left that way rather than filled with invented numbers: `DecisionTreeClassifierStat`, `RandomForestClassifierStat`, and `ClassCountsStat`. `GaussianScorerStat`, `QuantileFilterStat`, and `IsotonicCalibratorStat` are missing only `**Use cases:**`.

The `DDSketchStat` NaN fix documents the tested behavior. If dropping NaN was the actual intent, the code and the test are the things to change, not the doc.
