### PR TITLE
fix: honour the inert-weight contract in operators and reject degenerate optimizer bounds

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Hashes.kt
@@ -26,6 +26,20 @@ fun splitmix64(value: Long): Long {
 }
 
 /**
+ * Seed for the [ordinal]-th copy of a stat seeded with [seed].
+ *
+ * A stat that draws on its update path cannot hand its own seed to the copies
+ * [Stat.create][com.eignex.kumulant.core.Stat.create] makes, or
+ * every window slice replays one accept/reject sequence and an observation's fate depends only on its
+ * position within its slice. Callers pass a counter as [ordinal]; mixing it before it reaches the seed
+ * keeps a child seed from colliding with one of the parent's own draw inputs, which would overlap the
+ * two streams rather than separate them.
+ *
+ * `internal` because it is a construction detail rather than something a caller composes with.
+ */
+internal fun deriveChildSeed(seed: Long, ordinal: Long): Long = splitmix64(seed xor splitmix64(ordinal))
+
+/**
  * Default 64-bit hash of [bytes] for cardinality / sketch families. Currently
  * delegates to [SplitMixChunkHasher] - pin to that hasher directly if you need a
  * stable byte stream across library versions.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Gates.kt
@@ -1,8 +1,9 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.math.deriveChildSeed
+import com.eignex.kumulant.math.splitmix64
 import com.eignex.kumulant.stream.monotonicMode
-import kotlin.random.Random
 
 /**
  * Counts updates and lets every `every`-th one through.
@@ -10,6 +11,10 @@ import kotlin.random.Random
  * A wrapper holding one of these must call [reset] from its own `reset`: `Stat.reset` promises the
  * equivalent of a fresh stat, and `by delegate` forwards `reset` straight past the gate, leaving a reset
  * stat to forward on its first update rather than its `every`-th.
+ *
+ * A wrapper must also drop an inert weight before calling [pass]. The gate's phase is state, so
+ * counting an observation that carries no multiplicity would shift which later updates survive - see
+ * [Stat][com.eignex.kumulant.core.Stat] for the guarantee that makes that wrong.
  *
  * The counter resolves through [monotonicMode] so a gate under [Concurrency.None] costs a plain
  * increment rather than an atomic read-modify-write.
@@ -31,13 +36,43 @@ internal class ThrottleGate(private val every: Int, concurrency: Concurrency) {
 /**
  * Lets a Bernoulli-sampled fraction of updates through.
  *
- * The predicate is `<` rather than `<=`, which is what makes `rate = 0.0` reject everything.
+ * Counter-based rather than backed by a [kotlin.random.Random]: the draw is `splitmix64(seed + n)` for
+ * the gate's n-th update, with `n` resolved through [monotonicMode]. A `Random` is a mutable object with
+ * no atomicity, and this gate is read from every thread that updates the stat and is *copied* by
+ * [childSeed] into every window slice, so a shared one would be mutated concurrently on both axes.
+ * Deriving each draw from a counter makes the gate as thread-safe as the cell underneath it, and costs
+ * a plain increment plus a mix under [Concurrency.None].
+ *
+ * The same shape as [ThrottleGate], and it carries the same two obligations on the wrapper: call
+ * [reset] from the wrapper's `reset`, and drop an inert weight before calling [pass].
+ *
+ * The predicate is `<` rather than `<=`, which is what makes `rate = 0.0` reject everything;
+ * [unitDraw] returns a value strictly below `1.0`, which is what makes `rate = 1.0` accept everything.
  */
-internal class SampleGate(private val rate: Double, private val random: Random) {
+internal class SampleGate(private val rate: Double, private val seed: Long, concurrency: Concurrency) {
     init {
         checkRate(rate)
     }
 
+    private val mode = concurrency.monotonicMode()
+    private val draws = mode.newLong(0L)
+    private val copies = mode.newLong(0L)
+
     /** True when this update survives the sampling draw. */
-    fun pass(): Boolean = random.nextDouble() < rate
+    fun pass(): Boolean = unitDraw(seed + draws.addAndGet(1L)) < rate
+
+    /** Clears the draw counter, so the gate replays its sequence from the start. */
+    fun reset() = draws.store(0L)
+
+    /** A seed for a copy of the owning stat, distinct on every call; see [deriveChildSeed]. */
+    fun childSeed(): Long = deriveChildSeed(seed, copies.addAndGet(1L))
 }
+
+/**
+ * Map 64 mixed bits onto `[0, 1)`.
+ *
+ * The top 53 bits, because that is the width of a `Double`'s significand: taking fewer would leave
+ * representable values the draw can never produce, and taking more would round up to exactly `1.0` and
+ * break the `rate = 1.0` case in [SampleGate].
+ */
+private fun unitDraw(state: Long): Double = (splitmix64(state) ushr 11).toDouble() / (1L shl 53).toDouble()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.monotonicMode
 
 // Hysteresis adapter: maps a noisy numeric stream onto a debounced 0.0/1.0 signal.
@@ -16,6 +17,10 @@ import com.eignex.kumulant.stream.monotonicMode
 //
 // Each call forwards the current debounced state (not just transitions), so downstream
 // stats that consume a series naturally observe per-update progress.
+//
+// An inert weight is dropped before the state cell is read: the debounced state persists across
+// updates, so a value admitted with no multiplicity would flip the state and change what every
+// later update forwards. See [Stat].
 //
 // Concurrency: per-cell atomics with bounded drift (category 1). The state cell may
 // briefly observe stale reads under contention; rapid bouncing values can produce a
@@ -40,6 +45,7 @@ internal class HysteresisSeriesStat<R : Result>(
     private val state = mode.newLong(STATE_UNSET)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         val current = state.load()
         val next = when {
             value > high -> STATE_HIGH

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -7,9 +7,9 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
-import kotlin.random.Random
 
 // Decorator surface for [RegressionStat], mirroring the live ops on the other modalities.
 // Every wrapper delegates `read` / `merge` / `reset` / `concurrency` / `featureSize` to
@@ -49,9 +49,9 @@ internal fun <R : Result> RegressionStat<R>.throttle(every: Int): RegressionStat
     every,
 )
 
-/** Bernoulli-sample each update at probability [rate] using [random] as the PRNG. */
-internal fun <R : Result> RegressionStat<R>.sample(rate: Double, random: Random): RegressionStat<R> =
-    SampleRegressionStat(this, rate, random)
+/** Bernoulli-sample each update at probability [rate], drawing from [seed]. */
+internal fun <R : Result> RegressionStat<R>.sample(rate: Double, seed: Long): RegressionStat<R> =
+    SampleRegressionStat(this, rate, seed)
 
 /**
  * Lift a scalar [SeriesStat] into a [RegressionStat] by projecting `(x, y)` to a
@@ -140,6 +140,7 @@ internal class ThrottleRegressionStat<R : Result>(private val delegate: Regressi
     override val featureSize: Int = delegate.featureSize
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun reset() {
@@ -154,16 +155,23 @@ internal class ThrottleRegressionStat<R : Result>(private val delegate: Regressi
 internal class SampleRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
     private val rate: Double,
-    private val random: Random,
+    private val seed: Long,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
-    private val gate = SampleGate(rate, random)
+    private val gate = SampleGate(rate, seed, delegate.concurrency)
     override val featureSize: Int = delegate.featureSize
     override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
+
+    override fun reset() {
+        gate.reset()
+        delegate.reset()
+    }
+
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
-        SampleRegressionStat(delegate.create(concurrency), rate, random)
+        SampleRegressionStat(delegate.create(concurrency), rate, gate.childSeed())
 }
 
 internal class FoldRegressionStat<R : Result>(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -8,16 +8,19 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
-import kotlin.random.Random
+import com.eignex.kumulant.core.isInertWeight
 
 // Throttle / sample adapters. Each wraps an inner stat, intercepts at the update
 // boundary, and drops some updates before they reach the delegate. State per
-// wrapper is one atomic counter (throttle) or one [Random] reference (sample).
+// wrapper is one counter cell, held by the gate.
+//
+// Both gates are phase-carrying state, so both wrappers drop an inert weight before
+// consulting them: an observation that carries no multiplicity must not shift which
+// later updates survive. See [Stat] for the guarantee and `Gates.kt` for the gates.
 //
 // The constructed spec-layer counterparts live in
 // `com.eignex.kumulant.schema.Operations.kt`: `throttle(every)` and
-// `sample(rate, seed)`. The live forms below take a Kotlin [Random] so the
-// caller can plug in whatever PRNG they want.
+// `sample(rate, seed)`.
 
 /** Forward only every [every]th update to the delegate; drop the rest. */
 internal fun <R : Result> SeriesStat<R>.throttle(every: Int): SeriesStat<R> = ThrottleSeriesStat(this, every)
@@ -31,21 +34,21 @@ internal fun <R : Result> VectorStat<R>.throttle(every: Int): VectorStat<R> = Th
 /** Discrete-stat counterpart of [SeriesStat.throttle]. */
 internal fun <R : Result> DiscreteStat<R>.throttle(every: Int): DiscreteStat<R> = ThrottleDiscreteStat(this, every)
 
-/** Bernoulli-sample each update at probability [rate], using [random] as the PRNG. */
-internal fun <R : Result> SeriesStat<R>.sample(rate: Double, random: Random): SeriesStat<R> =
-    SampleSeriesStat(this, rate, random)
+/** Bernoulli-sample each update at probability [rate], drawing from [seed]. */
+internal fun <R : Result> SeriesStat<R>.sample(rate: Double, seed: Long): SeriesStat<R> =
+    SampleSeriesStat(this, rate, seed)
 
 /** Paired-stat counterpart of [SeriesStat.sample]. */
-internal fun <R : Result> PairedStat<R>.sample(rate: Double, random: Random): PairedStat<R> =
-    SamplePairedStat(this, rate, random)
+internal fun <R : Result> PairedStat<R>.sample(rate: Double, seed: Long): PairedStat<R> =
+    SamplePairedStat(this, rate, seed)
 
 /** Vector-stat counterpart of [SeriesStat.sample]. */
-internal fun <R : Result> VectorStat<R>.sample(rate: Double, random: Random): VectorStat<R> =
-    SampleVectorStat(this, rate, random)
+internal fun <R : Result> VectorStat<R>.sample(rate: Double, seed: Long): VectorStat<R> =
+    SampleVectorStat(this, rate, seed)
 
 /** Discrete-stat counterpart of [SeriesStat.sample]. */
-internal fun <R : Result> DiscreteStat<R>.sample(rate: Double, random: Random): DiscreteStat<R> =
-    SampleDiscreteStat(this, rate, random)
+internal fun <R : Result> DiscreteStat<R>.sample(rate: Double, seed: Long): DiscreteStat<R> =
+    SampleDiscreteStat(this, rate, seed)
 
 /**
  * Reject a throttle period that would forward nothing or everything unpredictably.
@@ -63,6 +66,7 @@ internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun reset() {
@@ -79,6 +83,7 @@ internal class ThrottlePairedStat<R : Result>(private val delegate: PairedStat<R
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
     override fun reset() {
@@ -95,6 +100,7 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
     override fun reset() {
@@ -111,6 +117,7 @@ internal class ThrottleDiscreteStat<R : Result>(private val delegate: DiscreteSt
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
     override fun reset() {
@@ -122,61 +129,84 @@ internal class ThrottleDiscreteStat<R : Result>(private val delegate: DiscreteSt
         ThrottleDiscreteStat(delegate.create(concurrency), every)
 }
 
-/** Bernoulli sampling helper. The [random] reference is shared across calls; caller
- *  is responsible for thread-safety; the spec materialiser hands each stat its own
- *  fresh `Random(seed)`. */
+/** Bernoulli sampling helper. [SampleGate] draws from [seed] through a counter cell, so the
+ *  gate is safe to share across threads and every copy gets its own derived stream. */
 internal class SampleSeriesStat<R : Result>(
     private val delegate: SeriesStat<R>,
     private val rate: Double,
-    private val random: Random,
+    private val seed: Long,
 ) : SeriesStat<R>,
     Stat<R> by delegate {
-    private val gate = SampleGate(rate, random)
+    private val gate = SampleGate(rate, seed, delegate.concurrency)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
+    override fun reset() {
+        gate.reset()
+        delegate.reset()
+    }
+
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
-        SampleSeriesStat(delegate.create(concurrency), rate, random)
+        SampleSeriesStat(delegate.create(concurrency), rate, gate.childSeed())
 }
 
 internal class SamplePairedStat<R : Result>(
     private val delegate: PairedStat<R>,
     private val rate: Double,
-    private val random: Random,
+    private val seed: Long,
 ) : PairedStat<R>,
     Stat<R> by delegate {
-    private val gate = SampleGate(rate, random)
+    private val gate = SampleGate(rate, seed, delegate.concurrency)
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
+    override fun reset() {
+        gate.reset()
+        delegate.reset()
+    }
+
     override fun create(concurrency: Concurrency?): PairedStat<R> =
-        SamplePairedStat(delegate.create(concurrency), rate, random)
+        SamplePairedStat(delegate.create(concurrency), rate, gate.childSeed())
 }
 
 internal class SampleVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val rate: Double,
-    private val random: Random,
+    private val seed: Long,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    private val gate = SampleGate(rate, random)
+    private val gate = SampleGate(rate, seed, delegate.concurrency)
     override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
+    override fun reset() {
+        gate.reset()
+        delegate.reset()
+    }
+
     override fun create(concurrency: Concurrency?): VectorStat<R> =
-        SampleVectorStat(delegate.create(concurrency), rate, random)
+        SampleVectorStat(delegate.create(concurrency), rate, gate.childSeed())
 }
 
 internal class SampleDiscreteStat<R : Result>(
     private val delegate: DiscreteStat<R>,
     private val rate: Double,
-    private val random: Random,
+    private val seed: Long,
 ) : DiscreteStat<R>,
     Stat<R> by delegate {
-    private val gate = SampleGate(rate, random)
+    private val gate = SampleGate(rate, seed, delegate.concurrency)
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(value, timestampNanos, weight)
     }
+    override fun reset() {
+        gate.reset()
+        delegate.reset()
+    }
+
     override fun create(concurrency: Concurrency?): DiscreteStat<R> =
-        SampleDiscreteStat(delegate.create(concurrency), rate, random)
+        SampleDiscreteStat(delegate.create(concurrency), rate, gate.childSeed())
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.NANOS_PER_SECOND
 import com.eignex.kumulant.stream.firstWriterMode
 import com.eignex.kumulant.stream.monotonicMode
@@ -15,6 +16,10 @@ import com.eignex.kumulant.stream.monotonicMode
 // Until enough history accumulates the operators suppress forwarding entirely: the first k
 // (for lag/diff) or first single (for derivative) updates are absorbed silently while the
 // buffer warms up.
+//
+// An inert weight is dropped before the ring is touched. The ring is state, and it is state the
+// stream is read back out of: an observation admitted with no multiplicity would not merely be
+// absorbed, it would be forwarded to the delegate at a later update's weight. See [Stat].
 //
 // Concurrency: per-cell atomics with bounded drift (category 1). Concurrent updates may briefly
 // observe an out-of-order ring slot but never throw; the forwarded value is always some value
@@ -49,6 +54,7 @@ internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, pr
     private val ring = mode.newDoubleArray(k)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         val n = tick.addAndGet(1L)
         val slot = ((n - 1L) % k).toInt()
         val past = ring.load(slot)
@@ -77,6 +83,7 @@ internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, p
     private val ring = mode.newDoubleArray(k)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         val n = tick.addAndGet(1L)
         val slot = ((n - 1L) % k).toInt()
         val past = ring.load(slot)
@@ -104,6 +111,7 @@ internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat
     private val lastTimestamp = tsMode.newLong(0L)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         val seen = initialized.addAndGet(1L)
         val prevValue = lastValue.load()
         val prevTs = lastTimestamp.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.monotonicMode
 
 // withSelfLag lifts a PairedStat<R> into a SeriesStat<R> by self-pairing each input
@@ -13,6 +14,10 @@ import com.eignex.kumulant.stream.monotonicMode
 //
 // Use case: lag-k autocorrelation is Pearson correlation of the (current, lag-k) pair,
 // so CovarianceStat.withSelfLag(k) is the streaming autocorrelation primitive.
+//
+// An inert weight is dropped before the ring is touched: the ring is what the lagged half of
+// each pair is read back out of, so admitting an observation that carries no multiplicity would
+// pair it with a real one later at that update's weight. See [Stat].
 //
 // Concurrency: per-cell atomics with bounded drift (category 1). The ring slot may briefly
 // observe an out-of-order write under contention but the paired stat always sees some
@@ -40,6 +45,7 @@ internal class WithSelfLagSeriesStat<R : Result>(private val delegate: PairedSta
     private val ring = mode.newDoubleArray(k)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
+        if (weight.isInertWeight()) return
         val n = tick.addAndGet(1L)
         val slot = ((n - 1L) % k).toInt()
         val past = ring.load(slot)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -131,7 +131,6 @@ import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.SummaryStat
 import com.eignex.kumulant.stat.summary.TotalWeightsStat
 import com.eignex.kumulant.stat.summary.VarianceStat
-import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -302,7 +301,7 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
             requireSeries(inner, "ThrottleSeries").materialize(concurrency).throttle(every)
 
         is SampleSeries ->
-            requireSeries(inner, "SampleSeries").materialize(concurrency).sample(rate, Random(seed))
+            requireSeries(inner, "SampleSeries").materialize(concurrency).sample(rate, seed)
 
         is LagSeries ->
             requireSeries(inner, "LagSeries").materialize(concurrency).lag(k)
@@ -419,7 +418,7 @@ fun <R : Result> PairedStatSpec<R>.materialize(concurrency: Concurrency = Concur
             requirePaired(inner, "ThrottlePaired").materialize(concurrency).throttle(every)
 
         is SamplePaired ->
-            requirePaired(inner, "SamplePaired").materialize(concurrency).sample(rate, Random(seed))
+            requirePaired(inner, "SamplePaired").materialize(concurrency).sample(rate, seed)
 
         is StandardScalerPaired ->
             requirePaired(inner, "StandardScalerPaired").materialize(concurrency).standardScaler(concurrency)
@@ -501,7 +500,7 @@ fun <R : Result> VectorStatSpec<R>.materialize(concurrency: Concurrency = Concur
             requireVector(inner, "ThrottleVector").materialize(concurrency).throttle(every)
 
         is SampleVector ->
-            requireVector(inner, "SampleVector").materialize(concurrency).sample(rate, Random(seed))
+            requireVector(inner, "SampleVector").materialize(concurrency).sample(rate, seed)
 
         is StandardScalerVector ->
             requireVector(inner, "StandardScalerVector").materialize(concurrency)
@@ -564,7 +563,7 @@ fun <R : Result> DiscreteStatSpec<R>.materialize(concurrency: Concurrency = Conc
             requireDiscrete(inner, "ThrottleDiscrete").materialize(concurrency).throttle(every)
 
         is SampleDiscrete ->
-            requireDiscrete(inner, "SampleDiscrete").materialize(concurrency).sample(rate, Random(seed))
+            requireDiscrete(inner, "SampleDiscrete").materialize(concurrency).sample(rate, seed)
     }
     return out as DiscreteStat<R>
 }
@@ -677,7 +676,7 @@ fun <R : Result> RegressionStatSpec<R>.materialize(concurrency: Concurrency = Co
             requireRegression(
                 inner,
                 "SampleRegression",
-            ).materialize(concurrency).sample(rate, Random(seed))
+            ).materialize(concurrency).sample(rate, seed)
 
         is FoldRegression -> {
             val m = requireSeries(inner, "FoldRegression").materialize(concurrency) as SeriesStat<Result>

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -38,6 +38,16 @@ data class SeasonalSmoothingResult(
     /** Seasonal coupling. */
     val mode: SeasonalMode,
 ) : Result {
+    init {
+        // Validated here rather than in merge, because the slot indexes [seasons] on the stat's
+        // update path: a decoded result carrying a negative slot merges without complaint and then
+        // takes the *next* update out with an index-out-of-bounds, which no stat may throw.
+        require(seasons.isNotEmpty()) { "seasons must not be empty" }
+        require(currentSlot in seasons.indices) {
+            "currentSlot must be in 0..${seasons.size - 1}; got $currentSlot"
+        }
+    }
+
     /** Length of the seasonal cycle. */
     val period: Int get() = seasons.size
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
+import com.eignex.kumulant.math.deriveChildSeed
 import com.eignex.kumulant.stream.NoopMutex
 import com.eignex.kumulant.stream.PlatformMutex
 import com.eignex.kumulant.stream.guarded
@@ -176,6 +177,9 @@ class ReservoirHistogramStat(
     }
     private val random = Random(seed)
 
+    // Copies made by `create`, so each gets its own admission stream. See `create`.
+    private val copies = mode.newLong(0L)
+
     // Sentinel key for "empty slot"; any real A-Res key (in (0, 1]) beats it.
     private val emptyKey = Double.NEGATIVE_INFINITY
 
@@ -223,9 +227,17 @@ class ReservoirHistogramStat(
         }
     }
 
+    /**
+     * Derives the copy's seed rather than passing this stat's own.
+     *
+     * A windowed reservoir builds one of these per slice, and slices sharing a seed would draw the
+     * same admission keys in the same order - so whether an observation survived would turn on its
+     * position within its slice rather than on its weight. The trees and forests derive for the same
+     * reason; advancing a counter here is what makes each copy distinct.
+     */
     override fun create(concurrency: Concurrency?) = ReservoirHistogramStat(
         capacity,
-        seed,
+        deriveChildSeed(seed, copies.addAndGet(1L)),
         concurrency ?: this.concurrency,
     )
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/Optimizer.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/Optimizer.kt
@@ -53,6 +53,10 @@ class SgdOptimizer(
     concurrency: Concurrency = Concurrency.None,
 ) : Optimizer {
 
+    init {
+        requirePositiveFeatureSize(featureSize)
+    }
+
     private val mode = concurrency.welfordMode()
     private val stepCell: StreamLong = mode.newLong(0L)
     private val cachedLr: StreamDouble = mode.newDouble(0.0)
@@ -136,7 +140,9 @@ class RmspropOptimizer(
 
     init {
         requirePositiveFeatureSize(featureSize)
-        require(rho in 0.0..1.0) { "rho must be in [0, 1]; got $rho" }
+        // Half-open at the top: rho == 1.0 freezes emaG2 at its initial zero, so the effective
+        // learning rate becomes lr / sqrt(epsilon) on every step and the weights diverge.
+        require(rho >= 0.0 && rho < 1.0) { "rho must be in [0, 1); got $rho" }
         require(epsilon > 0.0) { "epsilon must be positive" }
     }
 
@@ -184,8 +190,11 @@ class AdamOptimizer(
 
     init {
         requirePositiveFeatureSize(featureSize)
-        require(beta1 in 0.0..1.0) { "beta1 must be in [0, 1]; got $beta1" }
-        require(beta2 in 0.0..1.0) { "beta2 must be in [0, 1]; got $beta2" }
+        // Half-open at the top, because Adam's bias correction divides by 1 - beta^t. At beta == 1.0
+        // that denominator is exactly zero while the moment it corrects is identically zero too, so
+        // every delta is 0/0 = NaN and the weights never recover.
+        require(beta1 >= 0.0 && beta1 < 1.0) { "beta1 must be in [0, 1); got $beta1" }
+        require(beta2 >= 0.0 && beta2 < 1.0) { "beta2 must be in [0, 1); got $beta2" }
         require(epsilon > 0.0) { "epsilon must be positive" }
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/OperatorContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/OperatorContractSweepTest.kt
@@ -1,0 +1,105 @@
+package com.eignex.kumulant.core
+
+import com.eignex.kumulant.operation.derivative
+import com.eignex.kumulant.operation.diff
+import com.eignex.kumulant.operation.hysteresis
+import com.eignex.kumulant.operation.lag
+import com.eignex.kumulant.operation.resampleByTime
+import com.eignex.kumulant.operation.sample
+import com.eignex.kumulant.operation.throttle
+import com.eignex.kumulant.operation.withSelfLag
+import com.eignex.kumulant.stat.regression.CovarianceStat
+import com.eignex.kumulant.stat.summary.SummaryStat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+private const val NS_PER_SEC = 1_000_000_000L
+
+// The sibling of SeriesStatContractSweepTest for the operator layer. That sweep materializes bare
+// stats from specs, so an operator wrapping one is outside it - which is how a whole family of
+// operators came to carry phase across an inert weight while every stat underneath honoured it.
+//
+// The operators here are exactly those holding state between updates: a ring, a phase counter, a
+// debounced level. A stateless operator (filter, transform, fold, selector) cannot violate the
+// contract, since it has nothing to move.
+class OperatorContractSweepTest {
+
+    private val readAt = 9L * NS_PER_SEC
+
+    // An operator's state is only observable through what it forwards, so each entry replays the
+    // same stream twice: once with an inert-weight observation spliced in, once without. The two
+    // must agree, and the probe value is far outside the stream so absorbing it anywhere shows up.
+    //
+    // SummaryStat rather than SumStat as the delegate, because a sum telescopes under diff: the
+    // extra terms an absorbed observation contributes are (probe - prev) + (next - probe), which is
+    // exactly the (next - prev) the sum would have seen anyway. A delegate carrying count and
+    // extrema cannot cancel that way, and the vacuity guard below is what caught it.
+    private val operators: List<Pair<String, () -> SeriesStat<*>>> = listOf(
+        "lag(1)" to { SummaryStat().lag(1) },
+        "lag(3)" to { SummaryStat().lag(3) },
+        "diff(1)" to { SummaryStat().diff(1) },
+        "diff(2)" to { SummaryStat().diff(2) },
+        "derivative" to { SummaryStat().derivative() },
+        "withSelfLag(1)" to { CovarianceStat().withSelfLag(1) },
+        "throttle(2)" to { SummaryStat().throttle(2) },
+        "throttle(3)" to { SummaryStat().throttle(3) },
+        "sample(0.5)" to { SummaryStat().sample(0.5, seed = 42L) },
+        "hysteresis" to { SummaryStat().hysteresis(1.0, 5.0) },
+        "resampleByTime" to { SummaryStat().resampleByTime(2.seconds) },
+    )
+
+    private val samples = doubleArrayOf(3.0, 7.5, 1.0, 12.0, 6.25, 9.0, 2.5, 11.0)
+
+    private fun replay(stat: SeriesStat<*>, inertWeight: Double?, probe: Double) {
+        samples.forEachIndexed { i, v ->
+            if (inertWeight != null && i == 4) {
+                stat.update(probe, i.toLong() * NS_PER_SEC, inertWeight)
+            }
+            stat.update(v, i.toLong() * NS_PER_SEC, 1.0)
+        }
+    }
+
+    private fun sweep(weight: Double, label: String) {
+        val violations = mutableListOf<String>()
+        for ((name, build) in operators) {
+            for (probe in doubleArrayOf(999.0, -999.0)) {
+                val withProbe = build().also { replay(it, weight, probe) }
+                val without = build().also { replay(it, null, probe) }
+
+                val a = withProbe.read(readAt)
+                val b = without.read(readAt)
+                if (a != b) violations += "$name absorbed a $label $probe: $a vs $b"
+            }
+        }
+        assertEquals(emptyList(), violations.toList(), "$label updates must not move an operator")
+    }
+
+    @Test
+    fun `a zero weight is a no-op for every stateful operator`() {
+        sweep(0.0, "zero-weight")
+    }
+
+    @Test
+    fun `a NaN weight is a no-op for every stateful operator`() {
+        sweep(Double.NaN, "NaN-weighted")
+    }
+
+    @Test
+    fun `an infinite weight is a no-op for every stateful operator`() {
+        sweep(Double.POSITIVE_INFINITY, "+Infinity-weighted")
+        sweep(Double.NEGATIVE_INFINITY, "-Infinity-weighted")
+    }
+
+    @Test
+    fun `the sweep would notice an operator that absorbed the probe`() {
+        // Vacuity guard: the probe has to be an observation these operators visibly absorb at a live
+        // weight, or "state did not change" proves nothing about the inert case.
+        val inert = operators.filter { (_, build) ->
+            val withProbe = build().also { replay(it, 1.0, 999.0) }
+            val without = build().also { replay(it, null, 999.0) }
+            withProbe.read(readAt) == without.read(readAt)
+        }.map { it.first }
+        assertEquals(emptyList(), inert.toList(), "every operator must absorb a live-weight probe")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/RegressionOpsTest.kt
@@ -8,7 +8,6 @@ import com.eignex.kumulant.stat.regression.tree.RegressionTreeConfig
 import com.eignex.kumulant.stat.regression.tree.ThresholdSplit
 import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.VarianceStat
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -72,7 +71,7 @@ class RegressionOpsTest {
     fun `sample keeps roughly the rate fraction`() {
         val n = 10_000
         val inner = DecisionTreeRegressionStat(featureSize = 1, splitCandidates = emptyList())
-        val stat = inner.sample(rate = 0.25, random = Random(7))
+        val stat = inner.sample(rate = 0.25, seed = 7L)
         repeat(n) { stat.update(feat(0.0), y = 1.0) }
         val kept = stat.read(0L).totalWeights
         assertTrue(kept in 2_000.0..3_000.0, "expected ~2500, got $kept")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -4,13 +4,41 @@ import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.SumStat
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SamplingTest {
+
+    @Test
+    fun `reset replays the sampling sequence from the start`() {
+        // Stat.reset promises the equivalent of a fresh stat, and the gate's draw counter is state:
+        // without clearing it a reset stat would carry on mid-sequence.
+        val a = CountStat().sample(rate = 0.5, seed = 3L)
+        repeat(50) { a.update(1.0) }
+        val before = a.read().sum
+        a.reset()
+        repeat(50) { a.update(1.0) }
+        assertEquals(before, a.read().sum, DELTA)
+    }
+
+    @Test
+    fun `copies sample independently of the stat they came from`() {
+        // Window slices are built through create; sharing the parent's seed would make every slice
+        // accept and reject at the same positions.
+        val template = CountStat().sample(rate = 0.5, seed = 11L)
+        val first = template.create()
+        val second = template.create()
+        repeat(200) {
+            first.update(1.0)
+            second.update(1.0)
+        }
+        assertTrue(
+            first.read().sum != second.read().sum,
+            "copies drew the same sequence: ${first.read().sum}",
+        )
+    }
 
     @Test
     fun `series throttle forwards every Nth update`() {
@@ -51,7 +79,7 @@ class SamplingTest {
     @Test
     fun `series sample keeps roughly the rate fraction`() {
         val n = 10_000
-        val stat = CountStat().sample(rate = 0.3, random = Random(42))
+        val stat = CountStat().sample(rate = 0.3, seed = 42L)
         repeat(n) { stat.update(1.0) }
         val kept = stat.read().sum
         assertTrue(kept in 2_500.0..3_500.0, "expected ~3000, got $kept")
@@ -59,8 +87,8 @@ class SamplingTest {
 
     @Test
     fun `sample rate 0 drops everything and 1 keeps everything`() {
-        val none = CountStat().sample(rate = 0.0, random = Random(1))
-        val all = CountStat().sample(rate = 1.0, random = Random(1))
+        val none = CountStat().sample(rate = 0.0, seed = 1L)
+        val all = CountStat().sample(rate = 1.0, seed = 1L)
         repeat(50) {
             none.update(1.0)
             all.update(1.0)
@@ -71,8 +99,8 @@ class SamplingTest {
 
     @Test
     fun `sample rejects out-of-range rate`() {
-        assertFailsWith<IllegalArgumentException> { CountStat().sample(rate = -0.1, random = Random(0)) }
-        assertFailsWith<IllegalArgumentException> { CountStat().sample(rate = 1.1, random = Random(0)) }
+        assertFailsWith<IllegalArgumentException> { CountStat().sample(rate = -0.1, seed = 0L) }
+        assertFailsWith<IllegalArgumentException> { CountStat().sample(rate = 1.1, seed = 0L) }
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingValidationTest.kt
@@ -2,7 +2,6 @@ package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.summary.SumStat
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -44,16 +43,16 @@ class SamplingValidationTest {
     fun `sample rejects a rate outside the unit interval in every modality`() {
         for (rate in listOf(-0.1, 1.1, Double.NaN)) {
             assertFailsWith<IllegalArgumentException>("series accepted rate=$rate") {
-                SumStat().sample(rate, Random(0))
+                SumStat().sample(rate, 0L)
             }
             assertFailsWith<IllegalArgumentException>("paired accepted rate=$rate") {
-                SumStat().atY().sample(rate, Random(0))
+                SumStat().atY().sample(rate, 0L)
             }
             assertFailsWith<IllegalArgumentException>("vector accepted rate=$rate") {
-                VectorizedStat(2, SumStat()).sample(rate, Random(0))
+                VectorizedStat(2, SumStat()).sample(rate, 0L)
             }
             assertFailsWith<IllegalArgumentException>("regression accepted rate=$rate") {
-                StochasticRegressionStat(featureSize = 2).sample(rate, Random(0))
+                StochasticRegressionStat(featureSize = 2).sample(rate, 0L)
             }
         }
     }
@@ -61,11 +60,11 @@ class SamplingValidationTest {
     @Test
     fun `sample accepts both endpoints`() {
         // Zero and one are the drop-everything and keep-everything ends, both legitimate.
-        val none = SumStat().sample(0.0, Random(0))
+        val none = SumStat().sample(0.0, 0L)
         repeat(20) { none.update(1.0) }
         assertEquals(0.0, none.read().sum, 1e-12, "a rate of zero should drop every update")
 
-        val all = SumStat().sample(1.0, Random(0))
+        val all = SumStat().sample(1.0, 0L)
         repeat(20) { all.update(1.0) }
         assertEquals(20.0, all.read().sum, 1e-12, "a rate of one should keep every update")
     }
@@ -76,7 +75,7 @@ class SamplingValidationTest {
         assertTrue("throttle every must be >= 1" in every.message.orEmpty(), "unhelpful: ${every.message}")
         assertTrue("got 0" in every.message.orEmpty(), "did not name the value: ${every.message}")
 
-        val rate = assertFailsWith<IllegalArgumentException> { SumStat().sample(1.5, Random(0)) }
+        val rate = assertFailsWith<IllegalArgumentException> { SumStat().sample(1.5, 0L) }
         assertTrue("sample rate must be in [0, 1]" in rate.message.orEmpty(), "unhelpful: ${rate.message}")
         assertTrue("got 1.5" in rate.message.orEmpty(), "did not name the value: ${rate.message}")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
@@ -69,6 +69,43 @@ class SeasonalSmoothingStatTest {
     }
 
     @Test
+    fun `a result rejects a slot that does not index its seasons`() {
+        // The slot indexes the seasons array on the stat's update path, so an unchecked one merges
+        // without complaint and then takes the next update out with an index-out-of-bounds. Rejecting
+        // it at the result keeps that off the update path entirely.
+        for (slot in listOf(-1, 4, 99)) {
+            assertFailsWith<IllegalArgumentException> {
+                SeasonalSmoothingResult(
+                    level = 1.0,
+                    trend = 0.0,
+                    seasons = listOf(0.0, 0.0, 0.0, 0.0),
+                    currentSlot = slot,
+                    phi = 1.0,
+                    mode = SeasonalMode.Additive,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `merging a decoded result leaves the stat updatable`() {
+        val s = SeasonalSmoothingStat(alpha = 0.3, beta = 0.2, gamma = 0.1, period = 4)
+        s.update(1.0)
+        s.merge(
+            SeasonalSmoothingResult(
+                level = 1.0,
+                trend = 0.0,
+                seasons = listOf(0.0, 0.0, 0.0, 0.0),
+                currentSlot = 3,
+                phi = 1.0,
+                mode = SeasonalMode.Additive,
+            ),
+        )
+        s.update(2.0)
+        assertTrue(s.read().level.isFinite())
+    }
+
+    @Test
     fun `reset clears state`() {
         val s = SeasonalSmoothingStat(alpha = 0.4, beta = 0.1, gamma = 0.5, period = 4)
         repeat(20) { s.update(it.toDouble()) }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ReservoirHistogramTest.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.quantile
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ReservoirHistogramTest {
@@ -81,6 +82,21 @@ class ReservoirHistogramTest {
         val b = a.create()
         assertEquals(0, b.read().values.size)
         assertTrue(a.read().values.isNotEmpty())
+    }
+
+    @Test
+    fun `copies draw independent admission streams`() {
+        // A windowed reservoir builds one slice per copy. Sharing the parent's seed would give every
+        // slice the same admission keys in the same order, so surviving would turn on an
+        // observation's position within its slice rather than on its weight.
+        val template = ReservoirHistogramStat(capacity = 8, seed = 99)
+        val first = template.create()
+        val second = template.create()
+        for (i in 1..200) {
+            first.update(i.toDouble())
+            second.update(i.toDouble())
+        }
+        assertFalse(first.read().values.contentEquals(second.read().values))
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.fitLine
+import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.optimizer.Adagrad
 import com.eignex.kumulant.schema.optimizer.Adam
 import com.eignex.kumulant.schema.optimizer.Rmsprop
@@ -96,6 +97,35 @@ class OptimizerTest {
             if (r.predict(x) == c) correct++
         }
         assertTrue(correct.toDouble() / 300.0 > 0.9, "accuracy=${correct / 300.0}")
+    }
+
+    @Test
+    fun `Adam rejects a beta of one rather than learning nothing`() {
+        // At beta == 1.0 the bias correction 1 - beta^t is exactly zero while the moment it corrects
+        // is identically zero too, so every delta would be 0/0 and the weights would stay NaN for
+        // the life of the stat. The bound is half-open to keep that unreachable.
+        assertFailsWith<IllegalArgumentException> { AdamOptimizer(2, Const(0.1), beta1 = 1.0) }
+        assertFailsWith<IllegalArgumentException> { AdamOptimizer(2, Const(0.1), beta2 = 1.0) }
+    }
+
+    @Test
+    fun `Adam still accepts a beta of zero`() {
+        // The other end stays closed: beta1 = 0 is plain SGD on the first moment, which is degenerate
+        // but well defined, and the bias correction is 1 - 0^t = 1.
+        AdamOptimizer(2, Const(0.1), beta1 = 0.0, beta2 = 0.0)
+    }
+
+    @Test
+    fun `RMSProp rejects a rho of one rather than diverging`() {
+        // rho == 1.0 freezes the squared-gradient EMA at zero, so the effective step becomes
+        // lr / sqrt(epsilon) - four orders of magnitude larger than intended - on every update.
+        assertFailsWith<IllegalArgumentException> { RmspropOptimizer(2, Const(0.1), rho = 1.0) }
+    }
+
+    @Test
+    fun `Sgd rejects a non-positive feature size like its siblings`() {
+        assertFailsWith<IllegalArgumentException> { SgdOptimizer(0, Const(0.1)) }
+        assertFailsWith<IllegalArgumentException> { SgdOptimizer(-1, Const(0.1)) }
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Dropped an inert weight at the head of every stateful operator: lag, diff, derivative, withSelfLag, hysteresis, and the throttle and sample gates across all five modalities.
- Replaced SampleGate's shared Random with a counter-based draw, so the gate is race-free at every concurrency level and each copy gets its own stream.
- Changed the live sample operator to take a seed rather than a Random, matching the spec layer and the rest of the randomized stats.
- Added reset to the five Sample wrappers so the draw counter clears with the stat.
- Made AdamOptimizer reject beta1 or beta2 of exactly 1.0, and RmspropOptimizer reject rho of exactly 1.0.
- Added the missing non-positive featureSize guard to SgdOptimizer.
- Made SeasonalSmoothingResult reject a currentSlot that does not index its seasons.
- Made ReservoirHistogramStat.create derive a child seed instead of reusing its own.
- Added an internal deriveChildSeed helper next to splitmix64.

## Why

Stat guarantees that a weight of zero, NaN, or an infinity changes no state. Every stat honoured that; no operator wrapping one did. The ring-based operators were the worst of it, because they do not merely absorb the discarded observation, they hold it and forward it to the delegate at the next update's full weight. A lag of 1 fed a zero-weight 999.0 then a real 20.0 forwarded the 999.0 as if it were real data. Throttle and hysteresis carried phase across the discarded update instead. resampleByTime already guarded correctly and shows the shape the rest now follow.

The sample gate had a second problem behind the first. It held a caller-supplied Random, which is a mutable object with no atomicity, and create handed the same instance to every copy. A windowed stat builds one copy per slice on the update path, so a single Random was being mutated from every thread and every slice at once. Deriving each draw from a counter through splitmix64 removes both races and costs an increment and a mix. The rest of the library already takes a seed rather than a Random for this, so the live sample operator was the outlier, and the spec layer was already passing a seed that got wrapped at the boundary.

Adam divides by the bias correction 1 - beta^t. At beta of exactly 1.0 that denominator is zero while the moment it corrects is identically zero, so every delta is zero over zero and the weights stay NaN for the life of the stat. Both endpoints were reachable from the wire. RMSProp at rho of exactly 1.0 does not go NaN but freezes the squared-gradient average at zero, which multiplies the effective learning rate by ten thousand; on a trivially learnable problem it produced a bias of -8.9e10. Both bounds are now half-open.

SeasonalSmoothingStat.merge stored a decoded currentSlot verbatim, and Kotlin's remainder keeps the sign, so a negative slot indexed the seasons array on the next update and threw. No stat may throw from the update path on ordinary decoded input. The result type already normalised the same field inside forecast, which showed it expected a value nothing was making trustworthy, so the check belongs at construction where every consumer gets it.

ReservoirHistogramStat had the same copy-correlation issue as sampling: every window slice drew the identical admission sequence, so whether an observation survived turned on its position within its slice rather than on its weight. The trees and forests already derive child seeds for this reason.

## Testing

Added OperatorContractSweepTest, the operator-layer sibling of SeriesStatContractSweepTest. The existing sweeps materialize bare stats from specs, so an operator wrapping one sat outside them, which is how the whole family stayed hidden. It replays each stream twice, once with an inert-weight observation spliced in and once without, and requires the two to agree. Confirmed it fails against the unfixed code by reverting the Shifts guard: three of its four tests fail, naming lag as the culprit. Its vacuity guard earned its place by catching that a sum telescopes under diff, which had made that entry prove nothing; the delegate is now SummaryStat.

Added targeted tests for the rest: Adam and RMSProp rejecting the degenerate endpoint while still accepting zero, Sgd rejecting a non-positive featureSize, SeasonalSmoothingResult rejecting an out-of-range slot and a merged stat staying updatable afterwards, and both ReservoirHistogramStat and the sample gate giving copies independent streams. SamplingTest also covers reset replaying the sequence from the start.

Ran gradlew check lintDocs with rerun-tasks.
