### PR TITLE
docs: describe resample bucket visibility and the full inert-weight set

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -15,14 +15,30 @@ import kotlin.time.Duration
 
 // resampleByTime aligns the input stream onto fixed wall-clock buckets and forwards
 // one observation per closed bucket to the delegate stat. The per-bucket value is
-// determined by [ResampleAggregator]; the in-progress bucket is held until an update
-// arrives in a later bucket (or a flush is requested).
+// determined by [ResampleAggregator].
+//
+// An update in a later bucket is the only thing that closes the open one. There is no
+// flush, and `read` does not close it either, so the newest bucket is never visible: a
+// reader always sees the stream as of the last bucket boundary an update crossed. That
+// is what makes the operator's output independent of when it is read, which a windowed
+// or periodically-scraped consumer depends on - a flush on read would emit a partial
+// bucket whose value then changed as the rest of it arrived.
 //
 // Concurrency: coupled per-bucket state and bucket index (category 3). The internal
 // lock keeps the multi-cell transition consistent.
 
-/** Align this series on fixed wall-clock buckets of [bucket] length and forward one
- *  observation per closed bucket using [aggregator]. */
+/**
+ * Align this series on fixed wall-clock buckets of [bucket] length and forward one
+ * observation per closed bucket using [aggregator].
+ *
+ * A bucket closes when an update arrives in a later one, so the delegate lags the input by up to one
+ * bucket and the open bucket is never readable. Reads are therefore stable: the same read repeated
+ * returns the same value until an update crosses a boundary.
+ *
+ * Caller weight folds into the open bucket rather than passing through: [ResampleAggregator.Sum] and
+ * [ResampleAggregator.Mean] weight the observations they combine, and the closed bucket then reaches
+ * the delegate as a single observation of weight `1.0` however many raw ones went into it.
+ */
 internal fun <R : Result> SeriesStat<R>.resampleByTime(
     bucket: Duration,
     aggregator: ResampleAggregator = ResampleAggregator.Mean,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -13,10 +13,11 @@ import com.eignex.kumulant.core.isInertWeight
 /**
  * Force every update through this stat to use a constant [weight], discarding caller weight.
  *
- * An inert caller weight - exactly `0.0`, or `NaN` - is passed through unchanged rather than
- * replaced. The override sets the *magnitude* of a real observation, and neither "ignore this
- * observation" nor "no multiplicity at all" is a magnitude, so the no-op guarantees in [Stat] survive
- * the wrapper.
+ * An inert caller weight is passed through unchanged rather than replaced: that is every weight
+ * [isInertWeight] names, so `0.0`, `NaN`, and either infinity. The override sets the *magnitude* of a
+ * real observation, and none of "ignore this observation", "no multiplicity at all", or an infinity
+ * that is not a multiplicity either is a magnitude, so the no-op guarantees in [Stat] survive the
+ * wrapper.
  */
 internal fun <R : Result> SeriesStat<R>.withWeight(weight: Double): SeriesStat<R> = WithWeightStat(this, weight)
 


### PR DESCRIPTION
## What changed

- Removed the reference to a flush from the resampleByTime file comment, since no flush entry point exists, and said what actually closes a bucket.
- Documented that the open bucket is never readable and why that is the useful behaviour rather than a gap.
- Documented on the public resampleByTime how caller weight is treated: Sum and Mean weight what they combine, and the closed bucket reaches the delegate as one observation of weight 1.0.
- Corrected the withWeight KDoc, which listed the inert weights as zero and NaN and omitted the infinities.

## Why

Both were doc drift rather than wrong behaviour, so nothing here changes code. The diff touches no executable line.

The resampleByTime comment said the in-progress bucket is held "until an update arrives in a later bucket (or a flush is requested)". There is no flush to request, and read does not close the bucket either, so the parenthetical pointed at an entry point that was never written. Adding one would be a feature rather than a doc fix, and it would also be the wrong feature: closing on read makes the operator's output depend on when it is read, and emits a partial bucket whose value then changes as the rest of it arrives. Holding the bucket is what keeps a repeated read stable, which is what a windowed or periodically-scraped consumer needs, so the comment now says that instead of implying a missing escape hatch.

The weight note is new rather than corrected. Weight does not pass through this operator the way it does through the other adapters, and nothing said so.

withWeight passes an inert caller weight through instead of replacing it, and its KDoc named that set as "exactly 0.0, or NaN". The implementation goes through isInertWeight, which also covers both infinities, and has since the four guarantees in Stat were settled. The prose was a restatement that fell behind the predicate it describes, so it now names the predicate and lists all four cases.

## Testing

Ran gradlew check lintDocs with rerun-tasks.

Worth knowing for the next person: the first run failed in compileTestDevelopmentExecutableKotlinWasmJs with an internal compiler error, "Key ic#69:kotlin.text/replace is missing in the map". That is a stale Kotlin/Wasm incremental-compilation cache, not a real failure, and a comment-only diff cannot have caused it. Deleting kumulant/build/compileSync/wasmJs and kumulant/build/klib/cache cleared it, and the full gate then passed. Note that rerun-tasks alone does not fix it, since the incremental cache sits outside Gradle's up-to-date tracking.
