### PR TITLE
build: disable Kotlin/Wasm incremental compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,15 @@ org.gradle.caching=true
 kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 org.gradle.workers.max=4
+
+# Kotlin/Wasm incremental compilation, on by default, intermittently fails the wasmJs test link with
+# "Key ic#<n>:<declaration> is missing in the map" from DefinedDeclarationsResolver - a stale entry in
+# its own cache, for a stdlib declaration this project never calls. The failure is a compiler crash
+# rather than a diagnostic, so it reads as a broken source tree, and the only recovery is deleting
+# build/compileSync/wasmJs and build/klib/cache; --rerun-tasks does not help, since the cache sits
+# outside Gradle's up-to-date tracking.
+#
+# Turning it off costs nothing here: a touched-source wasm rebuild measured 5s incremental against 4s
+# full, because the module is small enough that there is no incremental work worth tracking. Revisit
+# if the wasm source set grows enough for that gap to open up.
+kotlin.incremental.wasm=false


### PR DESCRIPTION
## What changed

- Set kotlin.incremental.wasm=false in gradle.properties, with a comment recording the failure it prevents, the recovery it saves, and the measurements that show it costs nothing here.

## Why

The wasmJs test link intermittently fails with an internal compiler error rather than a diagnostic:

    e: java.util.NoSuchElementException: Key ic#69:kotlin.text/replace|...
       is missing in the map
       at DefinedDeclarationsResolver.resolve(DefinedDeclarationsResolver.kt:55)

The ic# prefix is the Kotlin/Wasm incremental compilation cache, and the declaration it cannot find is a stdlib one this project never calls, so the stale entry comes from a dependency rather than from anything in kumulant. Two things make it expensive out of proportion to how often it happens. It presents as a compiler crash, so it reads as a broken source tree when the tree is fine; it first hit on a diff that changed only comments. And the only recovery is deleting build/compileSync/wasmJs and build/klib/cache, which is not guessable, and which --rerun-tasks does not do, because the incremental cache sits outside Gradle's up-to-date tracking.

kotlin.incremental.wasm defaults to true in the Kotlin Gradle plugin, confirmed by reading PropertiesProvider in the 2.4.10 sources rather than assuming it.

Turning it off is free at this project's size. A touched-source wasm rebuild, measured in steady state over three runs each, takes 5s incremental against 4s full: the module is small enough that there is no incremental work worth tracking, and the bookkeeping costs about what it saves. The comment in gradle.properties says to revisit this if the wasm source set grows enough for that gap to open.

I could not reproduce the failure on demand. Four attempts, targeting the conditions of the original: declaration rename and revert, --rerun-tasks on the compile task alone, and the exact gate invocation that first failed. All passed. So this is a mitigation of a nondeterministic failure chosen because the mitigation is free, not a fix whose effect I can demonstrate.

## Testing

Ran gradlew check lintDocs with rerun-tasks, twice, both green.

One thing to flag rather than bury. The first of those runs failed, but in a different place and for an unrelated reason: wasmWasiNodeTest died with an uncaught WebAssembly.Exception and no test-level diagnostic. It passed on a forced re-run and on the two gates after it. That is a second, separate flake, and it happened with wasm incremental compilation already disabled, so nothing in this PR addresses it. Filed separately so it is not mistaken for a symptom of this change.
