### PR TITLE
docs: trim the wasm incremental compilation comment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,6 @@ kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 org.gradle.workers.max=4
 
-# Kotlin/Wasm incremental compilation, on by default, intermittently fails the wasmJs test link with
-# "Key ic#<n>:<declaration> is missing in the map" from DefinedDeclarationsResolver - a stale entry in
-# its own cache, for a stdlib declaration this project never calls. The failure is a compiler crash
-# rather than a diagnostic, so it reads as a broken source tree, and the only recovery is deleting
-# build/compileSync/wasmJs and build/klib/cache; --rerun-tasks does not help, since the cache sits
-# outside Gradle's up-to-date tracking.
-#
-# Turning it off costs nothing here: a touched-source wasm rebuild measured 5s incremental against 4s
-# full, because the module is small enough that there is no incremental work worth tracking. Revisit
-# if the wasm source set grows enough for that gap to open up.
+# Its cache intermittently crashes the wasmJs link with "Key ic#<n> is missing in the map". Free to
+# drop at this size: a touched-source rebuild is 5s incremental against 4s full.
 kotlin.incremental.wasm=false


### PR DESCRIPTION
## What changed

- Cut the kotlin.incremental.wasm comment from eleven lines to two.

## Why

It was far longer than the one-line setting it explains. Most of it was recovery instructions for the crash, which only apply while incremental compilation is on, and this line is what keeps it off. What survives is the two facts that justify the setting: the failure it avoids, and the measurement showing it costs nothing at this size.

## Testing

Comment-only change to gradle.properties. Confirmed the build still configures.