### PR TITLE
fix: draw tree and forest randomness from counters instead of shared Random

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CounterRandom.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CounterRandom.kt
@@ -1,0 +1,50 @@
+package com.eignex.kumulant.math
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stream.monotonicMode
+import kotlin.random.Random
+
+/**
+ * A [Random] whose state is a counter rather than a mutable seed, so it is safe to draw from under any
+ * [Concurrency] level.
+ *
+ * The n-th draw is `splitmix64(seed + n)`, with `n` resolved through
+ * [monotonicMode][com.eignex.kumulant.stream.monotonicMode]. A stock `Random` is a mutable object with
+ * no atomicity, so a stat that draws on its update path races on it as soon as two threads update at
+ * once - and a lock is the wrong answer on a path whose whole cost is a draw. Here each draw is one
+ * atomic increment and one mix, and under [Concurrency.None] the increment is plain.
+ *
+ * Subclassing [Random] rather than exposing a bespoke draw method is what keeps
+ * [nextPoissonOne][com.eignex.kumulant.math.nextPoissonOne] and every other distribution in
+ * `Distributions.kt` usable unchanged, including the ones that consume a variable number of draws.
+ *
+ * Draws interleave arbitrarily between threads, so a contended stat sees a different sequence than a
+ * serial replay would - the same bounded drift every concurrent stat is allowed. Each individual draw
+ * is well-formed whoever wins the increment, which is the property a shared `Random` cannot offer.
+ */
+internal class CounterRandom(private val seed: Long, concurrency: Concurrency) : Random() {
+
+    private val mode = concurrency.monotonicMode()
+    private val draws = mode.newLong(0L)
+
+    // Copies are counted apart from draws so that `reset` can restore the draw sequence without also
+    // handing a later copy a seed an earlier one already used.
+    private val copies = mode.newLong(0L)
+
+    override fun nextBits(bitCount: Int): Int = splitmix64(seed + draws.addAndGet(1L)).toInt().takeUpperBits(bitCount)
+
+    /** Restarts the draw sequence, so a reset stat draws what a fresh one would. */
+    fun reset() = draws.store(0L)
+
+    /** A seed for a copy of the owning stat, distinct on every call; see [deriveChildSeed]. */
+    fun childSeed(): Long = deriveChildSeed(seed, copies.addAndGet(1L))
+}
+
+/**
+ * Keep the top [bitCount] bits of this `Int`, zeroing the rest, as [Random.nextBits] requires.
+ *
+ * The stdlib has this exact helper and keeps it internal, so it is restated here. The mask
+ * `(-bitCount shr 31)` is what makes `bitCount = 0` yield `0` rather than an unshifted value: the sign
+ * propagation gives `-1` for any positive count and `0` for zero.
+ */
+private fun Int.takeUpperBits(bitCount: Int): Int = ushr(32 - bitCount) and (-bitCount shr 31)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -9,7 +9,7 @@ import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
-import kotlin.random.Random
+import com.eignex.kumulant.math.CounterRandom
 
 /**
  * Online VFDT decision-tree classifier; the classification counterpart of
@@ -57,7 +57,7 @@ class DecisionTreeClassifierStat(
         requireAtLeastTwoClasses(numClasses)
     }
 
-    private val seedRng = Random(randomSeed)
+    private val seedRng = CounterRandom(randomSeed.toLong(), concurrency)
     private var tree: ClassificationTree = newTree()
 
     private fun newTree(): ClassificationTree = ClassificationTree(
@@ -89,7 +89,13 @@ class DecisionTreeClassifierStat(
         tree.mergeSnapshot(values.root)
     }
 
+    /**
+     * Restarts the seed stream too, so the rebuilt tree is the one a fresh stat would have grown.
+     * Without it a reset stat draws its next seed from wherever construction left off, and `reset`
+     * promises the equivalent of a fresh stat rather than merely an empty one.
+     */
     override fun reset() {
+        seedRng.reset()
         tree = newTree()
     }
 
@@ -100,7 +106,7 @@ class DecisionTreeClassifierStat(
         config = config,
         concurrency = concurrency ?: this.concurrency,
         leafArmFactory = leafArmFactory,
-        randomSeed = seedRng.nextInt(),
+        randomSeed = seedRng.childSeed().toInt(),
     )
 
     /** Live underlying classification tree. Use for inspection / pretty-printing. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -7,9 +7,9 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
+import com.eignex.kumulant.math.CounterRandom
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
-import kotlin.random.Random
 
 /**
  * Online VFDT decision-tree regressor; a piecewise-constant predictor over the feature
@@ -66,7 +66,7 @@ class DecisionTreeRegressionStat(
         requirePositiveFeatureSize(featureSize)
     }
 
-    private val seedRng = Random(randomSeed)
+    private val seedRng = CounterRandom(randomSeed.toLong(), concurrency)
     private var tree: RegressionTree<VectorView> = newTree()
 
     private fun newTree(): RegressionTree<VectorView> = RegressionTree(
@@ -91,7 +91,13 @@ class DecisionTreeRegressionStat(
         tree.mergeSnapshot(values.root)
     }
 
+    /**
+     * Restarts the seed stream too, so the rebuilt tree is the one a fresh stat would have grown.
+     * Without it a reset stat draws its next seed from wherever construction left off, and `reset`
+     * promises the equivalent of a fresh stat rather than merely an empty one.
+     */
     override fun reset() {
+        seedRng.reset()
         tree = newTree()
     }
 
@@ -101,7 +107,7 @@ class DecisionTreeRegressionStat(
         config = config,
         concurrency = concurrency ?: this.concurrency,
         leafArmFactory = leafArmFactory,
-        randomSeed = seedRng.nextInt(),
+        randomSeed = seedRng.childSeed().toInt(),
     )
 
     /** Live underlying tree. Use for inspection / pretty-printing. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -10,11 +10,11 @@ import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
+import com.eignex.kumulant.math.CounterRandom
 import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.random.Random
 
 /**
  * Online random-forest classifier; the classification counterpart of
@@ -63,8 +63,11 @@ class RandomForestClassifierStat(
     /** [ClassificationTreeConfig] with [ClassificationTreeConfig.mtry] defaulted to `ceil(sqrt(p))` when null. */
     val config: ClassificationTreeConfig = config.copy(mtry = config.mtry ?: defaultMtry(splitCandidates.size))
 
-    private val seedRng = Random(randomSeed)
-    private val baggingRng = Random(seedRng.nextInt())
+    private val seedRng = CounterRandom(randomSeed.toLong(), concurrency)
+
+    // Drawn from on the update path, once per tree, with no lock over it - so it has to be a generator
+    // that concurrent updates can share. See CounterRandom.
+    private val baggingRng = CounterRandom(seedRng.childSeed(), concurrency)
     private var trees: Array<ClassificationTree> = Array(nbrTrees) { newTree() }
 
     private fun newTree(): ClassificationTree = ClassificationTree(
@@ -108,7 +111,14 @@ class RandomForestClassifierStat(
         for (i in trees.indices) trees[i].mergeSnapshot(values.trees[i].root)
     }
 
+    /**
+     * Restarts both seed streams, so the rebuilt forest is the one a fresh stat would have grown and
+     * the bagging draws resume from the start rather than from wherever the old forest left off.
+     * `reset` promises the equivalent of a fresh stat, not merely an emptied one.
+     */
     override fun reset() {
+        seedRng.reset()
+        baggingRng.reset()
         trees = Array(nbrTrees) { newTree() }
     }
 
@@ -121,7 +131,7 @@ class RandomForestClassifierStat(
         bagging = bagging,
         concurrency = concurrency ?: this.concurrency,
         leafArmFactory = leafArmFactory,
-        randomSeed = seedRng.nextInt(),
+        randomSeed = seedRng.childSeed().toInt(),
     )
 
     /** Live underlying classification trees. Use for inspection. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -8,12 +8,12 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
+import com.eignex.kumulant.math.CounterRandom
 import com.eignex.kumulant.math.nextPoissonOne
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.random.Random
 
 /**
  * Online random-forest regressor; a population of [RegressionTree]s sharing the candidate-split
@@ -65,8 +65,11 @@ class RandomForestRegressionStat(
     /** [RegressionTreeConfig] with [RegressionTreeConfig.mtry] defaulted to `ceil(sqrt(p))` when null. */
     val config: RegressionTreeConfig = config.copy(mtry = config.mtry ?: defaultMtry(splitCandidates.size))
 
-    private val seedRng = Random(randomSeed)
-    private val baggingRng = Random(seedRng.nextInt())
+    private val seedRng = CounterRandom(randomSeed.toLong(), concurrency)
+
+    // Drawn from on the update path, once per tree, with no lock over it - so it has to be a generator
+    // that concurrent updates can share. See CounterRandom.
+    private val baggingRng = CounterRandom(seedRng.childSeed(), concurrency)
     private var trees: Array<RegressionTree<VectorView>> = Array(nbrTrees) { newTree() }
 
     private fun newTree(): RegressionTree<VectorView> = RegressionTree(
@@ -102,7 +105,14 @@ class RandomForestRegressionStat(
         for (i in trees.indices) trees[i].mergeSnapshot(values.trees[i].root)
     }
 
+    /**
+     * Restarts both seed streams, so the rebuilt forest is the one a fresh stat would have grown and
+     * the bagging draws resume from the start rather than from wherever the old forest left off.
+     * `reset` promises the equivalent of a fresh stat, not merely an emptied one.
+     */
     override fun reset() {
+        seedRng.reset()
+        baggingRng.reset()
         trees = Array(nbrTrees) { newTree() }
     }
 
@@ -114,7 +124,7 @@ class RandomForestRegressionStat(
         bagging = bagging,
         concurrency = concurrency ?: this.concurrency,
         leafArmFactory = leafArmFactory,
-        randomSeed = seedRng.nextInt(),
+        randomSeed = seedRng.childSeed().toInt(),
     )
 
     /** Live underlying trees. Use for inspection. */

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStatTest.kt
@@ -64,4 +64,53 @@ class RandomForestRegressionStatTest {
         val totals = snap.trees.map { it.totalWeights }
         for (t in totals) assertEquals(200.0, t, 1e-9)
     }
+
+    @Test
+    fun `reset restarts the bagging stream a fresh stat would draw`() {
+        // reset promises the equivalent of a fresh stat, not merely an emptied one. The bagging draws
+        // are the visible half of that: without restarting them the rebuilt forest resumes from
+        // wherever the discarded one left off, and its per-tree weights never match a fresh stat's.
+        val fresh = baggedForest(seed = 7)
+        val reused = baggedForest(seed = 7)
+        feed(reused, 400)
+        reused.reset()
+
+        feed(fresh, 400)
+        feed(reused, 400)
+        assertEquals(perTreeWeights(fresh), perTreeWeights(reused))
+    }
+
+    @Test
+    fun `copies bag independently of the forest they came from`() {
+        // An invariant guard rather than a regression test: copies drew distinct seeds before the
+        // switch to CounterRandom too, since create advanced the parent's generator either way. What
+        // it pins is that create must keep deriving per-copy seeds at all, because a window builds one
+        // slice per copy and slices sharing a stream would bag every observation identically.
+        val template = baggedForest(seed = 11)
+        val first = template.create()
+        val second = template.create()
+        feed(first, 400)
+        feed(second, 400)
+        assertTrue(
+            perTreeWeights(first) != perTreeWeights(second),
+            "copies bagged identically: ${perTreeWeights(first)}",
+        )
+    }
+
+    private fun baggedForest(seed: Int) = RandomForestRegressionStat(
+        featureSize = 1,
+        splitCandidates = emptyList(),
+        nbrTrees = 4,
+        bagging = true,
+        randomSeed = seed,
+    )
+
+    // Per-tree weights rather than a prediction: bagging is exactly what they record, whereas a
+    // forest's prediction converges to the same value however the observations were reweighted.
+    private fun perTreeWeights(stat: RandomForestRegressionStat): List<Double> =
+        stat.read(0L).trees.map { it.totalWeights }
+
+    private fun feed(stat: RandomForestRegressionStat, n: Int) {
+        repeat(n) { stat.update(feat(0.0), 1.0) }
+    }
 }


### PR DESCRIPTION
## What changed

- Added CounterRandom, a kotlin.random.Random whose state is a counter cell resolved through monotonicMode, so drawing from it is safe under any Concurrency level.
- Switched the seed generators in both decision trees and both forests to it, and the forests' bagging generator too.
- Made create derive each copy's seed through childSeed rather than by advancing the parent's generator.
- Made reset restart the seed and bagging streams, so a reset stat is the one a fresh stat would be.

## Why

Three problems in one family, all from the same shared mutable Random.

The one already filed was create: each copy's seed came from seedRng.nextInt() on a generator shared with everything else, and create runs on the update path, because SliceRing builds a slot through it and windowedRead builds an accumulator on every read. Concurrent calls race on a generator with no atomicity.

Worse, and not previously filed: both forests draw baggingRng.nextPoissonOne() once per tree inside update, with no lock over it. That is a shared Random mutated from every updating thread on the hottest path in the stat. A lock is the wrong answer where the whole cost is a draw, so the fix is the same counter approach chosen for SampleGate earlier: each draw is one atomic increment and one mix.

Subclassing Random rather than exposing a bespoke draw method is what matters for the bagging case, because nextPoissonOne consumes a variable number of draws. Every distribution in Distributions.kt keeps working unchanged.

Third: reset restarted neither stream. It rebuilt the trees from wherever seedRng happened to be and left the bagging draws mid-sequence, so a reset forest was an emptied forest rather than a fresh one, which is not what Stat.reset promises. Counters make restarting them a store.

Draws and copies are counted separately so reset can restore the draw sequence without handing a later copy a seed an earlier one already used.

Not changed, having checked: TreeGrowth's own PRNG is touched only at construction or inside splitLock, so it never raced. HalfSpaceTreesStat still passes its own seed to copies, which it must, since merge rejects a mismatched tree structure.

## Testing

Added two tests to RandomForestRegressionStatTest, and verified the first fails against the unfixed code by reverting the reset calls.

The first drafts of both were vacuous: they asserted on predictions, and this training set is separable enough that two differently-bagged forests predict the same value, so they passed with the fix reverted. They asserted on per-tree weights instead, which is what bagging actually records. The copies test is labelled as an invariant guard rather than a regression test, because copies drew distinct seeds before this change as well; the defect there was the race, which no deterministic test pins.

Ran gradlew check lintDocs with rerun-tasks.