### PR TITLE
fix: guard resample buckets against a downdate that empties them

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.requireLiveWeight
 import com.eignex.kumulant.schema.spec.ResampleAggregator
 import com.eignex.kumulant.stream.additiveMode
 import com.eignex.kumulant.stream.guarded
@@ -77,6 +78,14 @@ internal class ResampleByTimeStat<R : Result>(
         lock.guarded {
             val newBucket = timestampNanos.floorDiv(bucketNanos)
             val cur = currentBucket.load()
+            // The same guard the Welford stats downstream apply, for the same reason: Mean divides by
+            // the bucket's accumulated weight, so a downdate that takes it to zero publishes an
+            // infinity that every later read inherits. A downdate can only remove what the open bucket
+            // already holds, and a bucket not yet open holds nothing, hence the zero prior.
+            //
+            // Checked before any cell is written, so a rejected update leaves the stat as it was
+            // rather than half-applied.
+            requireLiveWeight(if (cur == newBucket) bucketWeight.load() else 0.0, weight)
             if (cur == NO_BUCKET) {
                 currentBucket.store(newBucket)
                 seed(value, timestampNanos, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/ResampleAggregator.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/ResampleAggregator.kt
@@ -9,18 +9,32 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 enum class ResampleAggregator {
-    /** Forward the arithmetic mean of in-bucket values (unweighted). */
+    /** Forward the weighted mean of in-bucket values, `Sum(value * weight) / Sum(weight)`. */
     Mean,
 
-    /** Forward the sum of in-bucket values. */
+    /** Forward the weighted sum of in-bucket values, `Sum(value * weight)`. */
     Sum,
 
-    /** Forward the most recent in-bucket value. */
+    /**
+     * Forward the most recent in-bucket value.
+     *
+     * Selects a value rather than accumulating one, so it reads no weight at all - see [Min] for what
+     * that means for a negative one.
+     */
     Last,
 
-    /** Forward the minimum in-bucket value. */
+    /**
+     * Forward the minimum in-bucket value.
+     *
+     * Selects rather than accumulates, so weight does not enter: a minimum has no multiplicity to
+     * scale. The consequence is worth stating, because it is the one place resampling does not do what
+     * a negative weight asks. A downdate small enough to leave the bucket's weight positive is accepted
+     * and reduces that weight, but the value it meant to retract still competes for the extremum, since
+     * there is no arithmetic that removes a value from a minimum. Reach for [Mean] or [Sum] where
+     * retraction has to be exact.
+     */
     Min,
 
-    /** Forward the maximum in-bucket value. */
+    /** Forward the maximum in-bucket value. Weight-agnostic on the same terms as [Min]. */
     Max,
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
@@ -83,6 +83,47 @@ class ResampleTest {
     }
 
     @Test
+    fun `a downdate emptying the open bucket is rejected`() {
+        // The same guard MeanStat and the other Welford stats apply. Without it the flush divides by a
+        // bucket weight of exactly zero and forwards an infinity the delegate never recovers from.
+        val stat = SumStat().resampleByTime(bucket = 100.milliseconds, aggregator = ResampleAggregator.Mean)
+        stat.update(value = 10.0, timestampNanos = 10_000_000L, weight = 1.0)
+        assertFailsWith<IllegalArgumentException> {
+            stat.update(value = 20.0, timestampNanos = 50_000_000L, weight = -1.0)
+        }
+    }
+
+    @Test
+    fun `a downdate opening a bucket is rejected`() {
+        // A bucket not yet open holds nothing, so there is no observation for the downdate to remove.
+        val stat = SumStat().resampleByTime(bucket = 100.milliseconds, aggregator = ResampleAggregator.Mean)
+        assertFailsWith<IllegalArgumentException> {
+            stat.update(value = 10.0, timestampNanos = 10_000_000L, weight = -1.0)
+        }
+    }
+
+    @Test
+    fun `a rejected downdate leaves the bucket as it was`() {
+        // The guard runs before any cell is written, so the open bucket must still flush the value it
+        // held before the rejected call.
+        val stat = SumStat().resampleByTime(bucket = 100.milliseconds, aggregator = ResampleAggregator.Mean)
+        stat.update(value = 10.0, timestampNanos = 10_000_000L, weight = 1.0)
+        runCatching { stat.update(value = 20.0, timestampNanos = 50_000_000L, weight = -1.0) }
+        stat.update(value = 7.0, timestampNanos = 150_000_000L, weight = 1.0)
+        assertEquals(10.0, stat.read().sum, DELTA)
+    }
+
+    @Test
+    fun `a partial downdate is honoured as a weighted removal`() {
+        // Weights 2.0 then -1.0 leave the bucket at 1.0, so the mean is (10*2 - 20*1) / 1 = 0.0.
+        val stat = SumStat().resampleByTime(bucket = 100.milliseconds, aggregator = ResampleAggregator.Mean)
+        stat.update(value = 10.0, timestampNanos = 10_000_000L, weight = 2.0)
+        stat.update(value = 20.0, timestampNanos = 50_000_000L, weight = -1.0)
+        stat.update(value = 7.0, timestampNanos = 150_000_000L, weight = 1.0)
+        assertEquals(0.0, stat.read().sum, DELTA)
+    }
+
+    @Test
     fun `negative bucket duration is rejected`() {
         assertFailsWith<IllegalArgumentException> {
             SumStat().resampleByTime(bucket = (-1L).milliseconds, aggregator = ResampleAggregator.Mean)


### PR DESCRIPTION
## What changed

- resampleByTime now applies requireLiveWeight before touching any cell, so a negative weight that would take the open bucket's accumulated weight to zero or below is rejected instead of accepted.
- Corrected ResampleAggregator.Mean, documented as unweighted when it divides by accumulated weight, and stated the weight semantics of all five.

## Why

Verified rather than reasoned: two updates in one bucket whose weights cancel, (10.0, w=+1) and (20.0, w=-1), made Mean compute -10/0 and forward -Infinity to the delegate at weight 1.0, leaving it non-finite for good.

A negative weight is a real downdate here, not something to drop; it removes an observation the bucket already holds. What is not recoverable is a downdate that empties the bucket, because Mean divides by the accumulated weight. That is the same shape, and the same sentence, as requireLiveWeight already guards for MeanStat, VarianceStat, MomentsStat and SummaryStat. Resample divides by an accumulated weight in exactly their way and was the one accumulator that never adopted the guard, so it is now consistent with the stats it wraps rather than being a special case.

The prior is zero for a bucket that is not yet open, since a downdate can only remove what the bucket already holds, and nothing is open to remove from. The check runs before any cell is written, so a rejected update leaves the stat as it was instead of half-applied.

One thing this does not settle, now documented on Min rather than left implicit. Min, Max and Last select a value rather than accumulate one, so they read no weight. A downdate small enough to leave the bucket's weight positive is accepted and reduces that weight, but the value it meant to retract still competes for the extremum, because there is no arithmetic that removes a value from a minimum. The KDoc says so and points at Mean or Sum where retraction has to be exact.

## Testing

Four tests in ResampleTest: the emptying downdate rejected, a downdate opening a bucket rejected, a rejected downdate leaving the bucket intact, and a partial downdate honoured as a weighted removal.

Verified the first three fail with the guard removed. The fourth passes either way by design; it pins that the guard rejects only the emptying case and leaves legitimate downdates working.

Ran gradlew check lintDocs with rerun-tasks.