### PR TITLE
build: bound the js node tests with mocha

### DIFF
--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -25,7 +25,16 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
     jvm()
-    js { browser(); nodejs() }
+    // Mocha on the js node task, which otherwise runs Kotlin's builtin framework - and that one has
+    // no timeout at all, so a hung test wedges the gate rather than failing it. kbuild bounds Mocha at
+    // 120s through onTestFrameworkSet, so the value is not restated here; measured as 120s, not
+    // Mocha's 2s default, which would be worse than no timeout.
+    //
+    // Not applied to wasmJs or wasmWasi: the Kotlin plugin rejects Mocha on wasm ("Mocha test
+    // framework for Wasm target is not supported. For KotlinWasmNode used") and falls back silently,
+    // so asking for it there buys a warning and nothing else. Those two stay unbounded. The browser
+    // tasks are Karma, which kbuild bounds through a generated config.
+    js { browser(); nodejs { testTask { useMocha() } } }
     wasmJs { browser(); nodejs() }
     wasmWasi { nodejs() }
     linuxX64(); linuxArm64()


### PR DESCRIPTION
## What changed

- js { nodejs } now selects Mocha, so the js node tests run under a timeout instead of none.
- wasmJs and wasmWasi are deliberately left alone, with a comment saying why.

## Why

Kotlin's builtin test framework, which these node tasks used, has no timeout concept at all - grep KotlinWasmNode for "timeout" and there is nothing. A test that hangs therefore wedges the whole gate rather than failing it. Mocha gives the js node task a bound.

The value matters more than the switch. Mocha's own default is 2s, which would be worse than no timeout given some js tests report near a second. kbuild applies 120s through onTestFrameworkSet, so the correct value arrives without being restated here, and I measured it rather than assuming: probing the configured task reports jsNodeTest framework=KotlinMocha mochaTimeout=120s.

wasmJs and wasmWasi cannot have this. KotlinJsTest.useMocha runs its body only when compilation.wasmTarget is null; for a wasm target it logs "Mocha test framework for Wasm target is not supported. For KotlinWasmNode used" and never executes the body, so the framework stays KotlinWasmNode and any timeout passed to it is not even assigned. Asking for Mocha there buys a warning on every build and nothing else. The probe confirms it: wasmWasiNodeTest framework=KotlinWasmNode mochaTimeout=null. Those two stay unbounded, and the comment records that so the next reader does not retry it.

The browser tasks are untouched. They run Karma, which kbuild already bounds through a generated config directory.

This came out of investigating the wasmWasiNodeTest flake and does not fix it - that failure is a trap, not a timeout, and the wasm targets are exactly the ones this cannot reach. It is a separate robustness gap found on the way.

## Testing

Ran gradlew check lintDocs with rerun-tasks. Green, and no "not supported" warning, since Mocha is now only requested where it applies.