### PR TITLE
fix: correct bandit reward scale and weight handling

### DIFF
--- a/docs/internal/BUG_HUNT_2026-08-18.md
+++ b/docs/internal/BUG_HUNT_2026-08-18.md
@@ -1,0 +1,134 @@
+# Bug hunt 2026-08-18
+
+A six-way parallel hunt over `stat/summary`+`decay`+`math`, `stat/regression`, `stat/quantile`+`sketch`+`score`,
+`bandit/`, `stream/`+`core/`+`operation/`, and `schema/`. 37 findings. The bandit findings were measured against a
+compiled jar; the rest are source-verified unless marked PLAUSIBLE.
+
+Nothing here is fixed yet.
+
+## Wrong numbers users would see
+
+1. **`bandit/univariate/Posteriors.kt:61,71,133`** - `GeometricBetaPosterior`, `ExponentialGammaPosterior` and
+   `GammaScalePosterior` sample the rate / success probability, not the reward mean, so `choose()` argmaxes the
+   *worst* arm. Measured: two arms at reward 10.0 and 1.0, the good arm was picked 0 times in 1000 rounds.
+   `PoissonGammaPosterior` samples the mean correctly, so the family is internally inconsistent.
+2. **`stat/decay/EwmaVarianceStat.kt:71,76`** - the M2 increment is centred on the biased mean cell (seeded at 0.0)
+   while `read()` debiases M2, so the zero seed leaks in as a term proportional to `mean^2`. A constant stream of
+   100.0 reports variance 9048 after one update, 67 after fifty; true variance is 0. Not shift-invariant.
+3. **`stat/regression/glm/LinearPosteriors.kt:73-77,98-106,135-145,162-172`** - every concrete `evaluate` override
+   starts from `snapshot.predict(x)` (mu space) and adds an uncertainty term derived from the coefficient
+   posterior (eta space). Under a non-identity link the two scales are unrelated: a Logit `BayesianRegressionStat`
+   under `LinUcb` can score 1.52 for a probability, and saturated arms get the same bonus as arms near 0.5.
+4. **`bandit/univariate/RouletteWheelBandit.kt:135`** - segment average divides `sum(value*weight)` by an unweighted
+   call count, so weight rescales apparent reward. Same reward at weight 3.0 yields arm weight 2.0 instead of 1.0.
+5. **`stat/score/PitTests.kt:41,45-48`** - `pitChiSquared` counts the `[1.0, +Inf)` overflow weight in `total` but
+   only folds it into a bin if the top finite bin is populated. Sparse histograms drop it and then also charge the
+   bin as empty. `pitHistogram(2)` fed 0.25 and 1.0 returns 1.0 where the true statistic is 0.0; `pitKsDistance`
+   on the same input returns 0.0.
+
+## merge/create/read round-trips that corrupt state
+
+6. **`stat/quantile/LinearHistogramStat.kt:61 vs 115-121`** - `matchesLayout` rounds the edge ratio, `binOf`
+   truncates it. `read()` emits `29 * 0.01 = 0.29`, and `0.29 / 0.01 = 28.999...`, so merging a snapshot files the
+   weight in bin 28 whose reported range `[0.28, 0.29)` excludes every value that produced it.
+7. **`stat/quantile/HdrHistogramStat.kt:149-156`** - `merge` re-scales each `lowerBound` through `value * multiplier`,
+   which is not the inverse of `read`'s division. Swept 0..40000: 468 buckets round-trip one low, always downward,
+   so `merge(read())` is not idempotent.
+8. **`stat/regression/tree/TreeGrowth.kt:370-385`** - `cloneFromResult` rebuilds a snapshot subtree with
+   `makeTerminalLeaf` for every leaf, never `makeAuditLeaf`. The standard shard-and-merge flow (fresh accumulator,
+   merge in N worker snapshots) therefore freezes the accumulator's model permanently at merge time.
+9. **`stat/regression/tree/TreeGrowth.kt:313,339`** - leaf merge folds the incoming aggregate into the leaf arm but
+   leaves `posArms`/`negArms` untouched. The split audit then compares an impurity over 40 observations against
+   child impurities over 20, and `shouldSplit` sees a weight total neither replica reached alone: the leaf splits on
+   evidence it does not have, ranked by a mismatched comparison.
+10. **`stat/regression/tree/*Stat.kt` (`DecisionTreeRegression:61,109`, `DecisionTreeClassifier:51,108`,
+    `RandomForestRegression:56,126`, `RandomForestClassifier:53,133`)** - the default `leafArmFactory` closes over the
+    *constructor's* concurrency, and `create()` forwards that same lambda. `create(Concurrency.Strict)` returns a stat
+    that reports Strict and takes a real split lock but grows `Concurrency.None` leaf arms, so concurrent updates into
+    one leaf tear the Welford triple and drop observations. This is the path `StatGroup`/`ListStats` take.
+11. **`bandit/univariate/MultiArmedBandit.kt:110`** - `create(random)` hands the replica the *same* stateful
+    `BanditPolicy`. UCB1 and friends keep a mutable `totalSamples`, and the constructor calls `policy.addArm` per arm,
+    so creating a replica alone shifts the parent's bonus. Measured: parent `evaluate(0)` moved 1.877 -> 2.445 from
+    child-only updates. Spec-built bandits get a fresh policy, so the two paths diverge.
+12. **`stat/quantile/ThresholdBucketStat.kt:72-77`** - `merge` checks only the counts length, never that the incoming
+    result's `thresholds` match. Merging a `[100,200,300]` snapshot into a `[1,2,3]` stat silently succeeds.
+
+## Contract violations (weights, concurrency, reset)
+
+13. **`bandit/contextual/Exp4Bandit.kt:158-166`** - `update` ignores `weight` entirely. Measured: `weight = 0.0` still
+    moves expert weights off uniform, and `weight = 5.0` is byte-identical to `weight = 1.0`.
+14. **`bandit/contextual/KnnContextualBandit.kt:159-174`** - no inert-weight guard; a zero-weight observation consumes
+    a FIFO slot and can evict real data. Measured: k=1, one real observation of 9.0 then two zero-weight zeros ->
+    `evaluate` returns the cold-start score.
+15. **`stat/summary/SummaryStat.kt:108`, `stat/decay/EwmaMeanStat.kt:89`, `stat/decay/EwmaVarianceStat.kt:109`** -
+    `reset()` is not wrapped in `lock.guarded` while `update`/`read` are; every other locked stat in the tree guards
+    its reset. An in-flight update that already did `totalWeights.addAndGet` finishes after the reset, leaving
+    `totalWeights = 0.0` with a non-zero mean and stale min/max.
+16. **`stat/decay/DecayingSumStat.kt:140-143`** - `reset()` does a single un-retried CAS on the epoch reference and
+    silently drops the reset when it loses to a concurrent rotation. Propagates to `DecayingMeanStat`/`DecayingRateStat`.
+17. **`operation/Shifts.kt:58-62,87-91` and `operation/WithSelfLag.kt:49-53`** - `tick`, `ring.load` and `ring.store`
+    are three separate operations, so the `n > k` guard proves a tick was claimed, not that the value was stored. A
+    second thread can read the ring's initial 0.0 and forward it: `DiffSeriesStat` on a 1e6-scale stream emits a
+    fabricated 1e6 difference. Contradicts the file's own contract comment at `Shifts.kt:24-26`.
+18. **`stat/regression/glm/StochasticRegressionStat.kt:153-156`** - under `Penalty.L2`, `require(factor > 0.0)` throws
+    from `update()` on a legal positive weight (`Sgd(ConstantRate(0.01))` + `L2(0.1)` + weight >= 1000). The weight
+    contract says guard against corruption only; the other penalty branches accept the same weight.
+19. **`stream/PlatformMutex.*`** - jvm (`ReentrantLock`) and mingw (`CRITICAL_SECTION`) are recursive; posix
+    (`pthread_mutex_init(ptr, null)`) is not, and web is a no-op. The `expect` declaration documents no reentrancy
+    contract. No current path is reentrant, so this is latent - but `ResampleByTimeStat.update` already calls
+    `delegate.update` from inside its own `guarded` block.
+
+## Composition and operator bugs
+
+20. **`stream/SliceRing.kt:64,95` driven from `operation/WindowedStats.kt:75`** - a bucket rotation rebuilds the whole
+    wrapped chain via `template.create(c)`, so any stateful operator *inside* a window restarts once per slice.
+    `Mean.diff(1).windowed(60_000)` on a stream slower than one observation per slice reads empty forever;
+    `Mean.resampleByTime(60_000).windowed(60_000)` forwards nothing at all; `Mean.throttle(10).windowed(60_000)`
+    forwards nothing below 10 updates per slice. All three are expressible through the public spec API. The code
+    already special-cases `BandSeriesStat` for this hazard and no other operator.
+21. **`operation/Resample.kt:94-101`** - the KDoc says only a *later* bucket closes the open one; the code flushes on
+    any inequality. One late arrival makes a single wall-clock bucket emit twice.
+22. **`operation/Shifts.kt:113-124`** - `DerivativeSeriesStat` guards `deltaNanos` only against exactly 0, so an
+    unsorted replay divides by a negative delta and publishes a large negative rate for an increasing series. It also
+    stores `lastValue`/`lastTimestamp` *before* the early returns, so deliberately dropped updates still move the
+    reference point.
+
+## Schema / wire layer
+
+23. **`schema/runtime/StatSchema.kt:58-59,63-67`** - `GroupStatSpec` carries only `stats`, so a nested schema's
+    `Concurrency` is dropped and the subtree materializes at the parent's level. `StatSchemaConcurrencyTest.kt:53-67`
+    is named for exactly this case but only asserts on `seriesSpecs(inner)` directly, so it passes while the bug stands.
+24. **`schema/runtime/StatGroup.kt:41-42`** - `read` uses `associate`, so duplicate stat names silently collapse and
+    `merge` then feeds the survivor's result into both stats. `AbstractListStats` guards this; `AbstractStatGroup` does not.
+25. **`schema/runtime/StatSchema.kt:49-59`, `StatSchemaDef.kt:38-68`** - there is no `regression` declarator, so
+    `regressionSpecs` always returns empty and `RegressionListStats(schema)` unconditionally throws. The modality is
+    otherwise first-class on the wire.
+26. **`schema/ops/Operations.kt:18,22,26,30` and `schema/spec/Operations.kt:30,40,50,60`** - `withWeight` is documented
+    as a multiplier; `operation/Weights.kt:44-51` replaces the caller weight. `weightBy` is the multiplying operator.
+27. **`schema/spec/Operations.kt:168,176`** - `withTimeAsX`/`withTimeAsY` spec KDoc says nanoseconds;
+    `operation/AxisBindings.kt:23,39` feed fractional seconds. A 1e9 error for anyone trusting the spec doc.
+
+## Lower confidence / validation gaps
+
+28. `stat/regression/tree/ClassCounts.kt:154-160` - `subtractCC` clamps per class, so a residual negative in one class
+    and positive in another reports positive total weight and invents carryover mass. `subtractWVR` does not do this.
+29. `math/Cholesky.kt:43` - `if (norm <= 0.0 || norm >= 1.0)` does not catch NaN, so a NaN norm writes NaN through all
+    of `L` and returns 0.0 ("success"). `BayesianRegressionStat.kt:175-186` then keeps an all-NaN covariance forever.
+    Guard should be `if (!(norm > 0.0 && norm < 1.0))`.
+30. `stat/regression/tree/HoeffdingTreeConfig.kt` (+ `RegressionTreeConfig`, `ClassificationTreeConfig`) - no validation.
+    `delta = 1.0` splits on the first audit; `delta > 1.0` makes the bound NaN and the tree never grows, silently.
+31. `stat/sketch/CountMinSketchStat.kt:377-380`, `SpaceSavingStat.kt:455-465` - `merge` bypasses the `MAX_COUNTER_STEP`
+    saturation that `update` applies, so a saturated counter can wrap negative and break the one-sided guarantee.
+32. `bandit/contextual/KnnContextualBandit.kt:312` - `sparseSquaredL2` uses `a[i] == 0.0` to mean "index absent", but
+    koblas preserves explicitly stored zeros, so such an index is counted in both passes. Measured 18.0 vs 9.0.
+33. `stat/event/ExcursionStat.kt:111-119` - merge takes elementwise max/min and never computes the cross-shard
+    excursion, producing snapshots where `peak - trough` (80) exceeds the reported `maxExcursion` (30). Unlike
+    `AdwinStat.merge` and `MadStat.merge`, no KDoc caveat says the merge is approximate.
+34. `schema/runtime/BanditFactory.kt:346` - `MultiArmedSpec.materialize` never checks `MossSpec.nbrArms` against
+    `MultiArmedSpec.nbrArms`; a mismatched pair silently gets the wrong `t/(K*n)` denominator.
+35. `schema/spec/Stats.kt:249-256` - the `DDSketch` spec cannot express `minIndexableValue`/`maxIndexableValue`, so a
+    non-default `DDSketchStat` silently resets to defaults through a schema round trip.
+36. `stat/forecast/SeasonalSmoothingStat.kt:89-91` - the KDoc describes a first-cycle seasonal seeding that does not
+    exist; updates 2..period run the ordinary recurrence and the first cycle stays near identity.
+37. `stat/summary/CountStat.kt:12-17` - `CountResult` is dead public API registering a wire name no stat emits
+    (`CountStat` is `SeriesStat<SumResult>`).

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -493,6 +493,7 @@ public final class com/eignex/kumulant/bandit/univariate/BanditPoliciesKt {
 public abstract interface class com/eignex/kumulant/bandit/univariate/BanditPolicy {
 	public fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public abstract fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
 	public fun removeArm (Lcom/eignex/kumulant/core/Result;)V
@@ -503,6 +504,7 @@ public abstract interface class com/eignex/kumulant/bandit/univariate/BanditPoli
 public final class com/eignex/kumulant/bandit/univariate/BanditPolicy$DefaultImpls {
 	public static fun addArm (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;Lcom/eignex/kumulant/core/Result;)V
 	public static fun createArm (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;)Lcom/eignex/kumulant/core/SeriesStat;
+	public static fun createPolicy (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;)Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public static fun removeArm (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;Lcom/eignex/kumulant/core/Result;)V
 	public static fun update (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;Lcom/eignex/kumulant/core/SeriesStat;DD)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;Lcom/eignex/kumulant/core/SeriesStat;DDILjava/lang/Object;)V
@@ -722,6 +724,8 @@ public final class com/eignex/kumulant/bandit/univariate/EpsilonDecreasing : com
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/EpsilonDecreasing;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -777,6 +781,7 @@ public final class com/eignex/kumulant/bandit/univariate/EpsilonGreedy : com/eig
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -966,6 +971,7 @@ public final class com/eignex/kumulant/bandit/univariate/Greedy : com/eignex/kum
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -1016,6 +1022,8 @@ public final class com/eignex/kumulant/bandit/univariate/KlUcb : com/eignex/kumu
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/BernoulliSumResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/KlUcb;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/BernoulliSumResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -1184,6 +1192,8 @@ public final class com/eignex/kumulant/bandit/univariate/Moss : com/eignex/kumul
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/WeightedMeanResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/Moss;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/WeightedMeanResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -1342,15 +1352,15 @@ public final class com/eignex/kumulant/bandit/univariate/Posterior$Companion {
 
 public final class com/eignex/kumulant/bandit/univariate/RouletteWheelArmResult : com/eignex/kumulant/core/Result {
 	public static final field Companion Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult$Companion;
-	public fun <init> (DDI)V
+	public fun <init> (DDD)V
 	public final fun component1 ()D
 	public final fun component2 ()D
-	public final fun component3 ()I
-	public final fun copy (DDI)Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;DDIILjava/lang/Object;)Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;
+	public final fun component3 ()D
+	public final fun copy (DDD)Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;DDDILjava/lang/Object;)Lcom/eignex/kumulant/bandit/univariate/RouletteWheelArmResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccumulatedScore ()D
-	public final fun getCallCount ()I
+	public final fun getTotalWeights ()D
 	public final fun getWeight ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1435,6 +1445,7 @@ public final class com/eignex/kumulant/bandit/univariate/ThompsonSampling : com/
 	public fun <init> (Lcom/eignex/kumulant/bandit/univariate/Arm;Lcom/eignex/kumulant/bandit/univariate/Posterior;)V
 	public fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
 	public final fun getPosterior ()Lcom/eignex/kumulant/bandit/univariate/Posterior;
@@ -1534,6 +1545,8 @@ public final class com/eignex/kumulant/bandit/univariate/UCB1 : com/eignex/kumul
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/BernoulliSumResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/UCB1;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/BernoulliSumResult;JLkotlin/random/Random;)D
 	public final fun getAlpha ()D
@@ -1551,6 +1564,8 @@ public final class com/eignex/kumulant/bandit/univariate/UCB1Normal : com/eignex
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/MomentsResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/UCB1Normal;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/MomentsResult;JLkotlin/random/Random;)D
 	public final fun getAlpha ()D
@@ -1568,6 +1583,8 @@ public final class com/eignex/kumulant/bandit/univariate/UCB1Tuned : com/eignex/
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/MomentsResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/UCB1Tuned;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/MomentsResult;JLkotlin/random/Random;)D
 	public final fun getAlpha ()D
@@ -1684,6 +1701,8 @@ public final class com/eignex/kumulant/bandit/univariate/UcbV : com/eignex/kumul
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/MomentsResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public synthetic fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/UcbV;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/MomentsResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;
@@ -1737,6 +1756,7 @@ public final class com/eignex/kumulant/bandit/univariate/UniformSelection : com/
 	public synthetic fun addArm (Lcom/eignex/kumulant/core/Result;)V
 	public fun addArm (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)V
 	public fun createArm ()Lcom/eignex/kumulant/core/SeriesStat;
+	public fun createPolicy ()Lcom/eignex/kumulant/bandit/univariate/BanditPolicy;
 	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;JLkotlin/random/Random;)D
 	public fun evaluate (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;JLkotlin/random/Random;)D
 	public synthetic fun getArm ()Lcom/eignex/kumulant/bandit/univariate/Arm;

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -105,6 +105,7 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.ban
     abstract fun evaluate(#A, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/BanditPolicy.evaluate|evaluate(1:0;kotlin.Long;kotlin.random.Random){}[0]
     open fun addArm(#A) // com.eignex.kumulant.bandit.univariate/BanditPolicy.addArm|addArm(1:0){}[0]
     open fun createArm(): com.eignex.kumulant.core/SeriesStat<#A> // com.eignex.kumulant.bandit.univariate/BanditPolicy.createArm|createArm(){}[0]
+    open fun createPolicy(): com.eignex.kumulant.bandit.univariate/BanditPolicy<#A> // com.eignex.kumulant.bandit.univariate/BanditPolicy.createPolicy|createPolicy(){}[0]
     open fun removeArm(#A) // com.eignex.kumulant.bandit.univariate/BanditPolicy.removeArm|removeArm(1:0){}[0]
     open fun update(com.eignex.kumulant.core/SeriesStat<#A>, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.bandit.univariate/BanditPolicy.update|update(com.eignex.kumulant.core.SeriesStat<1:0>;kotlin.Double;kotlin.Double){}[0]
 }
@@ -1591,6 +1592,7 @@ final class com.eignex.kumulant.bandit.univariate/EpsilonDecreasing : com.eignex
         final fun <get-epsilon>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.epsilon.<get-epsilon>|<get-epsilon>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/WeightedVarianceResult) // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.addArm|addArm(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/EpsilonDecreasing // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/WeightedVarianceResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.evaluate|evaluate(com.eignex.kumulant.stat.summary.WeightedVarianceResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/WeightedVarianceResult) // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.removeArm|removeArm(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/EpsilonDecreasing.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.Double;kotlin.Double){}[0]
@@ -1844,6 +1846,7 @@ final class com.eignex.kumulant.bandit.univariate/KlUcb : com.eignex.kumulant.ba
         final fun <get-tolerance>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/KlUcb.tolerance.<get-tolerance>|<get-tolerance>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/BernoulliSumResult) // com.eignex.kumulant.bandit.univariate/KlUcb.addArm|addArm(com.eignex.kumulant.stat.summary.BernoulliSumResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/KlUcb // com.eignex.kumulant.bandit.univariate/KlUcb.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/BernoulliSumResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/KlUcb.evaluate|evaluate(com.eignex.kumulant.stat.summary.BernoulliSumResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/BernoulliSumResult) // com.eignex.kumulant.bandit.univariate/KlUcb.removeArm|removeArm(com.eignex.kumulant.stat.summary.BernoulliSumResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/KlUcb.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.BernoulliSumResult>;kotlin.Double;kotlin.Double){}[0]
@@ -1992,6 +1995,7 @@ final class com.eignex.kumulant.bandit.univariate/Moss : com.eignex.kumulant.ban
         final fun <get-nbrArms>(): kotlin/Int // com.eignex.kumulant.bandit.univariate/Moss.nbrArms.<get-nbrArms>|<get-nbrArms>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/WeightedMeanResult) // com.eignex.kumulant.bandit.univariate/Moss.addArm|addArm(com.eignex.kumulant.stat.summary.WeightedMeanResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/Moss // com.eignex.kumulant.bandit.univariate/Moss.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/WeightedMeanResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/Moss.evaluate|evaluate(com.eignex.kumulant.stat.summary.WeightedMeanResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/WeightedMeanResult) // com.eignex.kumulant.bandit.univariate/Moss.removeArm|removeArm(com.eignex.kumulant.stat.summary.WeightedMeanResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/WeightedMeanResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/Moss.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.WeightedMeanResult>;kotlin.Double;kotlin.Double){}[0]
@@ -2063,19 +2067,19 @@ final class com.eignex.kumulant.bandit.univariate/NormalArm : com.eignex.kumulan
 }
 
 final class com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult : com.eignex.kumulant.core/Result { // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult|null[0]
-    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Int) // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Int){}[0]
+    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double){}[0]
 
     final val accumulatedScore // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.accumulatedScore|{}accumulatedScore[0]
         final fun <get-accumulatedScore>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.accumulatedScore.<get-accumulatedScore>|<get-accumulatedScore>(){}[0]
-    final val callCount // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.callCount|{}callCount[0]
-        final fun <get-callCount>(): kotlin/Int // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.callCount.<get-callCount>|<get-callCount>(){}[0]
+    final val totalWeights // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.totalWeights|{}totalWeights[0]
+        final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weight // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.weight|{}weight[0]
         final fun <get-weight>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.weight.<get-weight>|<get-weight>(){}[0]
 
     final fun component1(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.component2|component2(){}[0]
-    final fun component3(): kotlin/Int // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.component3|component3(){}[0]
-    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Int = ...): com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.copy|copy(kotlin.Double;kotlin.Double;kotlin.Int){}[0]
+    final fun component3(): kotlin/Double // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.component3|component3(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.copy|copy(kotlin.Double;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.bandit.univariate/RouletteWheelArmResult.toString|toString(){}[0]
@@ -2166,6 +2170,7 @@ final class com.eignex.kumulant.bandit.univariate/UCB1 : com.eignex.kumulant.ban
         final fun <get-arm>(): com.eignex.kumulant.bandit.univariate/BernoulliArm // com.eignex.kumulant.bandit.univariate/UCB1.arm.<get-arm>|<get-arm>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/BernoulliSumResult) // com.eignex.kumulant.bandit.univariate/UCB1.addArm|addArm(com.eignex.kumulant.stat.summary.BernoulliSumResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/UCB1 // com.eignex.kumulant.bandit.univariate/UCB1.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/BernoulliSumResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/UCB1.evaluate|evaluate(com.eignex.kumulant.stat.summary.BernoulliSumResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/BernoulliSumResult) // com.eignex.kumulant.bandit.univariate/UCB1.removeArm|removeArm(com.eignex.kumulant.stat.summary.BernoulliSumResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/UCB1.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.BernoulliSumResult>;kotlin.Double;kotlin.Double){}[0]
@@ -2180,6 +2185,7 @@ final class com.eignex.kumulant.bandit.univariate/UCB1Normal : com.eignex.kumula
         final fun <get-arm>(): com.eignex.kumulant.bandit.univariate/MomentsArm // com.eignex.kumulant.bandit.univariate/UCB1Normal.arm.<get-arm>|<get-arm>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UCB1Normal.addArm|addArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/UCB1Normal // com.eignex.kumulant.bandit.univariate/UCB1Normal.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/MomentsResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/UCB1Normal.evaluate|evaluate(com.eignex.kumulant.stat.summary.MomentsResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UCB1Normal.removeArm|removeArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
 }
@@ -2193,6 +2199,7 @@ final class com.eignex.kumulant.bandit.univariate/UCB1Tuned : com.eignex.kumulan
         final fun <get-arm>(): com.eignex.kumulant.bandit.univariate/MomentsArm // com.eignex.kumulant.bandit.univariate/UCB1Tuned.arm.<get-arm>|<get-arm>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UCB1Tuned.addArm|addArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/UCB1Tuned // com.eignex.kumulant.bandit.univariate/UCB1Tuned.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/MomentsResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/UCB1Tuned.evaluate|evaluate(com.eignex.kumulant.stat.summary.MomentsResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UCB1Tuned.removeArm|removeArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/MomentsResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/UCB1Tuned.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.MomentsResult>;kotlin.Double;kotlin.Double){}[0]
@@ -2305,6 +2312,7 @@ final class com.eignex.kumulant.bandit.univariate/UcbV : com.eignex.kumulant.ban
         final fun <get-zeta>(): kotlin/Double // com.eignex.kumulant.bandit.univariate/UcbV.zeta.<get-zeta>|<get-zeta>(){}[0]
 
     final fun addArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UcbV.addArm|addArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
+    final fun createPolicy(): com.eignex.kumulant.bandit.univariate/UcbV // com.eignex.kumulant.bandit.univariate/UcbV.createPolicy|createPolicy(){}[0]
     final fun evaluate(com.eignex.kumulant.stat.summary/MomentsResult, kotlin/Long, kotlin.random/Random): kotlin/Double // com.eignex.kumulant.bandit.univariate/UcbV.evaluate|evaluate(com.eignex.kumulant.stat.summary.MomentsResult;kotlin.Long;kotlin.random.Random){}[0]
     final fun removeArm(com.eignex.kumulant.stat.summary/MomentsResult) // com.eignex.kumulant.bandit.univariate/UcbV.removeArm|removeArm(com.eignex.kumulant.stat.summary.MomentsResult){}[0]
     final fun update(com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/MomentsResult>, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.univariate/UcbV.update|update(com.eignex.kumulant.core.SeriesStat<com.eignex.kumulant.stat.summary.MomentsResult>;kotlin.Double;kotlin.Double){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -94,11 +94,17 @@ fun <R : Result> BanditPolicySpec<R>.materialize(): BanditPolicy<R> = when (this
 }
 
 /** Build a live [UnivariateBandit] from its spec. */
-fun MultiArmedSpec<*>.materialize(random: Random = Random.Default): MultiArmedBandit<Result> = MultiArmedBandit(
-    nbrArms = nbrArms,
-    policy = policy.materialize() as BanditPolicy<Result>,
-    random = random,
-)
+fun MultiArmedSpec<*>.materialize(random: Random = Random.Default): MultiArmedBandit<Result> {
+    val moss = policy as? MossSpec
+    require(moss == null || moss.nbrArms == nbrArms) {
+        "MossSpec.nbrArms (${moss?.nbrArms}) must match MultiArmedSpec.nbrArms ($nbrArms)"
+    }
+    return MultiArmedBandit(
+        nbrArms = nbrArms,
+        policy = policy.materialize() as BanditPolicy<Result>,
+        random = random,
+    )
+}
 
 /** Build a live [RouletteWheelBandit] from its spec. */
 fun RouletteWheelSpec.materialize(random: Random = Random.Default): RouletteWheelBandit =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/ExponentialWeights.kt
@@ -52,7 +52,7 @@ internal fun Random.sampleFromDistribution(p: DoubleArray): Int {
     var u = nextDouble()
     for (a in p.indices) {
         u -= p[a]
-        if (u <= 0.0) return a
+        if (u < 0.0) return a
     }
     return p.size - 1
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -160,7 +160,7 @@ class Exp4Bandit(
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)
         val pPlayed = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
-        val gainPlayed = reward / pPlayed
+        val gainPlayed = (reward * weight) / pPlayed
         for (i in experts.indices) {
             val expertGain = lastAdvice[i][armIndex] * gainPlayed
             weights[i] *= exp(eta * expertGain)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -12,6 +12,7 @@ import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -158,6 +159,8 @@ class KnnContextualBandit(
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
     override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
+        // An inert observation must not consume a history slot; the eviction below would drop real data.
+        if (weight.isInertWeight()) return
         val ctxs = historyContexts[armIndex]
         val rs = historyRewards[armIndex]
         val ws = historyWeights[armIndex]
@@ -308,8 +311,9 @@ class KnnContextualBandit(
                 val d = v - b[i]
                 s += d * d
             }
+            // Membership, not value: a stored zero is already covered by the first loop.
             b.forEachStored { i, v ->
-                if (a[i] == 0.0) s += v * v
+                if (i !in a.indices) s += v * v
             }
             return s
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
@@ -87,6 +87,14 @@ interface BanditPolicy<R : Result> {
      * their global counters. Default no-op.
      */
     fun removeArm(snapshot: R) {}
+
+    /**
+     * Fresh policy carrying the same configuration but no accumulated global state.
+     * A replica bandit must not share counters with the bandit it was created from,
+     * so any policy holding mutable state has to override this; the default returns
+     * `this` because a stateless policy is safe to share.
+     */
+    fun createPolicy(): BanditPolicy<R> = this
 }
 
 /**
@@ -173,6 +181,7 @@ class UCB1(
 ) : BanditPolicy<BernoulliSumResult> {
     override val arm = BernoulliArm(priorAlpha, priorBeta)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() = UCB1(alpha, arm.priorAlpha, arm.priorBeta)
 
     override fun update(stat: SeriesStat<BernoulliSumResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
@@ -211,6 +220,7 @@ class UCB1Normal(
 ) : BanditPolicy<MomentsResult> {
     override val arm = MomentsArm(priorMean, priorWeight)
     private var nbrArms = 0
+    override fun createPolicy() = UCB1Normal(alpha, arm.priorMean, arm.priorWeight)
 
     override fun evaluate(snapshot: MomentsResult, step: Long, rng: Random): Double {
         val nj = snapshot.totalWeights
@@ -256,6 +266,7 @@ class UCB1Tuned(
 ) : BanditPolicy<MomentsResult> {
     override val arm = MomentsArm(priorMean, priorWeight)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() = UCB1Tuned(alpha, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<MomentsResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
@@ -348,6 +359,8 @@ class EpsilonDecreasing(
     }
     override val arm = NormalArm(priorMean, priorWeight, priorSquaredDeviations)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() =
+        EpsilonDecreasing(epsilon, decay, arm.priorMean, arm.priorWeight, arm.priorSquaredDeviations)
 
     override fun update(stat: SeriesStat<WeightedVarianceResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
@@ -412,6 +425,7 @@ class KlUcb(
 ) : BanditPolicy<BernoulliSumResult> {
     override val arm = BernoulliArm(priorAlpha, priorBeta)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() = KlUcb(c, tolerance, arm.priorAlpha, arm.priorBeta)
 
     override fun update(stat: SeriesStat<BernoulliSumResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
@@ -489,6 +503,7 @@ class Moss(
     }
     override val arm = MeanArm(priorMean, priorWeight)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() = Moss(nbrArms, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<WeightedMeanResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
@@ -539,6 +554,7 @@ class UcbV(
     }
     override val arm = MomentsArm(priorMean, priorWeight)
     private var totalSamples: Double = 0.0
+    override fun createPolicy() = UcbV(zeta, c, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<MomentsResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -111,6 +111,8 @@ class Exp3Bandit(
     /** Fold a `(arm, reward)` observation into the played arm's weight. */
     override fun update(armIndex: Int, value: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
+        // Recomputed rather than reused from choose: one field cannot carry the propensity of
+        // every arm chosen since, so a stale distribution would be wrong more often than a fresh one.
         playDistribution().also { lastPlayDist = it }
         val p = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
         val gain = (value * weight) / p

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBandit.kt
@@ -107,7 +107,7 @@ class MultiArmedBandit<R : Result>(
         step.store(0L)
     }
 
-    override fun create(random: Random): MultiArmedBandit<R> = MultiArmedBandit(nbrArms, policy, random)
+    override fun create(random: Random): MultiArmedBandit<R> = MultiArmedBandit(nbrArms, policy.createPolicy(), random)
 
     /**
      * Live per-arm accumulator owned by this bandit. Exposed so callers can compose with

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Posteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Posteriors.kt
@@ -52,23 +52,23 @@ data object PoissonGammaPosterior : Posterior<WeightedMeanResult> {
     }
 }
 
-/** Beta posterior over a Geometric success probability. */
+/** Beta posterior over a Geometric success probability, reported as the mean trial count `1/p`. */
 @Serializable
 @SerialName("GeometricBetaPosterior")
 data object GeometricBetaPosterior : Posterior<WeightedMeanResult> {
     override fun sample(snapshot: WeightedMeanResult, rng: Random): Double {
         val sum = snapshot.mean * snapshot.totalWeights
-        return rng.nextBeta(snapshot.totalWeights, sum - snapshot.totalWeights)
+        return 1.0 / rng.nextBeta(snapshot.totalWeights, sum - snapshot.totalWeights)
     }
 }
 
-/** Gamma posterior over an Exponential rate. */
+/** Gamma posterior over an Exponential rate, reported as the mean inter-arrival time `1/lambda`. */
 @Serializable
 @SerialName("ExponentialGammaPosterior")
 data object ExponentialGammaPosterior : Posterior<WeightedMeanResult> {
     override fun sample(snapshot: WeightedMeanResult, rng: Random): Double {
         val sum = snapshot.mean * snapshot.totalWeights
-        return rng.nextGamma(snapshot.totalWeights) / sum
+        return sum / rng.nextGamma(snapshot.totalWeights)
     }
 }
 
@@ -118,9 +118,9 @@ data object LogNormalGammaPosterior : Posterior<WeightedVarianceResult> {
 }
 
 /**
- * Gamma posterior over the *scale* of a Gamma likelihood with fixed shape - the shape
- * is a posterior parameter rather than something we infer from data. Not an `object`
- * because of that parameter.
+ * Gamma posterior over the *scale* of a Gamma likelihood with fixed shape, reported as the
+ * mean `fixedShape * scale`. The shape is a posterior parameter rather than something we
+ * infer from data, so this is not an `object`.
  */
 @Serializable
 @SerialName("GammaScalePosterior")
@@ -130,6 +130,6 @@ data class GammaScalePosterior(
 ) : Posterior<WeightedMeanResult> {
     override fun sample(snapshot: WeightedMeanResult, rng: Random): Double {
         val sum = snapshot.mean * snapshot.totalWeights
-        return rng.nextGamma(snapshot.totalWeights * fixedShape) / sum
+        return fixedShape * sum / rng.nextGamma(snapshot.totalWeights * fixedShape)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
@@ -23,8 +23,8 @@ data class RouletteWheelArmResult(
     val weight: Double,
     /** Sum of rewards observed for this arm since the last segment rebalance. */
     val accumulatedScore: Double,
-    /** Number of updates observed for this arm since the last segment rebalance. */
-    val callCount: Int,
+    /** Total observation weight recorded for this arm since the last segment rebalance. */
+    val totalWeights: Double,
 ) : Result
 
 /**
@@ -34,7 +34,7 @@ data class RouletteWheelArmResult(
  *
  * After every [segmentLength] [update] calls, weights re-balance via
  * `w_i = w_i · (1 - reactionFactor) + reactionFactor · avgScore_i`, where
- * `avgScore_i` is the mean reward per call of arm `i` over the segment,
+ * `avgScore_i` is the weight-normalised mean reward of arm `i` over the segment,
  * floored at [minWeight] so no arm is permanently extinguished. Batched
  * re-balance (rather than per-observation) is useful when rewards are noisy
  * and continuous updates would thrash. Only meaningful for
@@ -51,7 +51,7 @@ data class RouletteWheelArmResult(
  * operators matters more than fine-grained per-step tracking.
  *
  * **Arms:** indexless, `nbrArms` fixed at construction; per-arm state is
- * `(weight, segment score sum, segment call count)`.
+ * `(weight, segment score sum, segment weight sum)`.
  *
  * **Memory:** O(nbrArms); three parallel arrays plus a segment counter.
  *
@@ -93,7 +93,7 @@ class RouletteWheelBandit(
 
     private val weights = DoubleArray(nbrArms) { initialWeight }
     private val accumulatedScores = DoubleArray(nbrArms)
-    private val callCounts = IntArray(nbrArms)
+    private val segmentWeights = DoubleArray(nbrArms)
     private var picksThisSegment = 0
 
     override fun choose(): Int {
@@ -121,7 +121,7 @@ class RouletteWheelBandit(
         // Zero weight means "ignore this observation" library-wide.
         if (weight.isInertWeight()) return
         accumulatedScores[armIndex] += value * weight
-        callCounts[armIndex]++
+        segmentWeights[armIndex] += weight
         picksThisSegment++
         if (picksThisSegment >= segmentLength) {
             rebalance()
@@ -131,22 +131,22 @@ class RouletteWheelBandit(
 
     private fun rebalance() {
         for (i in weights.indices) {
-            if (callCounts[i] > 0) {
-                val avg = accumulatedScores[i] / callCounts[i]
+            if (segmentWeights[i] > 0.0) {
+                val avg = accumulatedScores[i] / segmentWeights[i]
                 weights[i] = (weights[i] * (1.0 - reactionFactor) + reactionFactor * avg)
                     .coerceAtLeast(minWeight)
             }
             accumulatedScores[i] = 0.0
-            callCounts[i] = 0
+            segmentWeights[i] = 0.0
         }
     }
 
     override fun snapshot(): List<RouletteWheelArmResult> =
-        List(nbrArms) { RouletteWheelArmResult(weights[it], accumulatedScores[it], callCounts[it]) }
+        List(nbrArms) { RouletteWheelArmResult(weights[it], accumulatedScores[it], segmentWeights[it]) }
 
     /**
      * Heuristic merge: weights are arithmetically averaged across replicas; scores and
-     * call counts are summed (treating the other replica's segment as additional
+     * segment weights are summed (treating the other replica's segment as additional
      * unobserved data). Roulette-wheel adaptive selection has no canonical merge
      * semantics - the segment-based rebalance is inherently sequential - so use this
      * for "roughly combine two parallel runs" rather than for principled aggregation.
@@ -156,7 +156,7 @@ class RouletteWheelBandit(
         for (i in 0 until nbrArms) {
             weights[i] = ((weights[i] + other[i].weight) / 2.0).coerceAtLeast(minWeight)
             accumulatedScores[i] += other[i].accumulatedScore
-            callCounts[i] += other[i].callCount
+            segmentWeights[i] += other[i].totalWeights
         }
     }
 
@@ -164,7 +164,7 @@ class RouletteWheelBandit(
         for (i in 0 until nbrArms) {
             weights[i] = initialWeight
             accumulatedScores[i] = 0.0
-            callCounts[i] = 0
+            segmentWeights[i] = 0.0
         }
         picksThisSegment = 0
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -10,8 +10,8 @@ import com.eignex.kumulant.bandit.univariate.BetaPosterior
 import com.eignex.kumulant.bandit.univariate.BoltzmannSpec
 import com.eignex.kumulant.bandit.univariate.Exp3Bandit
 import com.eignex.kumulant.bandit.univariate.Exp3Spec
-import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.MossSpec
+import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.MultiArmedSpec
 import com.eignex.kumulant.bandit.univariate.NormalArm
 import com.eignex.kumulant.bandit.univariate.NormalGammaPosterior

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditFactoryTest.kt
@@ -11,6 +11,7 @@ import com.eignex.kumulant.bandit.univariate.BoltzmannSpec
 import com.eignex.kumulant.bandit.univariate.Exp3Bandit
 import com.eignex.kumulant.bandit.univariate.Exp3Spec
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
+import com.eignex.kumulant.bandit.univariate.MossSpec
 import com.eignex.kumulant.bandit.univariate.MultiArmedSpec
 import com.eignex.kumulant.bandit.univariate.NormalArm
 import com.eignex.kumulant.bandit.univariate.NormalGammaPosterior
@@ -24,6 +25,7 @@ import kotlinx.serialization.json.Json
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BanditFactoryTest {
@@ -135,5 +137,12 @@ class BanditFactoryTest {
         val encoded = json.encodeToString(UnivariateBanditSpec.serializer(), spec)
         val decoded = json.decodeFromString(UnivariateBanditSpec.serializer(), encoded)
         assertEquals(spec, decoded)
+    }
+
+    @Test
+    fun `MultiArmedSpec rejects a Moss policy with a different arm count`() {
+        assertFailsWith<IllegalArgumentException> {
+            MultiArmedSpec(nbrArms = 3, policy = MossSpec(nbrArms = 5)).materialize()
+        }
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ExponentialWeightsTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.bandit
 
 import com.eignex.kumulant.DELTA
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -89,5 +90,13 @@ class ExponentialWeightsTest {
     private fun DoubleArray.all(predicate: (Double) -> Boolean): Boolean {
         for (v in this) if (!predicate(v)) return false
         return true
+    }
+
+    @Test
+    fun `sampleFromDistribution skips a zero-probability leading arm`() {
+        val alwaysZero = object : Random() {
+            override fun nextBits(bitCount: Int): Int = 0
+        }
+        assertEquals(1, alwaysZero.sampleFromDistribution(doubleArrayOf(0.0, 1.0)))
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -113,4 +113,26 @@ class Exp4BanditTest {
         val w = bandit.expertWeights()
         assertTrue(w[0] > w[1], "left expert should dominate: $w")
     }
+
+    @Test
+    fun `zero-weight update leaves the expert weights untouched`() {
+        val expertA = Exp4Expert { _, n -> DoubleArray(n).also { it[0] = 1.0 } }
+        val expertB = Exp4Expert { _, n -> DoubleArray(n).also { it[1] = 1.0 } }
+        val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(expertA, expertB), random = Random(1))
+        val before = bandit.expertWeights().toList()
+        bandit.update(0, feat(0.0), 1.0, weight = 0.0)
+        assertEquals(before, bandit.expertWeights().toList())
+    }
+
+    @Test
+    fun `observation weight scales the expert weight update`() {
+        fun weightsAfter(observationWeight: Double): List<Double> {
+            val expertA = Exp4Expert { _, n -> DoubleArray(n).also { it[0] = 1.0 } }
+            val expertB = Exp4Expert { _, n -> DoubleArray(n).also { it[1] = 1.0 } }
+            val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(expertA, expertB), random = Random(1))
+            bandit.update(0, feat(0.0), 1.0, weight = observationWeight)
+            return bandit.expertWeights().toList()
+        }
+        assertTrue(weightsAfter(5.0)[0] > weightsAfter(1.0)[0])
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -129,4 +129,21 @@ class KnnContextualBanditTest {
         val q = DenseVector.of(doubleArrayOf(0.5, 0.0, 0.0, 1.5))
         assertEquals(denseInput.evaluate(0, q), sparseInput.evaluate(0, q), 1e-12)
     }
+
+    @Test
+    fun `zero-weight update does not displace real history`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 2, exploration = 0.0)
+        val x = feat(0.0)
+        bandit.update(0, x, 9.0, weight = 1.0)
+        bandit.update(0, x, 0.0, weight = 0.0)
+        bandit.update(0, x, 0.0, weight = 0.0)
+        assertEquals(9.0, bandit.evaluate(0, x))
+    }
+
+    @Test
+    fun `squaredL2 counts a stored zero once`() {
+        val a = SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
+        val b = SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
+        assertEquals(9.0, squaredL2(a, b))
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BanditPoliciesTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BanditPoliciesTest.kt
@@ -56,11 +56,11 @@ class BanditPoliciesTest {
     }
 
     @Test
-    fun `GeometricTS evaluate in 0_1`() {
+    fun `GeometricTS evaluate is a finite trial count`() {
         val mab = drive(GeometricTS(), listOf(2.0, 3.0, 4.0, 1.0))
         repeat(20) {
             val s = mab.evaluate(0)
-            assertTrue(s.isFinite() && s in 0.0..1.0)
+            assertTrue(s.isFinite() && s > 1.0)
         }
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/MultiArmedBanditTest.kt
@@ -115,4 +115,14 @@ class MultiArmedBanditTest {
         val origTrials = original.armResult(0).trials
         assertTrue(origTrials > freshTrials)
     }
+
+    @Test
+    fun `create yields a replica whose updates leave the parent score alone`() {
+        val parent = MultiArmedBandit(nbrArms = 3, policy = UCB1(), random = Random(3))
+        for (i in 0 until 3) parent.update(i, 1.0)
+        val before = parent.evaluate(0)
+        val child = parent.create(Random(4))
+        repeat(100) { child.update(0, 1.0) }
+        assertEquals(before, parent.evaluate(0))
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/PosteriorsExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/PosteriorsExtraTest.kt
@@ -71,12 +71,12 @@ class PosteriorsExtraTest {
     }
 
     @Test
-    fun `GeometricBetaPosterior samples in 0_1`() {
+    fun `GeometricBetaPosterior samples exceed one trial`() {
         val snap = WeightedMeanResult(totalWeights = 20.0, mean = 2.0)
         val rng = Random(5)
         repeat(50) {
             val s = GeometricBetaPosterior.sample(snap, rng)
-            assertTrue(s in 0.0..1.0, "got $s")
+            assertTrue(s.isFinite() && s > 1.0, "got $s")
         }
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/PosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/PosteriorsTest.kt
@@ -39,18 +39,22 @@ class PosteriorsTest {
     }
 
     @Test
-    fun `GeometricBetaPosterior samples are in 0_1`() {
-        val snap = WeightedMeanResult(totalWeights = 6.0, mean = 3.0)
+    fun `GeometricBetaPosterior samples center on the observed trial count`() {
+        val snap = WeightedMeanResult(totalWeights = 400.0, mean = 3.0)
         val rng = Random(3)
-        repeat(200) {
+        var sum = 0.0
+        val n = 3000
+        repeat(n) {
             val s = GeometricBetaPosterior.sample(snap, rng)
-            assertTrue(s.isFinite() && s in 0.0..1.0)
+            assertTrue(s.isFinite() && s > 1.0)
+            sum += s
         }
+        assertTrue(abs(sum / n - 3.0) < 0.15)
     }
 
     @Test
-    fun `ExponentialGammaPosterior samples are positive finite`() {
-        val snap = WeightedMeanResult(totalWeights = 5.0, mean = 2.0)
+    fun `ExponentialGammaPosterior samples center on the observed reward mean`() {
+        val snap = WeightedMeanResult(totalWeights = 200.0, mean = 2.0)
         val rng = Random(4)
         var sum = 0.0
         val n = 3000
@@ -59,7 +63,7 @@ class PosteriorsTest {
             assertTrue(s.isFinite() && s > 0.0)
             sum += s
         }
-        assertTrue(abs(sum / n - 0.5) < 0.05)
+        assertTrue(abs(sum / n - 2.0) < 0.1)
     }
 
     @Test
@@ -87,9 +91,9 @@ class PosteriorsTest {
     }
 
     @Test
-    fun `GammaScalePosterior samples are positive finite`() {
+    fun `GammaScalePosterior samples center on the observed reward mean`() {
         val pos = GammaScalePosterior(fixedShape = 2.0)
-        val snap = WeightedMeanResult(totalWeights = 5.0, mean = 1.0)
+        val snap = WeightedMeanResult(totalWeights = 200.0, mean = 1.0)
         val rng = Random(7)
         var sum = 0.0
         val n = 2000
@@ -98,6 +102,28 @@ class PosteriorsTest {
             assertTrue(s.isFinite() && s > 0.0)
             sum += s
         }
-        assertTrue(abs(sum / n - 2.0) < 0.2)
+        assertTrue(abs(sum / n - 1.0) < 0.1)
+    }
+
+    @Test
+    fun `ExponentialTS prefers the arm with the larger reward`() {
+        val mab = MultiArmedBandit(nbrArms = 2, policy = ExponentialTS(), random = Random(11))
+        repeat(200) {
+            mab.update(0, 10.0)
+            mab.update(1, 1.0)
+        }
+        val picks = (0 until 1000).count { mab.choose() == 0 }
+        assertTrue(picks > 900, "arm 0 chosen $picks/1000")
+    }
+
+    @Test
+    fun `GeometricTS prefers the arm with the larger reward`() {
+        val mab = MultiArmedBandit(nbrArms = 2, policy = GeometricTS(), random = Random(12))
+        repeat(200) {
+            mab.update(0, 8.0)
+            mab.update(1, 2.0)
+        }
+        val picks = (0 until 1000).count { mab.choose() == 0 }
+        assertTrue(picks > 900, "arm 0 chosen $picks/1000")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBanditTest.kt
@@ -71,4 +71,21 @@ class RouletteWheelBanditTest {
         bandit.evaluate(0)
         assertEquals(1.0, bandit.evaluate(0))
     }
+
+    @Test
+    fun `segment rebalance is invariant to a uniform observation weight`() {
+        fun weightAfter(observationWeight: Double): Double {
+            val bandit = RouletteWheelBandit(
+                nbrArms = 2,
+                reactionFactor = 0.5,
+                segmentLength = 2,
+                initialWeight = 1.0,
+                random = Random(1),
+            )
+            bandit.update(0, 1.0, observationWeight)
+            bandit.update(0, 1.0, observationWeight)
+            return bandit.snapshot()[0].weight
+        }
+        assertEquals(weightAfter(1.0), weightAfter(3.0))
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/UnivariateBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/UnivariateBanditTest.kt
@@ -114,7 +114,7 @@ class UnivariateBanditTest {
     }
 
     @Test
-    fun `RouletteWheelBandit update accepts custom weight argument`() {
+    fun `RouletteWheelBandit rebalances on the weighted mean of the segment`() {
         val bandit = RouletteWheelBandit(
             nbrArms = 1,
             reactionFactor = 1.0,
@@ -125,7 +125,7 @@ class UnivariateBanditTest {
         )
         bandit.update(0, 2.0, weight = 3.0)
         bandit.update(0, 0.0, weight = 1.0)
-        assertEquals(3.0, bandit.snapshot()[0].weight)
+        assertEquals(1.5, bandit.snapshot()[0].weight)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Geometric, Exponential and GammaScale Thompson posteriors sample the arm's reward mean instead of the rate or success probability.
- The roulette wheel segment average divides by accumulated weight rather than an unweighted call count.
- Exp4 applies the observation weight to the expert update.
- KnnContextualBandit ignores inert observations, and its sparse distance counts a stored zero once.
- MultiArmedBandit.create gives the replica its own policy state.
- MultiArmedSpec rejects a Moss policy whose arm count disagrees with it, and inverse-CDF sampling never draws a zero-probability arm.

## Why

Three posteriors returned a quantity inversely related to the reward, so the bandit maximised the worst arm. With two arms rewarding 10.0 and 1.0, the good arm was chosen 0 times in 1000 rounds. The weight defects broke the library-wide contract that zero weight is a no-op and that a weight scales an observation. Sharing one policy instance between a bandit and its replica meant a replica's pulls moved the parent's exploration bonus, which breaks the documented coordinator pattern.

## Testing

Each defect was reproduced in a failing test before the fix. The legacy assertions that pinned the old inverted scale were corrected in place, since they asserted the bug. `./gradlew check lintDocs` passes on every target.
