### PR TITLE
fix: repair histogram bin accounting and merge guards

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/ExcursionStat.kt
@@ -96,6 +96,12 @@ class ExcursionStat(override val concurrency: Concurrency = Concurrency.None) : 
         }
     }
 
+    /**
+     * Approximate merge: extremes combine element-wise and [ExcursionResult.maxExcursion] is the larger
+     * of the two, never a peak-to-trough span spanning both replicas. Two shards of one stream have no
+     * common order, so a cross-replica excursion cannot be shown to have happened peak-then-trough.
+     * A merged snapshot can therefore report `peak - trough` wider than its own `maxExcursion`.
+     */
     override fun merge(values: ExcursionResult) = lock.guarded {
         if (!values.hasObservation) return@guarded // nothing observed there, so nothing to fold in
         val seen = initialized.addAndGet(1L)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramStat.kt
@@ -8,6 +8,7 @@ import com.eignex.kumulant.stream.additiveMode
 import kotlin.math.ceil
 import kotlin.math.log2
 import kotlin.math.pow
+import kotlin.math.round
 
 /**
  * Auto-resizing High Dynamic Range (HDR) Histogram with native Double support.
@@ -124,8 +125,10 @@ class HdrHistogramStat(
         // throw. A NaN observation must not become an exception in the caller. See Stat.
         require(!(value < 0.0)) { "HdrHistogramStat only supports non-negative values; got $value" }
 
-        val internalValue = (value * multiplier).toLong()
+        addInternal((value * multiplier).toLong(), weight)
+    }
 
+    private fun addInternal(internalValue: Long, weight: Double) {
         while (true) {
             val state = stateRef.load()
 
@@ -150,7 +153,9 @@ class HdrHistogramStat(
         for (i in values.lowerBounds.indices) {
             val weight = values.weights[i]
             if (weight > 0.0) {
-                update(values.lowerBounds[i], weight)
+                // Rounded, not truncated: a bound this histogram emitted is an exact bucket floor
+                // divided by the multiplier, and multiplying it back lands a hair under the integer.
+                addInternal(round(values.lowerBounds[i] * multiplier).toLong(), weight)
             }
         }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramStat.kt
@@ -56,8 +56,8 @@ class LinearHistogramStat(
     private val overflow = mode.newDouble(0.0)
     private val bins = ArrayBins(mode)
 
-    // Shared by update and merge: the two paths have to agree exactly or a merged bucket lands
-    // somewhere a directly-observed value of the same magnitude would not.
+    // Only the update path: merge resolves its bucket from the emitted edge instead, because
+    // `lowerBound + i * binWidth` divided back by binWidth routinely lands just under `i`.
     private fun binOf(value: Double): Int = ((value - lowerBound) / binWidth).toInt().coerceIn(0, binCount - 1)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
@@ -87,6 +87,7 @@ class LinearHistogramStat(
             if (w <= 0.0) continue
             val lo = values.lowerBounds[i]
             val hi = values.upperBounds[i]
+            val aligned = if (lo.isFinite() && hi.isFinite()) alignedBin(lo, hi) else NO_BIN
             when {
                 !lo.isFinite() && hi == lowerBound -> {
                     underflow.add(w)
@@ -96,8 +97,8 @@ class LinearHistogramStat(
                     overflow.add(w)
                 }
 
-                lo.isFinite() && hi.isFinite() && matchesLayout(lo, hi) -> {
-                    bins.add(binOf(lo), w)
+                aligned >= 0 -> {
+                    bins.add(aligned, w)
                 }
 
                 else -> {
@@ -112,12 +113,14 @@ class LinearHistogramStat(
         }
     }
 
-    private fun matchesLayout(lo: Double, hi: Double): Boolean {
+    /** Index this bucket was emitted from, or [NO_BIN] when its edges do not match our layout. */
+    private fun alignedBin(lo: Double, hi: Double): Int {
         val span = hi - lo
-        if (abs(span - binWidth) > binWidth * 1e-12) return false
+        if (abs(span - binWidth) > binWidth * 1e-12) return NO_BIN
         val ratio = (lo - lowerBound) / binWidth
         val rounded = round(ratio)
-        return abs(ratio - rounded) < BIN_ALIGNMENT_TOLERANCE && rounded >= 0.0 && rounded < binCount
+        if (abs(ratio - rounded) >= BIN_ALIGNMENT_TOLERANCE || rounded < 0.0 || rounded >= binCount) return NO_BIN
+        return rounded.toInt()
     }
 
     override fun reset() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/QuantileResults.kt
@@ -156,3 +156,6 @@ internal const val PARAMETER_MATCH_TOLERANCE: Double = 1e-9
  * after division, not whether two configurations match.
  */
 internal const val BIN_ALIGNMENT_TOLERANCE: Double = 1e-9
+
+/** No bucket of the receiving layout matches the incoming edges. */
+internal const val NO_BIN: Int = -1

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
@@ -73,6 +73,9 @@ class ThresholdBucketStat(
         require(values.counts.size == thresholds.size + 1) {
             "merge counts length ${values.counts.size} != ${thresholds.size + 1}"
         }
+        require(values.thresholds.size == thresholds.size && values.thresholds.indices.all { values.thresholds[it] == thresholds[it] }) {
+            "merge thresholds ${values.thresholds} != ${thresholds.toList()}"
+        }
         values.counts.forEachIndexed { i, c -> counts.add(i, c) }
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStat.kt
@@ -73,7 +73,10 @@ class ThresholdBucketStat(
         require(values.counts.size == thresholds.size + 1) {
             "merge counts length ${values.counts.size} != ${thresholds.size + 1}"
         }
-        require(values.thresholds.size == thresholds.size && values.thresholds.indices.all { values.thresholds[it] == thresholds[it] }) {
+        require(
+            values.thresholds.size == thresholds.size &&
+                values.thresholds.indices.all { values.thresholds[it] == thresholds[it] },
+        ) {
             "merge thresholds ${values.thresholds} != ${thresholds.toList()}"
         }
         values.counts.forEachIndexed { i, c -> counts.add(i, c) }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/PitTests.kt
@@ -17,35 +17,28 @@ import kotlin.math.abs
  */
 fun SparseHistogramResult.pitChiSquared(numBins: Int): Double {
     requirePositiveBins(numBins)
+    val width = 1.0 / numBins
+    val weightPerBin = DoubleArray(numBins)
     var total = 0.0
-    var observedFinite = 0
     for (i in lowerBounds.indices) {
-        if (lowerBounds[i].isFinite() && upperBounds[i].isFinite()) {
+        if (isTopEdgeRow(lowerBounds[i], upperBounds[i])) {
+            weightPerBin[numBins - 1] += weights[i]
             total += weights[i]
-            observedFinite++
-        } else if (isTopEdgeRow(lowerBounds[i], upperBounds[i])) {
-            total += weights[i]
+            continue
         }
+        if (!lowerBounds[i].isFinite() || !upperBounds[i].isFinite()) continue
+        // Map a finite bin to its slot via its upper bound, with a small ulp guard so the
+        // top edge (upperBounds == 1.0) doesn't round into a non-existent bin numBins.
+        val idx = ((upperBounds[i] - 1e-12) / width).toInt().coerceIn(0, numBins - 1)
+        weightPerBin[idx] += weights[i]
+        total += weights[i]
     }
     if (total <= 0.0) return 0.0
     val expected = total / numBins
     var x2 = 0.0
-    var topEdgeWeight = 0.0
-    for (i in lowerBounds.indices) {
-        if (isTopEdgeRow(lowerBounds[i], upperBounds[i])) topEdgeWeight += weights[i]
-    }
-    for (i in lowerBounds.indices) {
-        if (!lowerBounds[i].isFinite() || !upperBounds[i].isFinite()) continue
-        // The top bin absorbs the `[1.0, +Inf)` row, so it is the one bin whose observed weight is
-        // not just its own.
-        val observed = weights[i] + if (upperBounds[i] == 1.0) topEdgeWeight else 0.0
-        val d = observed - expected
+    for (w in weightPerBin) {
+        val d = w - expected
         x2 += d * d / expected
-    }
-    val emptyBins = numBins - observedFinite
-    if (emptyBins > 0) {
-        // Each empty bin contributes (0 - expected)^2 / expected = expected.
-        x2 += emptyBins * expected
     }
     return x2
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -166,6 +166,8 @@ class CountMinSketchStat(
         require(values.counters.size == counterCount) {
             "Cannot merge CountMinSketchStat: expected $counterCount counters, got ${values.counters.size}"
         }
+        // Unclamped by design: MAX_COUNTER_STEP bounds one increment, never the running total, which
+        // an ordinary update stream grows past the same bound just as merging does.
         for (i in 0 until counterCount) {
             val incoming = values.counters[i]
             if (incoming != 0L) counters.add(i, incoming)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/HdrHistogramTest.kt
@@ -181,4 +181,13 @@ class HdrHistogramTest {
         val r = h.read()
         assertEquals(1.0, r.weights.sum(), 1e-9)
     }
+
+    @Test
+    fun `merging a snapshot reproduces the source histogram`() {
+        val source = HdrHistogramStat()
+        for (v in listOf(1.0015, 1.0035, 1.5005, 2.0)) source.update(v)
+        val target = HdrHistogramStat()
+        target.merge(source.read(0L))
+        assertEquals(source.read(0L), target.read(0L))
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/LinearHistogramTest.kt
@@ -109,4 +109,13 @@ class LinearHistogramTest {
         assertFailsWith<IllegalArgumentException> { LinearHistogramStat(0.0, 10.0, 0) }
         assertFailsWith<IllegalArgumentException> { LinearHistogramStat(0.0, 10.0, -1) }
     }
+
+    @Test
+    fun `merging a snapshot reproduces the source histogram`() {
+        val source = LinearHistogramStat(0.0, 1.0, 100)
+        for (v in listOf(0.295, 0.585, 0.135, 0.905)) source.update(v)
+        val target = LinearHistogramStat(0.0, 1.0, 100)
+        target.merge(source.read(0L))
+        assertEquals(source.read(0L), target.read(0L))
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/quantile/ThresholdBucketStatTest.kt
@@ -99,4 +99,11 @@ class ThresholdBucketStatTest {
         }
         assertModesAgree("ThresholdBucketStat", reads)
     }
+
+    @Test
+    fun `merge rejects a snapshot taken over different thresholds`() {
+        val stat = ThresholdBucketStat(doubleArrayOf(1.0, 2.0, 3.0))
+        val foreign = ThresholdBucketResult(listOf(100.0, 200.0, 300.0), listOf(0.0, 0.0, 0.0, 7.0))
+        assertFailsWith<IllegalArgumentException> { stat.merge(foreign) }
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitTestsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/score/PitTestsTest.kt
@@ -53,4 +53,13 @@ class PitTestsTest {
         assertEquals(0.0, res.pitChiSquared(numBins = 1), DELTA)
         assertEquals(0.0, res.pitKsDistance(numBins = 1), DELTA)
     }
+
+    @Test
+    fun `chi squared counts the top edge row when its bin is otherwise empty`() {
+        val h = pitHistogram(2)
+        h.update(0.25)
+        h.update(1.0)
+        val res = h.read(0L)
+        assertEquals(0.0, res.pitChiSquared(2), DELTA)
+    }
 }


### PR DESCRIPTION
## What changed

- LinearHistogramStat merges a bucket into the index it was emitted from rather than re-deriving it.
- HdrHistogramStat recovers the exact bucket when merging its own snapshot.
- pitChiSquared bins its weights, so the top edge row always counts.
- ThresholdBucketStat.merge rejects a snapshot taken over different thresholds.
- ExcursionStat documents that its merge is approximate.

## Why

Both histograms emitted a bucket edge and then divided it back by the bin width to recover the index, which lands just under the integer for many values. Merging a snapshot therefore filed weight one bin low: two of four buckets shifted in the linear case, and 468 of 40000 in the HDR case, always downward, so merge of a stat's own read was not idempotent. pitChiSquared folded the overflow row into a finite bin only when that bin already had weight, so a sparse histogram dropped it and then charged the bin as empty; a two bin histogram fed 0.25 and 1.0 returned 1.0 where the truth is 0.0.

## Why the sketch counters were left alone

MAX_COUNTER_STEP bounds a single increment, never the running total, so an ordinary update stream reaches the same overflow after about 1024 saturated steps. Merge is not a special hole, and a saturating add would need a CAS loop the additive-mode design does not support. A comment records this.

## Testing

Each defect was reproduced first, the histograms through a merge of the stat's own snapshot. `./gradlew check lintDocs` passes on every target.
