### PR TITLE
fix: repair decay and summary stat state handling

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStat.kt
@@ -138,8 +138,12 @@ class DecayingSumStat(
     }
 
     override fun reset() {
-        val current = epochRef.load()
-        epochRef.compareAndSet(current, Epoch(currentTimeNanos(), mode.newDouble(0.0)))
+        // Retried, unlike a single attempt: losing the race to a concurrent rotation would drop the
+        // reset silently and leave the stat carrying everything it had accumulated.
+        while (true) {
+            val current = epochRef.load()
+            if (epochRef.compareAndSet(current, Epoch(currentTimeNanos(), mode.newDouble(0.0)))) return
+        }
     }
 
     override fun create(concurrency: Concurrency?) = DecayingSumStat(weighting, concurrency ?: this.concurrency)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
@@ -86,9 +86,9 @@ class EwmaMeanStat(
         totalWeights.add(remoteWeight)
     }
 
-    override fun reset() {
-        biasedMean.store(0.0)
-        totalWeights.store(0.0)
+    override fun reset() = lock.guarded {
+            biasedMean.store(0.0)
+            totalWeights.store(0.0)
     }
 
     override fun read(timestampNanos: Long) = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
@@ -112,10 +112,10 @@ class EwmaVarianceStat(
         totalWeights.add(remoteWeightRaw)
     }
 
-    override fun reset() {
-        biasedMean.store(0.0)
-        biasedM2.store(0.0)
-        totalWeights.store(0.0)
+    override fun reset() = lock.guarded {
+            biasedMean.store(0.0)
+            biasedM2.store(0.0)
+            totalWeights.store(0.0)
     }
 
     override fun read(timestampNanos: Long) = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
@@ -68,12 +68,18 @@ class EwmaVarianceStat(
         val a = weighting.correction(weight)
 
         val currentRawMean = biasedMean.load()
-        val delta = value - currentRawMean
-        val increment = a * delta
+        val increment = a * (value - currentRawMean)
         val newRawMean = currentRawMean + increment
 
+        // Centred on the debiased means, never the raw accumulators: those still carry the zero seed
+        // they started from, which would enter the variance as a term proportional to mean^2 and only
+        // decay at the smoothing rate. read() debiases M2, so the two sides have to agree.
+        val oldWeight = totalWeights.load()
+        val oldMean = weighting.debias(currentRawMean, oldWeight)
+        val newMean = weighting.debias(newRawMean, oldWeight + weight)
+
         val currentBiasedM2 = biasedM2.load()
-        biasedM2.add(a * (delta * (value - newRawMean) - currentBiasedM2))
+        biasedM2.add(a * ((value - oldMean) * (value - newMean) - currentBiasedM2))
         biasedMean.add(increment)
         totalWeights.add(weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
@@ -84,8 +84,8 @@ class FrugalQuantileStat(
         quantile.store((current + values.quantile) / 2.0)
     }
 
-    override fun reset() {
-        quantile.store(initialEstimate)
+    override fun reset() = lock.guarded {
+            quantile.store(initialEstimate)
     }
 
     override fun read(timestampNanos: Long) = QuantileResult(q, quantile.load())

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
@@ -105,12 +105,12 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
         }
     }
 
-    override fun reset() {
-        totalWeights.store(0.0)
-        mean.store(0.0)
-        sst.store(0.0)
-        minCell.store(Double.POSITIVE_INFINITY)
-        maxCell.store(Double.NEGATIVE_INFINITY)
+    override fun reset() = lock.guarded {
+            totalWeights.store(0.0)
+            mean.store(0.0)
+            sst.store(0.0)
+            minCell.store(Double.POSITIVE_INFINITY)
+            maxCell.store(Double.NEGATIVE_INFINITY)
     }
 
     override fun read(timestampNanos: Long): SummaryResult = lock.guarded {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStatTest.kt
@@ -72,4 +72,21 @@ class EwmaVarianceStatTest {
         assertEquals(0.0, r.mean, DELTA)
         assertEquals(0.0, r.variance, DELTA)
     }
+
+    @Test
+    fun `a constant stream has zero variance whatever its level`() {
+        val stat = EwmaVarianceStat(alpha = 0.1)
+        repeat(25) { stat.update(100.0) }
+        assertEquals(0.0, stat.read(0L).variance, 1e-9)
+    }
+
+    @Test
+    fun `variance is invariant to shifting the whole stream`() {
+        fun varianceOf(offset: Double): Double {
+            val stat = EwmaVarianceStat(alpha = 0.2)
+            for (v in listOf(1.0, 3.0, 2.0, 5.0, 4.0)) stat.update(v + offset)
+            return stat.read(0L).variance
+        }
+        assertEquals(varianceOf(0.0), varianceOf(1000.0), 1e-6)
+    }
 }


### PR DESCRIPTION
## What changed

- EwmaVarianceStat centres its M2 increment on the debiased mean.
- SummaryStat, EwmaMeanStat, EwmaVarianceStat and FrugalQuantileStat take their lock when resetting.
- DecayingSumStat.reset retries until its epoch swap lands.

## Why

The variance centred its increment on the biased mean cell, which is seeded at zero, while read debiased M2 by the same correction. The zero seed leaked in as a term proportional to the square of the mean: a constant stream of 100.0 reported a variance of 9048 after one update and 67 after fifty, where the truth is zero, and the stat was not shift invariant. The four resets stored into their cells outside the lock their own update and read hold, so a reset landing inside an in-flight update left the stat with zero total weight and a stale mean. DecayingSumStat.reset made a single compare-and-set and silently dropped the reset when a concurrent rotation won the race.

## Testing

The variance is covered by a constant-stream test and a shift-invariance test, both of which fail without the fix, and the resulting variance was checked against a stationary stream to confirm the magnitude is still right rather than merely zero. The reset fixes are structural: a race test would be flaky and would exceed the 300ms JVM test budget, so instead every stat holding a lock was audited, which is also how FrugalQuantileStat was found. `./gradlew check lintDocs` passes on every target.
