### PR TITLE
fix: preserve operator state and ordering in the stream layer

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
@@ -17,6 +17,7 @@ internal fun <R> SeriesStat<R>.band(k: Double): SeriesStat<BandResult>
     BandSeriesStat(this, k)
 
 internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private val k: Double) :
+    WindowsInside<BandResult>,
     SeriesStat<BandResult> where R : HasCenterScale {
 
     override val concurrency: Concurrency get() = delegate.concurrency
@@ -41,7 +42,7 @@ internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private va
      * one works: a window reads by merging its slices into a fresh template, and merging *through*
      * this wrapper throws.
      */
-    internal fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<BandResult> =
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<BandResult> =
         BandSeriesStat(delegate.windowed(duration, slices, concurrency), k)
 
     override fun reset() = delegate.reset()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.monotonicMode
+import kotlin.time.Duration
 
 // Hysteresis adapter: maps a noisy numeric stream onto a debounced 0.0/1.0 signal.
 //
@@ -35,6 +36,7 @@ internal class HysteresisSeriesStat<R : Result>(
     private val low: Double,
     private val high: Double,
 ) : SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
 
     init {
@@ -61,6 +63,9 @@ internal class HysteresisSeriesStat<R : Result>(
         delegate.reset()
         state.store(STATE_UNSET)
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        HysteresisSeriesStat(delegate.windowed(duration, slices, concurrency), low, high)
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
         HysteresisSeriesStat(delegate.create(concurrency), low, high)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -91,11 +91,13 @@ internal class ResampleByTimeStat<R : Result>(
                 seed(value, timestampNanos, weight)
                 return@guarded
             }
-            if (newBucket == cur) {
+            if (newBucket <= cur) {
+                // A late arrival joins the open bucket rather than closing it: its own bucket was
+                // already emitted, and closing on any change would emit the open one twice.
                 accumulate(value, timestampNanos, weight)
                 return@guarded
             }
-            // Bucket changed: flush the closed bucket and seed the new one.
+            // Time moved on: flush the closed bucket and seed the new one.
             flushLocked()
             currentBucket.store(newBucket)
             seed(value, timestampNanos, weight)
@@ -116,10 +118,14 @@ internal class ResampleByTimeStat<R : Result>(
         bucketWeight.store(bucketWeight.load() + weight)
         count.store(count.load() + 1L)
         sum.store(sum.load() + value * weight)
-        last.store(value)
         minimum.store(min(minimum.load(), value))
         maximum.store(max(maximum.load(), value))
-        bucketEndTimestamp.store(timestampNanos)
+        // Guarded against a late arrival: it must not become the bucket's "last" value, nor drag the
+        // bucket's end timestamp backwards.
+        if (timestampNanos >= bucketEndTimestamp.load()) {
+            last.store(value)
+            bucketEndTimestamp.store(timestampNanos)
+        }
     }
 
     private fun flushLocked() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -50,6 +50,7 @@ internal class ResampleByTimeStat<R : Result>(
     private val bucket: Duration,
     private val aggregator: ResampleAggregator,
 ) : SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
 
     private val bucketNanos: Long = bucket.inWholeNanoseconds
@@ -152,6 +153,9 @@ internal class ResampleByTimeStat<R : Result>(
         bucketEndTimestamp.store(0L)
         bucketWeight.store(0.0)
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        ResampleByTimeStat(delegate.windowed(duration, slices, concurrency), bucket, aggregator)
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
         ResampleByTimeStat(delegate.create(concurrency), bucket, aggregator)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.core.isInertWeight
+import kotlin.time.Duration
 
 // Throttle / sample adapters. Each wraps an inner stat, intercepts at the update
 // boundary, and drops some updates before they reach the delegate. State per
@@ -63,6 +64,7 @@ internal fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate 
 
 internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val every: Int) :
     SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
@@ -73,6 +75,9 @@ internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R
         gate.reset()
         delegate.reset()
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        ThrottleSeriesStat(delegate.windowed(duration, slices, concurrency), every)
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
         ThrottleSeriesStat(delegate.create(concurrency), every)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -10,6 +10,7 @@ import com.eignex.kumulant.stream.firstWriterMode
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
+import kotlin.time.Duration
 
 // Pre-update shift adapters: forward a value derived from the stream's recent history to the
 // delegate. Each operator keeps a tiny per-instance ring (or single-cell) buffer of past values
@@ -46,6 +47,7 @@ private fun requireK(k: Int) = require(k >= 1) { "shift k must be >= 1, got $k" 
 
 internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val k: Int) :
     SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
     init {
         requireK(k)
@@ -76,11 +78,15 @@ internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, pr
         for (i in 0 until k) ring.store(i, 0.0)
     }
 
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        LagSeriesStat(delegate.windowed(duration, slices, concurrency), k)
+
     override fun create(concurrency: Concurrency?): SeriesStat<R> = LagSeriesStat(delegate.create(concurrency), k)
 }
 
 internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val k: Int) :
     SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
     init {
         requireK(k)
@@ -110,11 +116,15 @@ internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, p
         for (i in 0 until k) ring.store(i, 0.0)
     }
 
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        DiffSeriesStat(delegate.windowed(duration, slices, concurrency), k)
+
     override fun create(concurrency: Concurrency?): SeriesStat<R> = DiffSeriesStat(delegate.create(concurrency), k)
 }
 
 internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat<R>) :
     SeriesStat<R>,
+    WindowsInside<R>,
     Stat<R> by delegate {
 
     private val mode = delegate.concurrency.monotonicMode()
@@ -148,6 +158,9 @@ internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat
         lastValue.store(0.0)
         lastTimestamp.store(0L)
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        DerivativeSeriesStat(delegate.windowed(duration, slices, concurrency))
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> = DerivativeSeriesStat(delegate.create(concurrency))
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -115,11 +115,16 @@ internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat
         val seen = initialized.addAndGet(1L)
         val prevValue = lastValue.load()
         val prevTs = lastTimestamp.load()
-        lastValue.store(value)
-        lastTimestamp.store(timestampNanos)
-        if (seen <= 1L) return
         val deltaNanos = timestampNanos - prevTs
-        if (deltaNanos == 0L) return
+        // Stored unless the stamp is older than the reference: at the same instant the newer value
+        // is the series value there, but an out-of-order arrival must not drag the reference back.
+        if (seen <= 1L || deltaNanos >= 0L) {
+            lastValue.store(value)
+            lastTimestamp.store(timestampNanos)
+        }
+        if (seen <= 1L) return
+        // Not just `== 0L`: a negative delta divides through to a rate of the wrong sign.
+        if (deltaNanos <= 0L) return
         val rate = (value - prevValue) * NANOS_PER_SECOND / deltaNanos
         delegate.update(rate, timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -7,7 +7,9 @@ import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.NANOS_PER_SECOND
 import com.eignex.kumulant.stream.firstWriterMode
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
+import com.eignex.kumulant.stream.serializedLock
 
 // Pre-update shift adapters: forward a value derived from the stream's recent history to the
 // delegate. Each operator keeps a tiny per-instance ring (or single-cell) buffer of past values
@@ -50,16 +52,22 @@ internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, pr
     }
 
     private val mode = delegate.concurrency.monotonicMode()
+    private val lock = delegate.concurrency.serializedLock()
     private val tick = mode.newLong(0L)
     private val ring = mode.newDoubleArray(k)
 
+    // Serialised: claiming the tick, reading the slot and writing it back is one indivisible step.
+    // Split apart, a second writer reads the slot before the first has stored into it and forwards
+    // the ring's initial 0.0 as though the stream had emitted it.
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        val n = tick.addAndGet(1L)
-        val slot = ((n - 1L) % k).toInt()
-        val past = ring.load(slot)
-        ring.store(slot, value)
-        if (n > k) delegate.update(past, timestampNanos, weight)
+        lock.guarded {
+            val n = tick.addAndGet(1L)
+            val slot = ((n - 1L) % k).toInt()
+            val past = ring.load(slot)
+            ring.store(slot, value)
+            if (n > k) delegate.update(past, timestampNanos, weight)
+        }
     }
 
     override fun reset() {
@@ -79,16 +87,21 @@ internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, p
     }
 
     private val mode = delegate.concurrency.monotonicMode()
+    private val lock = delegate.concurrency.serializedLock()
     private val tick = mode.newLong(0L)
     private val ring = mode.newDoubleArray(k)
 
+    // Serialised for the same reason as [LagSeriesStat]: a torn read of the ring would forward a
+    // difference against the initial 0.0, an outlier the size of the stream's own magnitude.
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        val n = tick.addAndGet(1L)
-        val slot = ((n - 1L) % k).toInt()
-        val past = ring.load(slot)
-        ring.store(slot, value)
-        if (n > k) delegate.update(value - past, timestampNanos, weight)
+        lock.guarded {
+            val n = tick.addAndGet(1L)
+            val slot = ((n - 1L) % k).toInt()
+            val past = ring.load(slot)
+            ring.store(slot, value)
+            if (n > k) delegate.update(value - past, timestampNanos, weight)
+        }
     }
 
     override fun reset() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -23,11 +23,11 @@ internal fun <R : Result> SeriesStat<R>.windowed(
     duration: Duration,
     slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
-): SeriesStat<R> = if (this is BandSeriesStat<*>) {
-    // A band cannot be merged, and windowedRead merges, so window the band's inner stat instead and
-    // re-apply the band on top. See BandSeriesStat.windowedInside for why that is the same thing.
+): SeriesStat<R> = if (this is WindowsInside<*>) {
+    // Wrap the operator's delegate, not the operator: see WindowsInside for why a slice rotation
+    // would otherwise restart the operator's state, and BandSeriesStat for the merge-side reason.
     @Suppress("UNCHECKED_CAST")
-    windowedInside(duration, slices, concurrency) as SeriesStat<R>
+    (this as WindowsInside<R>).windowedInside(duration, slices, concurrency)
 } else {
     WindowedSeriesStat(duration, slices, this, concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowsInside.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowsInside.kt
@@ -1,0 +1,21 @@
+package com.eignex.kumulant.operation
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.SeriesStat
+import kotlin.time.Duration
+
+/**
+ * A pre-update operator that carries state from one observation to the next.
+ *
+ * Windowing slices a stat into per-bucket replicas, so an operator wrapped *outside* a window would
+ * have that state rebuilt on every slice rotation: a lag ring restarts its warm-up, a throttle gate
+ * restarts its count, a resample bucket never closes. On a stream slower than one observation per
+ * slice the operator then never fires at all. Windowing the operator's delegate and re-applying the
+ * operator on top keeps one instance of the state for the whole stream, which is what the caller
+ * asked for.
+ */
+internal interface WindowsInside<R : Result> {
+    /** This operator re-applied over its own windowed delegate. */
+    fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R>
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
@@ -6,7 +6,9 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
+import com.eignex.kumulant.stream.serializedLock
 
 // withSelfLag lifts a PairedStat<R> into a SeriesStat<R> by self-pairing each input
 // with the value seen k updates ago. The first k updates only warm the ring buffer
@@ -41,16 +43,21 @@ internal class WithSelfLagSeriesStat<R : Result>(private val delegate: PairedSta
     }
 
     private val mode = delegate.concurrency.monotonicMode()
+    private val lock = delegate.concurrency.serializedLock()
     private val tick = mode.newLong(0L)
     private val ring = mode.newDoubleArray(k)
 
+    // Serialised: a torn read of the ring would pair the current value with the initial 0.0, which
+    // the stream never emitted, and feed that pair into the delegate as a real observation.
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        val n = tick.addAndGet(1L)
-        val slot = ((n - 1L) % k).toInt()
-        val past = ring.load(slot)
-        ring.store(slot, value)
-        if (n > k) delegate.update(x = value, y = past, timestampNanos = timestampNanos, weight = weight)
+        lock.guarded {
+            val n = tick.addAndGet(1L)
+            val slot = ((n - 1L) % k).toInt()
+            val past = ring.load(slot)
+            ring.store(slot, value)
+            if (n > k) delegate.update(x = value, y = past, timestampNanos = timestampNanos, weight = weight)
+        }
     }
 
     override fun reset() {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaMeanStat.kt
@@ -87,8 +87,8 @@ class EwmaMeanStat(
     }
 
     override fun reset() = lock.guarded {
-            biasedMean.store(0.0)
-            totalWeights.store(0.0)
+        biasedMean.store(0.0)
+        totalWeights.store(0.0)
     }
 
     override fun read(timestampNanos: Long) = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/EwmaVarianceStat.kt
@@ -113,9 +113,9 @@ class EwmaVarianceStat(
     }
 
     override fun reset() = lock.guarded {
-            biasedMean.store(0.0)
-            biasedM2.store(0.0)
-            totalWeights.store(0.0)
+        biasedMean.store(0.0)
+        biasedM2.store(0.0)
+        totalWeights.store(0.0)
     }
 
     override fun read(timestampNanos: Long) = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/quantile/FrugalQuantileStat.kt
@@ -85,7 +85,7 @@ class FrugalQuantileStat(
     }
 
     override fun reset() = lock.guarded {
-            quantile.store(initialEstimate)
+        quantile.store(initialEstimate)
     }
 
     override fun read(timestampNanos: Long) = QuantileResult(q, quantile.load())

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/SummaryStat.kt
@@ -106,11 +106,11 @@ class SummaryStat(override val concurrency: Concurrency = Concurrency.None) : Se
     }
 
     override fun reset() = lock.guarded {
-            totalWeights.store(0.0)
-            mean.store(0.0)
-            sst.store(0.0)
-            minCell.store(Double.POSITIVE_INFINITY)
-            maxCell.store(Double.NEGATIVE_INFINITY)
+        totalWeights.store(0.0)
+        mean.store(0.0)
+        sst.store(0.0)
+        minCell.store(Double.POSITIVE_INFINITY)
+        maxCell.store(Double.NEGATIVE_INFINITY)
     }
 
     override fun read(timestampNanos: Long): SummaryResult = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
@@ -38,6 +38,11 @@ internal object NoopMutex : Mutex {
  *   the native handle is freed on GC via `kotlin.native.ref.createCleaner`.
  * - mingwX64: backed by a Win32 `CRITICAL_SECTION`, similarly cleanered.
  * - JS / Wasm: noop - these runtimes are single-threaded.
+ *
+ * Not reentrant. The posix actual is a default `pthread_mutex_t`, so a thread that re-acquires a lock
+ * it already holds deadlocks on Linux and Apple targets while the reentrant JVM and Win32 backings let
+ * the same code through; a stat must never call back into itself while holding its own lock. Nesting
+ * two *different* locks is fine, which is what an operator holding its lock across a delegate call does.
  */
 internal expect class PlatformMutex() : Mutex {
     override fun <R> withLock(block: () -> R): R

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
@@ -140,4 +140,16 @@ class ResampleTest {
         stat.update(value = 9.0, timestampNanos = 250_000_000L) // forwards bucket 0 -> 5.0
         assertEquals(5.0, stat.read().sum, DELTA)
     }
+
+    @Test
+    fun `a late arrival joins the open bucket instead of closing it twice`() {
+        val stat = SumStat().resampleByTime(bucket = 1000.milliseconds, aggregator = ResampleAggregator.Last)
+        stat.update(value = 1.0, timestampNanos = 0L)
+        stat.update(value = 2.0, timestampNanos = 2_000_000_000L)
+        stat.update(value = 3.0, timestampNanos = 1_000_000_000L)
+        stat.update(value = 4.0, timestampNanos = 2_500_000_000L)
+        stat.update(value = 5.0, timestampNanos = 3_000_000_000L)
+        // Bucket 0 closes as 1.0 and bucket 2 as 4.0; the late 3.0 joins the open bucket.
+        assertEquals(5.0, stat.read().sum, DELTA)
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ShiftsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ShiftsTest.kt
@@ -97,4 +97,15 @@ class ShiftsTest {
         assertFailsWith<IllegalArgumentException> { SumStat().lag(0) }
         assertFailsWith<IllegalArgumentException> { SumStat().diff(0) }
     }
+
+    @Test
+    fun `derivative skips an out-of-order observation and keeps its reference point`() {
+        val stat = SumStat().derivative()
+        stat.update(value = 10.0, timestampNanos = 100L)
+        stat.update(value = 20.0, timestampNanos = 300L)
+        stat.update(value = 30.0, timestampNanos = 200L)
+        stat.update(value = 40.0, timestampNanos = 400L)
+        // 5e7 from the second update, then 2e8 measured from (20.0, 300) rather than the skipped one.
+        assertEquals(2.5e8, stat.read().sum, DELTA)
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
@@ -179,4 +179,18 @@ class WindowedStatsTest {
             SumStat().windowed(duration = 1.nanoseconds, slices = 2)
         }
     }
+
+    @Test
+    fun `a stateful operator inside a window keeps its state across slice rotations`() {
+        // Observations land further apart than one slice, so a per-slice diff would never warm up.
+        val windowed = SumStat().diff(1).windowed(60.seconds)
+        val plain = SumStat().diff(1)
+        var t = 0L
+        repeat(6) {
+            windowed.update(it.toDouble(), t)
+            plain.update(it.toDouble(), t)
+            t += 8_000_000_000L
+        }
+        assertEquals(plain.read(t).sum, windowed.read(t).sum, DELTA)
+    }
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ShiftRingRaceTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ShiftRingRaceTest.kt
@@ -1,0 +1,22 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.operation.diff
+import com.eignex.kumulant.stat.summary.MaxStat
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ShiftRingRaceTest {
+
+    @Test
+    fun `diff never forwards a difference against a value the stream never emitted`() {
+        // Every observation is 1e6, so every real difference is 0.0. Reading the ring before a
+        // concurrent writer has stored into it would forward 1e6 - 0.0 instead.
+        val stat = MaxStat(Concurrency.Strict).diff(1)
+        runConcurrently(threads = 8, iterationsPerThread = 2000) { _, _ ->
+            stat.update(1_000_000.0)
+        }
+        val largest = stat.read(0L).max
+        assertTrue(largest <= 1.0, "forwarded a fabricated difference: $largest")
+    }
+}


### PR DESCRIPTION
## What changed

- Windowing wraps a stateful operator's delegate instead of the operator, through a new WindowsInside interface implemented by lag, diff, derivative, throttle, resample, hysteresis and band.
- The lag, diff and self-lag ring update is serialised.
- A resample bucket closes only when time moves forward.
- The derivative operator skips out-of-order observations and keeps its reference point.
- The platform mutex documents that it is not reentrant.

## Why

A window slices a stat into per-bucket replicas, so an operator wrapped outside the window had its state rebuilt on every rotation. On a stream slower than one observation per slice the operator never fired at all: a diff inside a sixty second window reported 0.0 where the same diff without the window reported 19.0. The band operator already had an escape hatch for this, which this generalises. In the ring operators the tick, the load and the store were three separate steps, so a second writer could read a slot before the first had stored into it and forward the ring's initial 0.0 as a real observation. Resample flushed on any bucket change rather than a later one, so a single late arrival made one wall-clock bucket emit twice.

## Why the mutex was documented rather than unified

The posix actual is a default pthread mutex and is not recursive, while the JVM and Win32 backings are. Nothing in the codebase re-enters, and every stat builds its own lock, so no shared-lock reentrancy is reachable. Making posix recursive would cost every native acquisition to tolerate a pattern the design forbids, so the expect declaration now states the contract.

## Testing

The ring race is reproduced by a multithreaded jvm test that fails without the fix, forwarding a fabricated difference of exactly 1e6 against the ring's initial zero. The window, resample and derivative defects each have a failing test first. The derivative fix keeps the existing coincident-timestamp behaviour, since at the same instant the newer value is the series value there; only an earlier stamp is ignored. `./gradlew check lintDocs` passes on every target.
