### PR TITLE
fix: complete and correct the schema layer

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -3040,6 +3040,7 @@ public abstract class com/eignex/kumulant/schema/runtime/StatSchema : com/eignex
 	public final fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
 	protected final fun group (Lcom/eignex/kumulant/schema/runtime/StatSchema;)Lkotlin/properties/PropertyDelegateProvider;
 	protected final fun paired (Lcom/eignex/kumulant/schema/spec/PairedStatSpec;)Lkotlin/properties/PropertyDelegateProvider;
+	protected final fun regression (Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;)Lkotlin/properties/PropertyDelegateProvider;
 	protected final fun series (Lcom/eignex/kumulant/schema/spec/SeriesStatSpec;)Lkotlin/properties/PropertyDelegateProvider;
 	public final fun statSchemaDef ()Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;
 	protected final fun vector (Lcom/eignex/kumulant/schema/spec/VectorStatSpec;)Lkotlin/properties/PropertyDelegateProvider;
@@ -3079,6 +3080,8 @@ public final class com/eignex/kumulant/schema/runtime/StatSchemaDefKt {
 	public static synthetic fun materializeDiscrete$default (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun materializePaired (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;)Ljava/util/List;
 	public static synthetic fun materializePaired$default (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun materializeRegression (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;)Ljava/util/List;
+	public static synthetic fun materializeRegression$default (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun materializeSeries (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;)Ljava/util/List;
 	public static synthetic fun materializeSeries$default (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun materializeVector (Lcom/eignex/kumulant/schema/runtime/StatSchemaDef;Lcom/eignex/kumulant/core/Concurrency;)Ljava/util/List;
@@ -3458,13 +3461,17 @@ public final class com/eignex/kumulant/schema/spec/Cusum$Companion {
 public final class com/eignex/kumulant/schema/spec/DDSketch : com/eignex/kumulant/schema/spec/SeriesStatSpec {
 	public static final field Companion Lcom/eignex/kumulant/schema/spec/DDSketch$Companion;
 	public fun <init> ()V
-	public fun <init> (DLjava/util/List;)V
-	public synthetic fun <init> (DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (DLjava/util/List;DD)V
+	public synthetic fun <init> (DLjava/util/List;DDILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()D
 	public final fun component2 ()Ljava/util/List;
-	public final fun copy (DLjava/util/List;)Lcom/eignex/kumulant/schema/spec/DDSketch;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/schema/spec/DDSketch;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/schema/spec/DDSketch;
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun copy (DLjava/util/List;DD)Lcom/eignex/kumulant/schema/spec/DDSketch;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/schema/spec/DDSketch;DLjava/util/List;DDILjava/lang/Object;)Lcom/eignex/kumulant/schema/spec/DDSketch;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxIndexableValue ()D
+	public final fun getMinIndexableValue ()D
 	public final fun getProbabilities ()Ljava/util/List;
 	public final fun getRelativeError ()D
 	public fun hashCode ()I
@@ -9017,33 +9024,6 @@ public final class com/eignex/kumulant/stat/summary/BernoulliSumStat : com/eigne
 	public fun reset ()V
 	public fun update (DD)V
 	public fun update (DJD)V
-}
-
-public final class com/eignex/kumulant/stat/summary/CountResult : com/eignex/kumulant/core/Result {
-	public static final field Companion Lcom/eignex/kumulant/stat/summary/CountResult$Companion;
-	public fun <init> (J)V
-	public final fun component1 ()J
-	public final fun copy (J)Lcom/eignex/kumulant/stat/summary/CountResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/summary/CountResult;JILjava/lang/Object;)Lcom/eignex/kumulant/stat/summary/CountResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCount ()J
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class com/eignex/kumulant/stat/summary/CountResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/eignex/kumulant/stat/summary/CountResult$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/eignex/kumulant/stat/summary/CountResult;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/eignex/kumulant/stat/summary/CountResult;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/eignex/kumulant/stat/summary/CountResult$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/eignex/kumulant/stat/summary/CountStat : com/eignex/kumulant/core/SeriesStat {

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -816,6 +816,7 @@ abstract class com.eignex.kumulant.schema.runtime/StatSchema : com.eignex.skema/
 
     final fun <#A1: com.eignex.kumulant.core/Result> discrete(com.eignex.kumulant.schema.spec/DiscreteStatSpec<#A1>): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/StatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.discrete|discrete(com.eignex.kumulant.schema.spec.DiscreteStatSpec<0:0>){0§<com.eignex.kumulant.core.Result>}[0]
     final fun <#A1: com.eignex.kumulant.core/Result> paired(com.eignex.kumulant.schema.spec/PairedStatSpec<#A1>): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/StatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.paired|paired(com.eignex.kumulant.schema.spec.PairedStatSpec<0:0>){0§<com.eignex.kumulant.core.Result>}[0]
+    final fun <#A1: com.eignex.kumulant.core/Result> regression(com.eignex.kumulant.schema.spec/RegressionStatSpec<#A1>): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/StatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.regression|regression(com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>){0§<com.eignex.kumulant.core.Result>}[0]
     final fun <#A1: com.eignex.kumulant.core/Result> series(com.eignex.kumulant.schema.spec/SeriesStatSpec<#A1>): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/StatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.series|series(com.eignex.kumulant.schema.spec.SeriesStatSpec<0:0>){0§<com.eignex.kumulant.core.Result>}[0]
     final fun <#A1: com.eignex.kumulant.core/Result> vector(com.eignex.kumulant.schema.spec/VectorStatSpec<#A1>): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/StatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.vector|vector(com.eignex.kumulant.schema.spec.VectorStatSpec<0:0>){0§<com.eignex.kumulant.core.Result>}[0]
     final fun <#A1: com.eignex.kumulant.schema.runtime/StatSchema> group(#A1): kotlin.properties/PropertyDelegateProvider<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, kotlin.properties/ReadOnlyProperty<com.eignex.skema/Schema<com.eignex.kumulant.schema.spec/StatSpec>, com.eignex.kumulant.schema/GroupStatKey<#A1>>> // com.eignex.kumulant.schema.runtime/StatSchema.group|group(0:0){0§<com.eignex.kumulant.schema.runtime.StatSchema>}[0]
@@ -3197,8 +3198,12 @@ final class com.eignex.kumulant.schema.spec/Cusum : com.eignex.kumulant.schema.s
 }
 
 final class com.eignex.kumulant.schema.spec/DDSketch : com.eignex.kumulant.schema.spec/SeriesStatSpec<com.eignex.kumulant.stat.quantile/SketchResult> { // com.eignex.kumulant.schema.spec/DDSketch|null[0]
-    constructor <init>(kotlin/Double = ..., kotlin.collections/List<kotlin/Double> = ...) // com.eignex.kumulant.schema.spec/DDSketch.<init>|<init>(kotlin.Double;kotlin.collections.List<kotlin.Double>){}[0]
+    constructor <init>(kotlin/Double = ..., kotlin.collections/List<kotlin/Double> = ..., kotlin/Double = ..., kotlin/Double = ...) // com.eignex.kumulant.schema.spec/DDSketch.<init>|<init>(kotlin.Double;kotlin.collections.List<kotlin.Double>;kotlin.Double;kotlin.Double){}[0]
 
+    final val maxIndexableValue // com.eignex.kumulant.schema.spec/DDSketch.maxIndexableValue|{}maxIndexableValue[0]
+        final fun <get-maxIndexableValue>(): kotlin/Double // com.eignex.kumulant.schema.spec/DDSketch.maxIndexableValue.<get-maxIndexableValue>|<get-maxIndexableValue>(){}[0]
+    final val minIndexableValue // com.eignex.kumulant.schema.spec/DDSketch.minIndexableValue|{}minIndexableValue[0]
+        final fun <get-minIndexableValue>(): kotlin/Double // com.eignex.kumulant.schema.spec/DDSketch.minIndexableValue.<get-minIndexableValue>|<get-minIndexableValue>(){}[0]
     final val probabilities // com.eignex.kumulant.schema.spec/DDSketch.probabilities|{}probabilities[0]
         final fun <get-probabilities>(): kotlin.collections/List<kotlin/Double> // com.eignex.kumulant.schema.spec/DDSketch.probabilities.<get-probabilities>|<get-probabilities>(){}[0]
     final val relativeError // com.eignex.kumulant.schema.spec/DDSketch.relativeError|{}relativeError[0]
@@ -3206,7 +3211,9 @@ final class com.eignex.kumulant.schema.spec/DDSketch : com.eignex.kumulant.schem
 
     final fun component1(): kotlin/Double // com.eignex.kumulant.schema.spec/DDSketch.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Double> // com.eignex.kumulant.schema.spec/DDSketch.component2|component2(){}[0]
-    final fun copy(kotlin/Double = ..., kotlin.collections/List<kotlin/Double> = ...): com.eignex.kumulant.schema.spec/DDSketch // com.eignex.kumulant.schema.spec/DDSketch.copy|copy(kotlin.Double;kotlin.collections.List<kotlin.Double>){}[0]
+    final fun component3(): kotlin/Double // com.eignex.kumulant.schema.spec/DDSketch.component3|component3(){}[0]
+    final fun component4(): kotlin/Double // com.eignex.kumulant.schema.spec/DDSketch.component4|component4(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin.collections/List<kotlin/Double> = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.schema.spec/DDSketch // com.eignex.kumulant.schema.spec/DDSketch.copy|copy(kotlin.Double;kotlin.collections.List<kotlin.Double>;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.schema.spec/DDSketch.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.schema.spec/DDSketch.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.schema.spec/DDSketch.toString|toString(){}[0]
@@ -8199,32 +8206,6 @@ final class com.eignex.kumulant.stat.summary/BernoulliSumStat : com.eignex.kumul
     final fun update(kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.summary/BernoulliSumStat.update|update(kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
-final class com.eignex.kumulant.stat.summary/CountResult : com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.summary/CountResult|null[0]
-    constructor <init>(kotlin/Long) // com.eignex.kumulant.stat.summary/CountResult.<init>|<init>(kotlin.Long){}[0]
-
-    final val count // com.eignex.kumulant.stat.summary/CountResult.count|{}count[0]
-        final fun <get-count>(): kotlin/Long // com.eignex.kumulant.stat.summary/CountResult.count.<get-count>|<get-count>(){}[0]
-
-    final fun component1(): kotlin/Long // com.eignex.kumulant.stat.summary/CountResult.component1|component1(){}[0]
-    final fun copy(kotlin/Long = ...): com.eignex.kumulant.stat.summary/CountResult // com.eignex.kumulant.stat.summary/CountResult.copy|copy(kotlin.Long){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.summary/CountResult.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.summary/CountResult.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // com.eignex.kumulant.stat.summary/CountResult.toString|toString(){}[0]
-
-    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.summary/CountResult> { // com.eignex.kumulant.stat.summary/CountResult.$serializer|null[0]
-        final val descriptor // com.eignex.kumulant.stat.summary/CountResult.$serializer.descriptor|{}descriptor[0]
-            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.eignex.kumulant.stat.summary/CountResult.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
-
-        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.eignex.kumulant.stat.summary/CountResult.$serializer.childSerializers|childSerializers(){}[0]
-        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.eignex.kumulant.stat.summary/CountResult // com.eignex.kumulant.stat.summary/CountResult.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
-        final fun serialize(kotlinx.serialization.encoding/Encoder, com.eignex.kumulant.stat.summary/CountResult) // com.eignex.kumulant.stat.summary/CountResult.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.eignex.kumulant.stat.summary.CountResult){}[0]
-    }
-
-    final object Companion { // com.eignex.kumulant.stat.summary/CountResult.Companion|null[0]
-        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.summary/CountResult> // com.eignex.kumulant.stat.summary/CountResult.Companion.serializer|serializer(){}[0]
-    }
-}
-
 final class com.eignex.kumulant.stat.summary/CountStat : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.summary/SumResult> { // com.eignex.kumulant.stat.summary/CountStat|null[0]
     constructor <init>(com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.stat.summary/CountStat.<init>|<init>(com.eignex.kumulant.core.Concurrency){}[0]
 
@@ -9287,6 +9268,7 @@ final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schem
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materialize(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, *, *>> // com.eignex.kumulant.schema.runtime/materialize|materialize@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeDiscrete(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/DiscreteStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeDiscrete|materializeDiscrete@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializePaired(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/PairedStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializePaired|materializePaired@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
+final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeRegression(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/RegressionStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeRegression|materializeRegression@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeSeries(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/SeriesStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeSeries|materializeSeries@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeVector(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/VectorStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeVector|materializeVector@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.spec/SeriesStatSpec<*>).com.eignex.kumulant.schema.ops/band(kotlin/Double): com.eignex.kumulant.schema.spec/SeriesStatSpec<com.eignex.kumulant.schema/BandResult> // com.eignex.kumulant.schema.ops/band|band@com.eignex.kumulant.schema.spec.SeriesStatSpec<*>(kotlin.Double){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
@@ -15,19 +15,19 @@ import com.eignex.kumulant.stream.DEFAULT_WINDOW_SLICES
 // Each returns a spec of the same modality, building the internal wrapper
 // spec it corresponds to; AST-backed ops carry a ScalarExpr / BoolExpr.
 
-/** Wrap this series spec so every update applies the per-observation [weight] multiplier. */
+/** Wrap this series spec so every update uses [weight] regardless of caller input. */
 fun <R : Result> SeriesStatSpec<R>.withWeight(weight: Double): SeriesStatSpec<R> =
     WithWeightSeries(this, weight) as SeriesStatSpec<R>
 
-/** Wrap this paired spec so every update applies the per-observation [weight] multiplier. */
+/** Wrap this paired spec so every update uses [weight] regardless of caller input. */
 fun <R : Result> PairedStatSpec<R>.withWeight(weight: Double): PairedStatSpec<R> =
     WithWeightPaired(this, weight) as PairedStatSpec<R>
 
-/** Wrap this vector spec so every update applies the per-observation [weight] multiplier. */
+/** Wrap this vector spec so every update uses [weight] regardless of caller input. */
 fun <R : Result> VectorStatSpec<R>.withWeight(weight: Double): VectorStatSpec<R> =
     WithWeightVector(this, weight) as VectorStatSpec<R>
 
-/** Wrap this discrete spec so every update applies the per-observation [weight] multiplier. */
+/** Wrap this discrete spec so every update uses [weight] regardless of caller input. */
 fun <R : Result> DiscreteStatSpec<R>.withWeight(weight: Double): DiscreteStatSpec<R> =
     WithWeightDiscrete(this, weight) as DiscreteStatSpec<R>
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -13,7 +13,7 @@ import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.schema.*
 import com.eignex.kumulant.schema.spec.*
 
-private fun requireUniqueNames(entries: List<Pair<String, *>>, typeName: String) {
+internal fun requireUniqueNames(entries: List<Pair<String, *>>, typeName: String) {
     val duplicates = entries.map { it.first }.groupingBy { it }.eachCount().filter { it.value > 1 }.keys
     require(duplicates.isEmpty()) {
         "Duplicate stat names in $typeName: $duplicates - pass explicit Pair<String, ...> to disambiguate"

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -197,6 +197,8 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
         is DDSketch -> DDSketchStat(
             relativeError = relativeError,
             probabilities = probabilities.toDoubleArray(),
+            minIndexableValue = minIndexableValue,
+            maxIndexableValue = maxIndexableValue,
             concurrency = concurrency,
         )
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -18,6 +18,12 @@ sealed class AbstractStatGroup<S : Stat<*>>(
     protected val stats: List<BoundStat<*, out S, *>>,
     protected val concurrencyOverride: Concurrency?,
 ) : GroupedStat {
+    init {
+        // read() keys results by name, so a duplicate would silently drop one stat's result and then
+        // feed the survivor's back into both on merge.
+        requireUniqueNames(stats.map { (key, _) -> key.name to key }, this::class.simpleName ?: "StatGroup")
+    }
+
     /**
      * The group's effective level: the override when one was given, otherwise the *weakest* level any
      * child uses.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
@@ -54,6 +54,8 @@ abstract class StatSchema(val concurrency: Concurrency = Concurrency.None) : Sch
 
     protected fun <R : Result> discrete(config: DiscreteStatSpec<R>) = register(config) { StatKey<R>(it) }
 
+    protected fun <R : Result> regression(config: RegressionStatSpec<R>) = register(config) { StatKey<R>(it) }
+
     /**
      * Nest a sub-schema as a [GroupStatSpec]; materialization recurses at the parent's group construction.
      *

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
@@ -54,7 +54,13 @@ abstract class StatSchema(val concurrency: Concurrency = Concurrency.None) : Sch
 
     protected fun <R : Result> discrete(config: DiscreteStatSpec<R>) = register(config) { StatKey<R>(it) }
 
-    /** Nest a sub-schema as a [GroupStatSpec]; materialization recurses at the parent's group construction. */
+    /**
+     * Nest a sub-schema as a [GroupStatSpec]; materialization recurses at the parent's group construction.
+     *
+     * The nested schema contributes its stats, never its [concurrency]: that is a deployment knob applied
+     * at materialization, not part of the wire description, so the whole tree materializes at whatever
+     * concurrency the parent is materialized with. Set it on the outermost schema.
+     */
     protected fun <T : StatSchema> group(nestedSchema: T) =
         register(GroupStatSpec(nestedSchema.statSchemaDef().stats)) { GroupStatKey(it, nestedSchema) }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchemaDef.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.schema.runtime
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
@@ -67,6 +68,16 @@ fun StatSchemaDef.materializeDiscrete(
     bindDiscrete(name, config.materialize(concurrency))
 }
 
+/** Materialize regression-modality entries only; throws if any entry isn't regression. */
+fun StatSchemaDef.materializeRegression(
+    concurrency: Concurrency = Concurrency.None,
+): List<BoundStat<*, out RegressionStat<*>, *>> = stats.map { (name, config) ->
+    require(config is RegressionStatSpec<*>) {
+        "Entry '$name' has config ${config::class.simpleName}, expected a RegressionStatSpec"
+    }
+    bindRegression(name, config.materialize(concurrency))
+}
+
 private fun bind(name: String, stat: Stat<*>): BoundStat<*, *, *> = toSpec(StatKey<Result>(name), stat)
 
 private fun bindSeries(name: String, stat: SeriesStat<*>): BoundStat<*, out SeriesStat<*>, *> =
@@ -79,4 +90,7 @@ private fun bindVector(name: String, stat: VectorStat<*>): BoundStat<*, out Vect
     toSpec(StatKey<Result>(name), stat)
 
 private fun bindDiscrete(name: String, stat: DiscreteStat<*>): BoundStat<*, out DiscreteStat<*>, *> =
+    toSpec(StatKey<Result>(name), stat)
+
+private fun bindRegression(name: String, stat: RegressionStat<*>): BoundStat<*, out RegressionStat<*>, *> =
     toSpec(StatKey<Result>(name), stat)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
@@ -27,43 +27,43 @@ import kotlinx.serialization.Serializable
 // Lambda-only live forms (`mapResult`, the lambda overloads of
 // `transformValue`/`transformPair`/`filter`) stay in the live-stat package only.
 
-/** Wire spec for `SeriesStat.withWeight(weight)`: multiplies every update by [weight]. */
+/** Wire spec for `SeriesStat.withWeight(weight)`: every update uses [weight] regardless of caller input. */
 @Serializable
 @SerialName("WithWeightSeries")
 internal data class WithWeightSeries(
     /** Inner spec whose updates are weighted. */
     val inner: StatSpec,
-    /** Per-update weight multiplier. */
+    /** Weight used for every update, in place of the caller's. */
     val weight: Double,
 ) : SeriesStatSpec<Result>
 
-/** Wire spec for `PairedStat.withWeight(weight)`: multiplies every update by [weight]. */
+/** Wire spec for `PairedStat.withWeight(weight)`: every update uses [weight] regardless of caller input. */
 @Serializable
 @SerialName("WithWeightPaired")
 internal data class WithWeightPaired(
     /** Inner spec whose updates are weighted. */
     val inner: StatSpec,
-    /** Per-update weight multiplier. */
+    /** Weight used for every update, in place of the caller's. */
     val weight: Double,
 ) : PairedStatSpec<Result>
 
-/** Wire spec for `VectorStat.withWeight(weight)`: multiplies every update by [weight]. */
+/** Wire spec for `VectorStat.withWeight(weight)`: every update uses [weight] regardless of caller input. */
 @Serializable
 @SerialName("WithWeightVector")
 internal data class WithWeightVector(
     /** Inner spec whose updates are weighted. */
     val inner: StatSpec,
-    /** Per-update weight multiplier. */
+    /** Weight used for every update, in place of the caller's. */
     val weight: Double,
 ) : VectorStatSpec<Result>
 
-/** Wire spec for `DiscreteStat.withWeight(weight)`: multiplies every update by [weight]. */
+/** Wire spec for `DiscreteStat.withWeight(weight)`: every update uses [weight] regardless of caller input. */
 @Serializable
 @SerialName("WithWeightDiscrete")
 internal data class WithWeightDiscrete(
     /** Inner spec whose updates are weighted. */
     val inner: StatSpec,
-    /** Per-update weight multiplier. */
+    /** Weight used for every update, in place of the caller's. */
     val weight: Double,
 ) : DiscreteStatSpec<Result>
 
@@ -165,7 +165,7 @@ internal data class WithFixedY(
 @Serializable
 @SerialName("WithTimeAsX")
 internal data class WithTimeAsX(
-    /** Inner paired spec whose `x` is the wall-clock timestamp (nanoseconds). */
+    /** Inner paired spec whose `x` is the wall-clock timestamp in fractional seconds. */
     val inner: StatSpec,
 ) : SeriesStatSpec<Result>
 
@@ -173,7 +173,7 @@ internal data class WithTimeAsX(
 @Serializable
 @SerialName("WithTimeAsY")
 internal data class WithTimeAsY(
-    /** Inner paired spec whose `y` is the wall-clock timestamp (nanoseconds). */
+    /** Inner paired spec whose `y` is the wall-clock timestamp in fractional seconds. */
     val inner: StatSpec,
 ) : SeriesStatSpec<Result>
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
@@ -253,6 +253,10 @@ data class DDSketch(
     val relativeError: Double = 0.01,
     /** Quantiles to evaluate at read time. */
     val probabilities: List<Double> = listOf(0.5, 0.75, 0.9, 0.95, 0.99, 0.999),
+    /** Smallest magnitude given its own bin; smaller non-zero values fold into the bottom bin. */
+    val minIndexableValue: Double = 1e-9,
+    /** Largest magnitude given its own bin; larger values fold into the top bin. */
+    val maxIndexableValue: Double = 1e12,
 ) : SeriesStatSpec<SketchResult>
 
 /** Spec for `FrugalQuantileStat`: O(1)-memory single-quantile estimator. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -86,9 +86,12 @@ data class SeasonalSmoothingResult(
  * ```
  *
  * Multiplicative is the same shape with subtraction replaced by division and addition by
- * multiplication. The first [period] updates seed the seasonal vector (additive: from
- * the residual `value - level`; multiplicative: from `value / level`, falling back to
- * `1.0` if `level == 0.0`).
+ * multiplication; a zero season falls back to `1.0` and a zero level leaves the season as it was, so
+ * neither path divides by zero.
+ *
+ * The first update seeds the level and leaves the seasonal vector at its identity (0 additive, 1
+ * multiplicative); every later update runs the recurrence above. Nothing seeds the seasonal vector
+ * separately, so the first cycle carries little seasonal signal.
  *
  * **Use cases:** short-horizon forecasting of streams with a recurring cycle on top
  * of a level and trend; pairs with [HoltStat] when no seasonal component is present.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/CountStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/summary/CountStat.kt
@@ -1,20 +1,9 @@
 package com.eignex.kumulant.stat.summary
 
 import com.eignex.kumulant.core.Concurrency
-import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.operation.withValue
 import com.eignex.kumulant.operation.withWeight
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-/** Unweighted event count. */
-@Serializable
-@SerialName("CountResult")
-data class CountResult(
-    /** Number of observations seen. */
-    val count: Long,
-) : Result
 
 /**
  * Observation count: each update contributes 1 regardless of supplied value and weight.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -60,4 +60,23 @@ class RegressionListStatsTest {
         val sum = byName["marginalY"] as SumResult
         assertEquals(12.0, sum.sum, DELTA)
     }
+
+    @Test
+    fun `a schema can declare regression stats and build RegressionListStats`() {
+        val schema = object : StatSchema() {
+            val sgd by regression(StochasticRegression(featureSize = 1))
+        }
+        val stats = RegressionListStats<Result>(schema)
+        for (y in doubleArrayOf(1.0, 2.0, 3.0)) stats.update(feat(0.5), y)
+        assertEquals(listOf("sgd"), stats.read(0L).names)
+    }
+
+    @Test
+    fun `a schema definition materializes its regression entries`() {
+        val schema = object : StatSchema() {
+            val sgd by regression(StochasticRegression(featureSize = 1))
+        }
+        val bound = schema.statSchemaDef().materializeRegression()
+        assertEquals(listOf("sgd"), bound.map { it.key.name })
+    }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -301,6 +301,13 @@ class StatGroupTest {
         assertEquals(1.0, clonedAfterReset[schema.requests].sum, DELTA)
         assertEquals(10.0, clonedAfterReset[schema.billableMsTotal].sum, DELTA)
     }
+
+    @Test
+    fun `StatGroup rejects duplicate stat names`() {
+        assertFailsWith<IllegalArgumentException> {
+            StatGroup(StatKey<SumResult>("hits") to SumStat(), StatKey<SumResult>("hits") to SumStat())
+        }
+    }
 }
 
 class PairedStatGroupTest {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatSchemaConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatSchemaConcurrencyTest.kt
@@ -51,7 +51,7 @@ class StatSchemaConcurrencyTest {
     }
 
     @Test
-    fun `nested schema keeps its own concurrency independent of parent`() {
+    fun `nested schema reports its own concurrency when materialized directly`() {
         val inner = object : StatSchema(Concurrency.Strict) {
             val mean by series(Mean)
         }
@@ -64,5 +64,17 @@ class StatSchemaConcurrencyTest {
         val innerSpecs = seriesSpecs(inner)
         assertTrue(innerSpecs.isNotEmpty())
         assertEquals(Concurrency.Strict, innerSpecs.single().stat.concurrency)
+    }
+
+    @Test
+    fun `a nested schema materializes at its parent's concurrency`() {
+        val inner = object : StatSchema(Concurrency.Strict) {
+            val mean by series(Mean)
+        }
+        val parent = object : StatSchema(Concurrency.None) {
+            val nested by group(inner)
+        }
+        val nested = seriesSpecs(parent).single().stat
+        assertEquals(Concurrency.None, nested.concurrency)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatsRoundTripTest.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.schema.runtime.*
 import com.eignex.kumulant.schema.spec.*
 import com.eignex.kumulant.stat.anomaly.FeatureRange
 import com.eignex.kumulant.stat.forecast.SeasonalMode
+import com.eignex.kumulant.stat.quantile.DDSketchStat
 import com.eignex.kumulant.stat.regression.glm.Penalty
 import com.eignex.kumulant.stat.summary.MaxResult
 import com.eignex.kumulant.stat.summary.MinResult
@@ -18,6 +19,7 @@ import com.eignex.skema.SchemaJson
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 // For each modality: build a schema with a config-only entry, encode, decode, materialize, drive a
 // small fixed input through both the original live stat and the rehydrated stat, and compare results.
 class StatsRoundTripTest {
@@ -377,5 +379,13 @@ class StatsRoundTripTest {
         )
         assertEquals(live0[schema.min].min, rebuilt0[StatKey<MinResult>("min")].min)
         assertEquals(live0[schema.max].max, rebuilt0[StatKey<MaxResult>("max")].max)
+    }
+
+    @Test
+    fun `DDSketch spec carries a non-default indexable range through materialize`() {
+        val stat = DDSketch(minIndexableValue = 1e-3, maxIndexableValue = 1e6).materialize(Concurrency.None)
+        val sketch = assertIs<DDSketchStat>(stat)
+        assertEquals(1e-3, sketch.minIndexableValue)
+        assertEquals(1e6, sketch.maxIndexableValue)
     }
 }


### PR DESCRIPTION
## What changed

- StatGroup rejects duplicate stat names, using the same guard the list stats already had.
- A schema can declare regression stats, and a schema definition can materialize them.
- The DDSketch spec carries its indexable range on the wire.
- withWeight documents that it replaces the caller's weight rather than multiplying it.
- The time axis specs document fractional seconds instead of nanoseconds.
- SeasonalSmoothingStat documents the seeding it actually performs.
- The unused CountResult wire type is removed.

## Why

A group keys its results by name, so a duplicate silently dropped one stat's result and then fed the survivor's back into both on merge. The regression modality was first class on the wire but unreachable from a schema: there was no declarator, so regressionSpecs always returned empty and RegressionListStats built from a schema always threw. A non-default DDSketch had no wire representation and reset to defaults through a round trip. The three doc corrections each described behaviour the code does not have, the time axis one by a factor of 1e9.

## Why nested schema concurrency was documented rather than carried

A schema nested through group() materializes at its parent's concurrency, not its own. Carrying it would mean making Concurrency serializable and putting it into GroupStatSpec, but the repo treats concurrency as a deployment knob applied at materialize time rather than wire data, and putting it on the wire would let a remote peer dictate local threading. The declarator now says so, the existing test that was named for this case but only checked direct materialization was renamed, and a new test pins the behaviour through the parent.

## Testing

The duplicate name and regression modality defects were reproduced first. `./gradlew check lintDocs` passes on every target.
