### PR TITLE
refactor: migrate to the koblas f64 type names

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
@@ -7,7 +7,7 @@ import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.UCB1
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
 import com.eignex.kumulant.stat.regression.glm.PointPosterior
@@ -100,14 +100,14 @@ fun contextualBanditSpec(
     build = build,
     cycle = { bandit, oracle ->
         val ctx = sampleContext(oracle)
-        val x = DenseVector.of(ctx)
+        val x = F64DenseVector.of(ctx)
         val i = bandit.choose(x)
         val r = sampleReward(i, ctx, oracle)
         bandit.update(i, x, r)
     },
     regretCycle = { bandit, oracle, ref ->
         val ctx = sampleContext(oracle)
-        val x = DenseVector.of(ctx)
+        val x = F64DenseVector.of(ctx)
         val i = bandit.choose(x)
         val r = sampleReward(i, ctx, oracle)
         bandit.update(i, x, r)

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
@@ -6,7 +6,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.random.Random
 
 /** Single observation passed to a stat under test. */
@@ -119,7 +119,7 @@ fun <R : Result> regressionStatSpec(
             var y = bias
             var i = 0
             while (i < featureSize) { y += trueWeights[i] * x[i]; i++ }
-            s.update(DenseVector.of(x), y, u.timestampNanos, u.weight)
+            s.update(F64DenseVector.of(x), y, u.timestampNanos, u.weight)
         },
         readSnapshot = { s, ts -> s.read(ts) },
         merge = { s, r -> s.merge(r) },

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -27,17 +27,17 @@ public final class com/eignex/kumulant/bandit/BanditFactoryKt {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualBandit : com/eignex/kumulant/bandit/Bandit {
-	public abstract fun choose (Lcom/eignex/koblas/VectorView;)I
-	public abstract fun update (ILcom/eignex/koblas/VectorView;DD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorView;DDILjava/lang/Object;)V
+	public abstract fun choose (Lcom/eignex/koblas/F64VectorView;)I
+	public abstract fun update (ILcom/eignex/koblas/F64VectorView;DD)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/bandit/ContextualBandit$DefaultImpls {
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualScorable {
-	public abstract fun evaluate (ILcom/eignex/koblas/VectorView;)D
+	public abstract fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/bandit/PerArmBandit : com/eignex/kumulant/bandit/Snapshotable {
@@ -61,14 +61,14 @@ public abstract interface class com/eignex/kumulant/bandit/Snapshotable {
 public final class com/eignex/kumulant/bandit/TrackedContextualBandit : com/eignex/kumulant/bandit/ContextualBandit {
 	public fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/VectorView;)I
+	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
 	public final fun chooseResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun getContextFeatureSize ()I
 	public final fun getInner ()Lcom/eignex/kumulant/bandit/ContextualBandit;
 	public fun getNbrArms ()I
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun reset ()V
-	public fun update (ILcom/eignex/koblas/VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
 	public final fun updateArmRewardResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateJointResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateMarginalResult ()Lcom/eignex/kumulant/core/Result;
@@ -114,7 +114,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion;
 	public fun <init> (ILjava/util/List;DDLkotlin/random/Random;)V
 	public synthetic fun <init> (ILjava/util/List;DDLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/VectorView;)I
+	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit;
 	public final fun expertWeights ()[D
@@ -125,11 +125,11 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun merge (Lcom/eignex/kumulant/bandit/contextual/Exp4State;)V
 	public synthetic fun merge (Ljava/lang/Object;)V
-	public final fun playDistribution (Lcom/eignex/koblas/VectorView;)[D
+	public final fun playDistribution (Lcom/eignex/koblas/F64VectorView;)[D
 	public fun reset ()V
 	public fun snapshot ()Lcom/eignex/kumulant/bandit/contextual/Exp4State;
 	public synthetic fun snapshot ()Ljava/lang/Object;
-	public fun update (ILcom/eignex/koblas/VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
@@ -138,7 +138,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/contextual/Exp4Expert {
-	public abstract fun advise (Lcom/eignex/koblas/VectorView;I)[D
+	public abstract fun advise (Lcom/eignex/koblas/F64VectorView;I)[D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4State : com/eignex/kumulant/core/Result {
@@ -208,10 +208,10 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun armResult (I)Lcom/eignex/kumulant/bandit/contextual/KnnArmResult;
 	public synthetic fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armWeight (I)D
-	public fun choose (Lcom/eignex/koblas/VectorView;)I
+	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/VectorView;)D
+	public fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
 	public final fun getColdStartScore ()D
 	public final fun getDistance ()Lkotlin/jvm/functions/Function2;
 	public final fun getExploration ()D
@@ -225,11 +225,11 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit$Companion {
-	public final fun squaredL2 (Lcom/eignex/koblas/VectorView;Lcom/eignex/koblas/VectorView;)D
+	public final fun squaredL2 (Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -391,10 +391,10 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public synthetic fun <init> (ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/stat/regression/RegressionPosterior;DLcom/eignex/kumulant/core/RegressionStat;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armStat (I)Lcom/eignex/kumulant/core/RegressionStat;
-	public fun choose (Lcom/eignex/koblas/VectorView;)I
+	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/VectorView;)D
+	public fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
 	public final fun getExploration ()D
 	public fun getNbrArms ()I
 	public final fun getPosterior ()Lcom/eignex/kumulant/stat/regression/RegressionPosterior;
@@ -407,7 +407,7 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/RegressionContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -1840,13 +1840,13 @@ public abstract interface class com/eignex/kumulant/core/HasCenterScale : com/ei
 public abstract interface class com/eignex/kumulant/core/HasLinearModel : com/eignex/kumulant/core/Result {
 	public abstract fun getBias ()D
 	public fun getFeatureSize ()I
-	public abstract fun getWeights ()Lcom/eignex/koblas/VectorView;
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/core/HasLinearModel$DefaultImpls {
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasLinearModel;)I
-	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/core/HasMinMax : com/eignex/kumulant/core/Result {
@@ -1939,16 +1939,16 @@ public abstract interface class com/eignex/kumulant/core/HasSlope : com/eignex/k
 	public fun getFeatureSize ()I
 	public abstract fun getIntercept ()D
 	public abstract fun getSlope ()D
-	public fun getWeights ()Lcom/eignex/koblas/VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/F64VectorView;
 	public fun predict (D)D
 }
 
 public final class com/eignex/kumulant/core/HasSlope$DefaultImpls {
 	public static fun getBias (Lcom/eignex/kumulant/core/HasSlope;)D
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasSlope;)I
-	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/VectorView;
+	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/F64VectorView;
 	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;D)D
-	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/core/IndexedResult : com/eignex/kumulant/core/Result {
@@ -1999,22 +1999,22 @@ public abstract interface class com/eignex/kumulant/core/RegressionStat : com/ei
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public abstract fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public abstract fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorView;DDILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorView;DJDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DJDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/RegressionStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorView;DD)V
+	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DD)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDD)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorView;DDILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorView;DJDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DJDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDILjava/lang/Object;)V
 }
@@ -2086,22 +2086,22 @@ public final class com/eignex/kumulant/core/Stat$DefaultImpls {
 public abstract interface class com/eignex/kumulant/core/VectorStat : com/eignex/kumulant/core/Stat {
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/VectorView;D)V
-	public abstract fun update (Lcom/eignex/koblas/VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
+	public abstract fun update (Lcom/eignex/koblas/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorView;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorView;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/VectorStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorView;D)V
+	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;D)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DD)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorView;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorView;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
@@ -3099,8 +3099,8 @@ public final class com/eignex/kumulant/schema/runtime/VectorStatGroup : com/eign
 	public synthetic fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/VectorView;D)V
-	public fun update (Lcom/eignex/koblas/VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -5001,7 +5001,7 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult : com/e
 	public fun getTotalWeights ()D
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun score (Lcom/eignex/koblas/VectorView;)D
+	public final fun score (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -5038,8 +5038,8 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat : com/eig
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;D)V
-	public fun update (Lcom/eignex/koblas/VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -6770,30 +6770,30 @@ public final class com/eignex/kumulant/stat/regression/CovarianceStat : com/eign
 }
 
 public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesResult : com/eignex/kumulant/core/HasObservationCount {
-	public fun <init> (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DD)V
+	public fun <init> (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/DenseMatrix;
-	public final fun component5 ()Lcom/eignex/koblas/DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun component5 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component6 ()D
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public final fun copy (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getClassWeights ()Lcom/eignex/koblas/DenseVector;
+	public final fun getClassWeights ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun getFeatureSize ()I
-	public final fun getMeans ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun getMeans ()Lcom/eignex/koblas/F64DenseMatrix;
 	public final fun getNumClasses ()I
 	public fun getTotalWeights ()D
 	public final fun getVarianceFloor ()D
-	public final fun getVariances ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun getVariances ()Lcom/eignex/koblas/F64DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logPosterior (Lcom/eignex/koblas/VectorView;I)D
-	public final fun predict (Lcom/eignex/koblas/VectorView;)I
+	public final fun logPosterior (Lcom/eignex/koblas/F64VectorView;I)D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
 	public final fun prior (I)D
-	public final fun probabilities (Lcom/eignex/koblas/VectorView;)[D
+	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6823,8 +6823,8 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat : 
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -6841,12 +6841,12 @@ public final class com/eignex/kumulant/stat/regression/Optimizer$DefaultImpls {
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/RegressionPosterior {
-	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
+	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RegressionPosterior$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RmspropOptimizer : com/eignex/kumulant/stat/regression/Optimizer {
@@ -6874,29 +6874,29 @@ public final class com/eignex/kumulant/stat/regression/SgdOptimizer : com/eignex
 
 public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult$Companion;
-	public fun <init> (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJD)V
+	public fun <init> (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component5 ()D
 	public final fun component6 ()J
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public final fun copy (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBiases ()Lcom/eignex/koblas/DenseVector;
+	public final fun getBiases ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun getCrossEntropy ()D
 	public final fun getFeatureSize ()I
 	public final fun getNumClasses ()I
 	public final fun getStep ()J
 	public fun getTotalWeights ()D
-	public final fun getWeights ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun getWeights ()Lcom/eignex/koblas/F64DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logit (Lcom/eignex/koblas/VectorView;I)D
-	public final fun predict (Lcom/eignex/koblas/VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorView;)[D
+	public final fun logit (Lcom/eignex/koblas/F64VectorView;I)D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6934,16 +6934,16 @@ public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionStat : c
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat : com/eignex/kumulant/core/RegressionStat {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat$Companion;
-	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorView;Lcom/eignex/koblas/MatrixView;)V
-	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorView;Lcom/eignex/koblas/MatrixView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64MatrixView;)V
+	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64MatrixView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
@@ -6956,8 +6956,8 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -6969,24 +6969,24 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 
 public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
+	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/DenseMatrix;
-	public final fun component7 ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun component6 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun component7 ()Lcom/eignex/koblas/F64DenseMatrix;
 	public final fun component8 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component9 ()D
-	public final fun copy (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
-	public final fun getCovariance ()Lcom/eignex/koblas/DenseMatrix;
-	public final fun getCovarianceL ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun getCovariance ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getCovarianceL ()Lcom/eignex/koblas/F64DenseMatrix;
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
@@ -7001,12 +7001,12 @@ public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionR
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorView;)D
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7027,25 +7027,25 @@ public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionR
 
 public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
+	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/DenseVector;
+	public final fun component6 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component7 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component8 ()D
-	public final fun copy (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
-	public final fun getPrecision ()Lcom/eignex/koblas/DenseVector;
+	public final fun getPrecision ()Lcom/eignex/koblas/F64DenseVector;
 	public fun getRSquared ()D
 	public fun getRmse ()D
 	public fun getSampleStdDev ()D
@@ -7057,12 +7057,12 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionRes
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorView;)D
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7098,8 +7098,8 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7107,19 +7107,19 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 public final class com/eignex/kumulant/stat/regression/glm/FactorisedGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/FactorisedGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression {
-	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;)V
-	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;)V
+	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createInstance ()Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
 	public final fun getBiasPriorVariance ()D
 	public final fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
@@ -7143,22 +7143,22 @@ public final class com/eignex/kumulant/stat/regression/glm/LearningRatesKt {
 public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/LinUcb;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearPosterior : com/eignex/kumulant/stat/regression/RegressionPosterior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion;
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorView;
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/F64VectorView;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion {
@@ -7166,8 +7166,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Compa
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$DefaultImpls {
-	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorView;
+	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/F64VectorView;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult : com/eignex/kumulant/core/HasLinearModel, com/eignex/kumulant/core/HasRegression, com/eignex/kumulant/core/Result {
@@ -7176,9 +7176,9 @@ public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRe
 	public abstract fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public abstract fun getStep ()J
 	public abstract fun getTotalWeights ()D
-	public abstract fun getWeights ()Lcom/eignex/koblas/VectorView;
-	public fun linearPredictor (Lcom/eignex/koblas/VectorView;)D
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult$Companion {
@@ -7197,8 +7197,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResul
 	public static fun getStdDev (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun getVariance (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun isEmpty (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)Z
-	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;)D
-	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;)D
+	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/Link {
@@ -7248,12 +7248,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Link$Logit : com/eign
 public final class com/eignex/kumulant/stat/regression/glm/MultivariateGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/MultivariateGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
@@ -7331,28 +7331,28 @@ public final class com/eignex/kumulant/stat/regression/glm/Penalty$None : com/ei
 public final class com/eignex/kumulant/stat/regression/glm/PointPosterior : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/PointPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior$Companion;
-	public fun <init> (Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;I)V
-	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
-	public final fun component2 ()Lcom/eignex/koblas/DenseMatrix;
+	public fun <init> (Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;I)V
+	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun component2 ()Lcom/eignex/koblas/F64DenseMatrix;
 	public final fun component3 ()I
-	public final fun copy (Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public final fun copy (Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCovariance ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun getCovariance ()Lcom/eignex/koblas/F64DenseMatrix;
 	public final fun getInstanceCount ()I
-	public final fun getMean ()Lcom/eignex/koblas/DenseVector;
+	public final fun getMean ()Lcom/eignex/koblas/F64DenseVector;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7374,17 +7374,17 @@ public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior$Compa
 
 public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
-	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
+	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
+	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component6 ()D
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public fun getFeatureSize ()I
@@ -7402,12 +7402,12 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionR
 	public fun getTotalWeights ()D
 	public final fun getUpdaterState ()Ljava/util/List;
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorView;)D
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7447,8 +7447,8 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionS
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7486,13 +7486,13 @@ public final class com/eignex/kumulant/stat/regression/glm/UnivariateRegressionR
 	public final fun getSxy ()D
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/F64VectorView;
 	public final fun getX ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public final fun getY ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public fun predict (D)D
-	public fun predict (Lcom/eignex/koblas/VectorView;)D
+	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7594,12 +7594,12 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationAuditL
 }
 
 public abstract class com/eignex/kumulant/stat/regression/tree/ClassificationLeafNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public final fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public abstract fun getArm ()Lcom/eignex/kumulant/core/SeriesStat;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric {
@@ -7614,7 +7614,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitM
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
 	public fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getCarryover ()Lcom/eignex/kumulant/core/SeriesStat;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
@@ -7632,19 +7632,19 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTermin
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTree {
 	public fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;I)V
 	public synthetic fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getNodeCount ()I
 	public final fun merge (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;)V
 	public final fun mergeSnapshot (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)V
-	public final fun predict (Lcom/eignex/koblas/VectorView;)I
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
 	public final fun prettyPrint (Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun prettyPrint$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun probabilities (Lcom/eignex/koblas/VectorView;)[D
+	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
 	public final fun reset ()V
 	public final fun rootNode ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun rootSnapshot ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
-	public final fun update (Lcom/eignex/koblas/VectorView;ID)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/VectorView;IDILjava/lang/Object;)V
+	public final fun update (Lcom/eignex/koblas/F64VectorView;ID)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/F64VectorView;IDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
@@ -7711,8 +7711,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7733,8 +7733,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/RegressionTree;
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7745,7 +7745,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ExprSplit : com/eign
 	public final fun component1 ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public final fun copy (Lcom/eignex/kumulant/schema/expr/BoolExpr;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;Lcom/eignex/kumulant/schema/expr/BoolExpr;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
-	public fun direction (Lcom/eignex/koblas/VectorView;)Z
+	public fun direction (Lcom/eignex/koblas/F64VectorView;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpr ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -7780,8 +7780,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestClassification
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorView;)[D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7810,11 +7810,11 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestRegressionResu
 	public final fun copy (Ljava/util/List;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Ljava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeafMerged (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeafMerged (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorView;)D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7866,8 +7866,8 @@ public final class com/eignex/kumulant/stat/regression/tree/InformationGain : co
 public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior : com/eignex/kumulant/stat/regression/tree/ForestPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7875,8 +7875,8 @@ public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior 
 public final class com/eignex/kumulant/stat/regression/tree/MeanTreePosterior : com/eignex/kumulant/stat/regression/tree/TreePosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7900,8 +7900,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestClassificationResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7924,8 +7924,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -8082,8 +8082,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonForestPoster
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8099,8 +8099,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonTreePosterio
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8114,7 +8114,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ThresholdSplit : com
 	public final fun component2 ()D
 	public final fun copy (ID)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;IDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
-	public fun direction (Lcom/eignex/koblas/VectorView;)Z
+	public fun direction (Lcom/eignex/koblas/F64VectorView;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatureIndex ()I
@@ -8145,7 +8145,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8168,7 +8168,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 }
 
@@ -8183,13 +8183,13 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationRe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNumClasses ()I
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorView;)[D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8218,7 +8218,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationSp
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8249,7 +8249,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult : com
 	public final fun copy (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8272,7 +8272,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult$Compa
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 }
 
@@ -8290,12 +8290,12 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeRegressionResult
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getRootMean ()D
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorView;)D
+	public final fun predict (Lcom/eignex/koblas/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8329,7 +8329,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeSplitResult : co
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8362,8 +8362,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbForestPosterior :
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8379,8 +8379,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbTreePosterior : c
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -91,7 +91,7 @@ final enum class com.eignex.kumulant.stat.sketch/AdmissionPolicy : kotlin/Enum<c
 }
 
 abstract fun interface com.eignex.kumulant.bandit.contextual/Exp4Expert { // com.eignex.kumulant.bandit.contextual/Exp4Expert|null[0]
-    abstract fun advise(com.eignex.koblas/VectorView, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.VectorView;kotlin.Int){}[0]
+    abstract fun advise(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
 }
 
 abstract fun interface com.eignex.kumulant.math/Hasher64 { // com.eignex.kumulant.math/Hasher64|null[0]
@@ -131,8 +131,8 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
         abstract fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/RegressionStat.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.core/RegressionStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
@@ -155,14 +155,14 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.core/VectorStat : com.eignex.kumulant.core/Stat<#A> { // com.eignex.kumulant.core/VectorStat|null[0]
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<#A> // com.eignex.kumulant.core/VectorStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/VectorView, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorView;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas/VectorView, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorView;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas/F64VectorView, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Long;kotlin.Double){}[0]
 }
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.stat.regression/RegressionPosterior { // com.eignex.kumulant.stat.regression/RegressionPosterior|null[0]
-    abstract fun evaluate(#A, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    abstract fun evaluate(#A, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
 }
 
 abstract interface <#A: in kotlin/Any?> com.eignex.kumulant.stat.regression.tree/Split { // com.eignex.kumulant.stat.regression.tree/Split|null[0]
@@ -185,12 +185,12 @@ abstract interface com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.ba
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualBandit : com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.bandit/ContextualBandit|null[0]
-    abstract fun choose(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.VectorView){}[0]
-    abstract fun update(kotlin/Int, com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    abstract fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
+    abstract fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualScorable { // com.eignex.kumulant.bandit/ContextualScorable|null[0]
-    abstract fun evaluate(kotlin/Int, com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorView){}[0]
+    abstract fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/Scorable { // com.eignex.kumulant.bandit/Scorable|null[0]
@@ -214,11 +214,11 @@ abstract interface com.eignex.kumulant.core/HasLinearModel : com.eignex.kumulant
     abstract val bias // com.eignex.kumulant.core/HasLinearModel.bias|{}bias[0]
         abstract fun <get-bias>(): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.bias.<get-bias>|<get-bias>(){}[0]
     abstract val weights // com.eignex.kumulant.core/HasLinearModel.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/VectorView // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
     open val featureSize // com.eignex.kumulant.core/HasLinearModel.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasLinearModel.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
-    open fun predict(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.VectorView){}[0]
+    open fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.F64VectorView){}[0]
 }
 
 abstract interface com.eignex.kumulant.core/HasMinMax : com.eignex.kumulant.core/Result { // com.eignex.kumulant.core/HasMinMax|null[0]
@@ -295,7 +295,7 @@ abstract interface com.eignex.kumulant.core/HasSlope : com.eignex.kumulant.core/
     open val featureSize // com.eignex.kumulant.core/HasSlope.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasSlope.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     open val weights // com.eignex.kumulant.core/HasSlope.weights|{}weights[0]
-        open fun <get-weights>(): com.eignex.koblas/VectorView // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
+        open fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
 
     open fun predict(kotlin/Double): kotlin/Double // com.eignex.kumulant.core/HasSlope.predict|predict(kotlin.Double){}[0]
 }
@@ -398,8 +398,8 @@ sealed interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.schem
 }
 
 sealed interface <#A: com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> com.eignex.kumulant.stat.regression.glm/LinearPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<#A> { // com.eignex.kumulant.stat.regression.glm/LinearPosterior|null[0]
-    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
-    open fun evaluate(#A, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
+    open fun evaluate(#A, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion|null[0]
         final fun <#A2: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A2>): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearPosterior<#A2>> // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
@@ -620,10 +620,10 @@ sealed interface com.eignex.kumulant.stat.regression.glm/LinearRegressionResult 
     abstract val totalWeights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights|{}totalWeights[0]
         abstract fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     abstract val weights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    open fun linearPredictor(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.VectorView){}[0]
-    open fun predict(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.VectorView){}[0]
+    open fun linearPredictor(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.F64VectorView){}[0]
+    open fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion.serializer|serializer(){}[0]
@@ -743,7 +743,7 @@ sealed interface com.eignex.kumulant.stat.regression.glm/Penalty { // com.eignex
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationNode { // com.eignex.kumulant.stat.regression.tree/ClassificationNode|null[0]
-    abstract fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric { // com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric|null[0]
@@ -757,7 +757,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMet
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ForestPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestPosterior|null[0]
 
-sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/VectorView> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
+sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/F64VectorView> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/SerializableSplit> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(){}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -777,7 +777,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeClassificationNode
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion.serializer|serializer(){}[0]
@@ -789,7 +789,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeNodeResult { // co
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion.serializer|serializer(){}[0]
@@ -835,10 +835,10 @@ final class <#A: com.eignex.kumulant.bandit/ContextualBandit> com.eignex.kumulan
     final val random // com.eignex.kumulant.bandit/TrackedContextualBandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit/TrackedContextualBandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.VectorView){}[0]
+    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
     final fun chooseResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.chooseResult|chooseResult(){}[0]
     final fun reset() // com.eignex.kumulant.bandit/TrackedContextualBandit.reset|reset(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
     final fun updateArmRewardResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateArmRewardResult|updateArmRewardResult(){}[0]
     final fun updateJointResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateJointResult|updateJointResult(){}[0]
     final fun updateMarginalResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateMarginalResult|updateMarginalResult(){}[0]
@@ -891,16 +891,16 @@ final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.con
 
     final fun armResult(kotlin/Int): #A // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armResult|armResult(kotlin.Int){}[0]
     final fun armStat(kotlin/Int): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armStat|armStat(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.VectorView){}[0]
+    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/RegressionContextualBandit<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorView){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
     final fun globalSnapshot(): #A? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalSnapshot|globalSnapshot(){}[0]
     final fun globalStat(): com.eignex.kumulant.core/RegressionStat<#A>? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalStat|globalStat(){}[0]
     final fun merge(kotlin.collections/List<#A>) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.merge|merge(kotlin.collections.List<1:0>){}[0]
     final fun mergeGlobal(#A) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.mergeGlobal|mergeGlobal(1:0){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 }
 
 final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.univariate/MultiArmedBandit : com.eignex.kumulant.bandit/PerArmBandit<#A>, com.eignex.kumulant.bandit/Scorable, com.eignex.kumulant.bandit/UnivariateBandit { // com.eignex.kumulant.bandit.univariate/MultiArmedBandit|null[0]
@@ -1194,14 +1194,14 @@ final class com.eignex.kumulant.bandit.contextual/Exp4Bandit : com.eignex.kumula
     final val random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.VectorView){}[0]
+    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/Exp4Bandit // com.eignex.kumulant.bandit.contextual/Exp4Bandit.create|create(kotlin.random.Random){}[0]
     final fun expertWeights(): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.expertWeights|expertWeights(){}[0]
     final fun merge(com.eignex.kumulant.bandit.contextual/Exp4State) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.merge|merge(com.eignex.kumulant.bandit.contextual.Exp4State){}[0]
-    final fun playDistribution(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.VectorView){}[0]
+    final fun playDistribution(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.F64VectorView){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/Exp4Bandit.reset|reset(){}[0]
     final fun snapshot(): com.eignex.kumulant.bandit.contextual/Exp4State // com.eignex.kumulant.bandit.contextual/Exp4Bandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion|null[0]
         final fun defaultEta(kotlin/Int, kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion.defaultEta|defaultEta(kotlin.Int;kotlin.Int){}[0]
@@ -1273,12 +1273,12 @@ final class com.eignex.kumulant.bandit.contextual/KnnArmResult : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eignex.kumulant.bandit/ContextualBandit, com.eignex.kumulant.bandit/ContextualScorable, com.eignex.kumulant.bandit/PerArmBandit<com.eignex.kumulant.bandit.contextual/KnnArmResult> { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/VectorView, com.eignex.koblas/VectorView, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.VectorView,com.eignex.koblas.VectorView,kotlin.Double>;kotlin.random.Random){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.F64VectorView,com.eignex.koblas.F64VectorView,kotlin.Double>;kotlin.random.Random){}[0]
 
     final val coldStartScore // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore|{}coldStartScore[0]
         final fun <get-coldStartScore>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore.<get-coldStartScore>|<get-coldStartScore>(){}[0]
     final val distance // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance|{}distance[0]
-        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/VectorView, com.eignex.koblas/VectorView, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
+        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
     final val exploration // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration|{}exploration[0]
         final fun <get-exploration>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration.<get-exploration>|<get-exploration>(){}[0]
     final val k // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.k|{}k[0]
@@ -1291,17 +1291,17 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.random.<get-random>|<get-random>(){}[0]
 
     final fun armWeight(kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.armWeight|armWeight(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.VectorView){}[0]
+    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorView){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
     final fun historySize(kotlin/Int): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.historySize|historySize(kotlin.Int){}[0]
     final fun merge(kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult>) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.merge|merge(kotlin.collections.List<com.eignex.kumulant.bandit.contextual.KnnArmResult>){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion|null[0]
-        final fun squaredL2(com.eignex.koblas/VectorView, com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.VectorView;com.eignex.koblas.VectorView){}[0]
+        final fun squaredL2(com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.F64VectorView;com.eignex.koblas.F64VectorView){}[0]
     }
 }
 
@@ -2896,7 +2896,7 @@ final class com.eignex.kumulant.schema.runtime/VectorStatGroup : com.eignex.kumu
     constructor <init>(kotlin/Array<out kotlin/Pair<com.eignex.kumulant.schema/StatKey<*>, com.eignex.kumulant.core/VectorStat<*>>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/VectorStatGroup.<init>|<init>(kotlin.Array<out|kotlin.Pair<com.eignex.kumulant.schema.StatKey<*>,com.eignex.kumulant.core.VectorStat<*>>>...;com.eignex.kumulant.core.Concurrency?){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/VectorStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.VectorView;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
@@ -4627,7 +4627,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult : com.eignex.k
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/IntArray = ..., kotlin/DoubleArray = ..., kotlin/DoubleArray = ...): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.IntArray;kotlin.DoubleArray;kotlin.DoubleArray){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.hashCode|hashCode(){}[0]
-    final fun score(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.VectorView){}[0]
+    final fun score(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult> { // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.$serializer|null[0]
@@ -4666,7 +4666,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat : com.eignex.kum
     final fun merge(com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.merge|merge(com.eignex.kumulant.stat.anomaly.HalfSpaceTreesResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.VectorView;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.anomaly/QuantileFilterResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.anomaly/QuantileFilterResult|null[0]
@@ -6280,7 +6280,7 @@ final class com.eignex.kumulant.stat.rate/RateStat : com.eignex.kumulant.core/Se
 }
 
 final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult> { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat|null[0]
-    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/VectorView? = ..., com.eignex.koblas/MatrixView? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.VectorView?;com.eignex.koblas.MatrixView?){}[0]
+    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/F64VectorView? = ..., com.eignex.koblas/F64MatrixView? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.F64VectorView?;com.eignex.koblas.F64MatrixView?){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
@@ -6295,7 +6295,7 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion|null[0]
         final fun fitPopulationPrior(kotlin.collections/List<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlin/Function1<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin/Double> = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion.fitPopulationPrior|fitPopulationPrior(kotlin.collections.List<com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult>;kotlin.Function1<com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult,kotlin.Double>){}[0]
@@ -6303,16 +6303,16 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
 }
 
 final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
     final val biasPrecision // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.biasPrecision|{}biasPrecision[0]
         final fun <get-biasPrecision>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.biasPrecision.<get-biasPrecision>|<get-biasPrecision>(){}[0]
     final val covariance // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance|{}covariance[0]
-        final fun <get-covariance>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance.<get-covariance>|<get-covariance>(){}[0]
+        final fun <get-covariance>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance.<get-covariance>|<get-covariance>(){}[0]
     final val covarianceL // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL|{}covarianceL[0]
-        final fun <get-covarianceL>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL.<get-covarianceL>|<get-covarianceL>(){}[0]
+        final fun <get-covarianceL>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL.<get-covarianceL>|<get-covarianceL>(){}[0]
     final val link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.sse|{}sse[0]
@@ -6322,18 +6322,18 @@ final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component6|component6(){}[0]
-    final fun component7(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component7|component7(){}[0]
+    final fun component6(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component6|component6(){}[0]
+    final fun component7(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component7|component7(){}[0]
     final fun component8(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component8|component8(){}[0]
     final fun component9(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component9|component9(){}[0]
-    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.toString|toString(){}[0]
@@ -6355,7 +6355,7 @@ final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult :
 }
 
 final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/F64DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6364,7 +6364,7 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val precision // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision|{}precision[0]
-        final fun <get-precision>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
+        final fun <get-precision>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse|{}sse[0]
         final fun <get-sse>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse.<get-sse>|<get-sse>(){}[0]
     final val step // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.step|{}step[0]
@@ -6372,17 +6372,17 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
+    final fun component6(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
     final fun component7(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component7|component7(){}[0]
     final fun component8(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component8|component8(){}[0]
-    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/F64DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.toString|toString(){}[0]
@@ -6423,11 +6423,11 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression { // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression|null[0]
-    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas/DenseVector? = ..., com.eignex.koblas/DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.DenseVector?;com.eignex.koblas.DenseMatrix?){}[0]
+    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas/F64DenseVector? = ..., com.eignex.koblas/F64DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.F64DenseVector?;com.eignex.koblas.F64DenseMatrix?){}[0]
 
     final val biasPriorVariance // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance|{}biasPriorVariance[0]
         final fun <get-biasPriorVariance>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance.<get-biasPriorVariance>|<get-biasPriorVariance>(){}[0]
@@ -6449,19 +6449,19 @@ final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegressi
 }
 
 final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eignex.kumulant.stat.regression.glm/PopulationPrior|null[0]
-    constructor <init>(com.eignex.koblas/DenseVector, com.eignex.koblas/DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.DenseVector;com.eignex.koblas.DenseMatrix;kotlin.Int){}[0]
+    constructor <init>(com.eignex.koblas/F64DenseVector, com.eignex.koblas/F64DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.F64DenseVector;com.eignex.koblas.F64DenseMatrix;kotlin.Int){}[0]
 
     final val covariance // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance|{}covariance[0]
-        final fun <get-covariance>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
+        final fun <get-covariance>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
     final val instanceCount // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount|{}instanceCount[0]
         final fun <get-instanceCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount.<get-instanceCount>|<get-instanceCount>(){}[0]
     final val mean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean|{}mean[0]
-        final fun <get-mean>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
+        final fun <get-mean>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
 
-    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
-    final fun component2(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
+    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
+    final fun component2(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
     final fun component3(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component3|component3(){}[0]
-    final fun copy(com.eignex.koblas/DenseVector = ..., com.eignex.koblas/DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.DenseVector;com.eignex.koblas.DenseMatrix;kotlin.Int){}[0]
+    final fun copy(com.eignex.koblas/F64DenseVector = ..., com.eignex.koblas/F64DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.F64DenseVector;com.eignex.koblas.F64DenseMatrix;kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PopulationPrior.toString|toString(){}[0]
@@ -6481,7 +6481,7 @@ final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eig
 }
 
 final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorView> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorView>){}[0]
+    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/F64VectorView> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.F64VectorView>){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6494,18 +6494,18 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val updaterState // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState|{}updaterState[0]
-        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
+        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component4|component4(){}[0]
     final fun component5(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<com.eignex.koblas/VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
-    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorView> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorView>){}[0]
+    final fun component7(): kotlin.collections/List<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
+    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/F64VectorView> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.F64VectorView>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.toString|toString(){}[0]
@@ -6554,7 +6554,7 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat : c
     final fun merge(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult : com.eignex.kumulant.core/HasRegression, com.eignex.kumulant.core/HasSlope, com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult|null[0]
@@ -6716,7 +6716,7 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode : c
         final fun <get-pos>(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<get-pos>|<get-pos>(){}[0]
         final fun <set-pos>(com.eignex.kumulant.stat.regression.tree/ClassificationNode) // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<set-pos>|<set-pos>(com.eignex.kumulant.stat.regression.tree.ClassificationNode){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf : com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode { // com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf|null[0]
@@ -6732,16 +6732,16 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationTree { // com
     final val nodeCount // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount|{}nodeCount[0]
         final fun <get-nodeCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount.<get-nodeCount>|<get-nodeCount>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun merge(com.eignex.kumulant.stat.regression.tree/ClassificationTree) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.merge|merge(com.eignex.kumulant.stat.regression.tree.ClassificationTree){}[0]
     final fun mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.mergeSnapshot|mergeSnapshot(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.VectorView){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.F64VectorView){}[0]
     final fun prettyPrint(kotlin/String = ...): kotlin/String // com.eignex.kumulant.stat.regression.tree/ClassificationTree.prettyPrint|prettyPrint(kotlin.String){}[0]
-    final fun probabilities(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.VectorView){}[0]
+    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/ClassificationTree.reset|reset(){}[0]
     final fun rootNode(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootNode|rootNode(){}[0]
     final fun rootSnapshot(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootSnapshot|rootSnapshot(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.VectorView;kotlin.Int;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.F64VectorView;kotlin.Int;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
@@ -6818,7 +6818,7 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.reset|reset(){}[0]
     final fun tree(): com.eignex.kumulant.stat.regression.tree/ClassificationTree // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat|null[0]
@@ -6837,8 +6837,8 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.reset|reset(){}[0]
-    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorView> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumulant.stat.regression.tree/SerializableSplit { // com.eignex.kumulant.stat.regression.tree/ExprSplit|null[0]
@@ -6849,7 +6849,7 @@ final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumu
 
     final fun component1(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.stat.regression.tree/ExprSplit.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.schema.expr/BoolExpr = ...): com.eignex.kumulant.stat.regression.tree/ExprSplit // com.eignex.kumulant.stat.regression.tree/ExprSplit.copy|copy(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-    final fun direction(com.eignex.koblas/VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.VectorView){}[0]
+    final fun direction(com.eignex.koblas/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.F64VectorView){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ExprSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ExprSplit.toString|toString(){}[0]
@@ -6885,8 +6885,8 @@ final class com.eignex.kumulant.stat.regression.tree/ForestClassificationResult 
     final fun copy(kotlin/Int = ..., kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.copy|copy(kotlin.Int;kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeClassificationResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorView){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestClassificationResult> { // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.$serializer|null[0]
@@ -6916,9 +6916,9 @@ final class com.eignex.kumulant.stat.regression.tree/ForestRegressionResult : co
     final fun component1(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.component1|component1(){}[0]
     final fun copy(kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.copy|copy(kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeRegressionResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeafMerged(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.VectorView){}[0]
+    final fun findLeafMerged(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.VectorView){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.$serializer|null[0]
@@ -6960,7 +6960,7 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.reset|reset(){}[0]
     final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/ClassificationTree> // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat|null[0]
@@ -6983,8 +6983,8 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.reset|reset(){}[0]
-    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorView>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
@@ -7073,7 +7073,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior : c
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.toString|toString(){}[0]
 }
@@ -7090,7 +7090,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior : com
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.toString|toString(){}[0]
 }
@@ -7106,7 +7106,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThresholdSplit : com.eignex
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component2|component2(){}[0]
     final fun copy(kotlin/Int = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThresholdSplit // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.copy|copy(kotlin.Int;kotlin.Double){}[0]
-    final fun direction(com.eignex.koblas/VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.VectorView){}[0]
+    final fun direction(com.eignex.koblas/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.F64VectorView){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.toString|toString(){}[0]
@@ -7134,7 +7134,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResul
     final fun component1(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.copy|copy(com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.toString|toString(){}[0]
 
@@ -7165,10 +7165,10 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationResult : 
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorView){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> { // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.$serializer|null[0]
@@ -7205,7 +7205,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResu
     final fun component4(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.toString|toString(){}[0]
 
@@ -7234,7 +7234,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeLeafResult : com.eignex
     final fun component1(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeLeafResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.copy|copy(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.toString|toString(){}[0]
 
@@ -7265,9 +7265,9 @@ final class com.eignex.kumulant.stat.regression.tree/TreeRegressionResult : com.
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.VectorView){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.$serializer|null[0]
@@ -7304,7 +7304,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeSplitResult : com.eigne
     final fun component4(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeSplitResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.toString|toString(){}[0]
 
@@ -7336,7 +7336,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbForestPosterior : com.ei
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbForestPosterior // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.toString|toString(){}[0]
 }
@@ -7353,7 +7353,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbTreePosterior : com.eign
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbTreePosterior // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.toString|toString(){}[0]
 }
@@ -7456,14 +7456,14 @@ final class com.eignex.kumulant.stat.regression/CovarianceStat : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
 
     final val classWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights|{}classWeights[0]
-        final fun <get-classWeights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
+        final fun <get-classWeights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize|{}featureSize[0]
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     final val means // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means|{}means[0]
-        final fun <get-means>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
+        final fun <get-means>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
     final val numClasses // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses|{}numClasses[0]
         final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
     final val totalWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.totalWeights|{}totalWeights[0]
@@ -7471,22 +7471,22 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.e
     final val varianceFloor // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor|{}varianceFloor[0]
         final fun <get-varianceFloor>(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor.<get-varianceFloor>|<get-varianceFloor>(){}[0]
     final val variances // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances|{}variances[0]
-        final fun <get-variances>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
+        final fun <get-variances>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
-    final fun component5(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
+    final fun component3(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
+    final fun component5(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.hashCode|hashCode(){}[0]
-    final fun logPosterior(com.eignex.koblas/VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.VectorView;kotlin.Int){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.VectorView){}[0]
+    final fun logPosterior(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
     final fun prior(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.prior|prior(kotlin.Int){}[0]
-    final fun probabilities(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.VectorView){}[0]
+    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult> { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.$serializer|null[0]
@@ -7515,7 +7515,7 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat : com.eig
     final fun merge(com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.merge|merge(com.eignex.kumulant.stat.regression.GaussianNaiveBayesResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression/RmspropOptimizer : com.eignex.kumulant.stat.regression/Optimizer { // com.eignex.kumulant.stat.regression/RmspropOptimizer|null[0]
@@ -7551,10 +7551,10 @@ final class com.eignex.kumulant.stat.regression/SgdOptimizer : com.eignex.kumula
 }
 
 final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 
     final val biases // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases|{}biases[0]
-        final fun <get-biases>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
+        final fun <get-biases>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
     final val crossEntropy // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy|{}crossEntropy[0]
         final fun <get-crossEntropy>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy.<get-crossEntropy>|<get-crossEntropy>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.featureSize|{}featureSize[0]
@@ -7566,21 +7566,21 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.ei
     final val totalWeights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
+    final fun component3(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Long // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.hashCode|hashCode(){}[0]
-    final fun logit(com.eignex.koblas/VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.VectorView;kotlin.Int){}[0]
-    final fun predict(com.eignex.koblas/VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.VectorView){}[0]
+    final fun logit(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
+    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/SoftmaxRegressionResult> { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.$serializer|null[0]
@@ -7621,7 +7621,7 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionStat : com.eign
     final fun merge(com.eignex.kumulant.stat.regression/SoftmaxRegressionResult) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.SoftmaxRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.score/AccuracyStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.stat.score/AccuracyStat|null[0]
@@ -8802,7 +8802,7 @@ sealed class com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode : c
     abstract val arm // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm|{}arm[0]
         abstract fun <get-arm>(): com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.regression.tree/ClassCountsResult> // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm.<get-arm>|<get-arm>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
 }
 
 final object com.eignex.kumulant.bandit.univariate/BetaPosterior : com.eignex.kumulant.bandit.univariate/Posterior<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.univariate/BetaPosterior|null[0]
@@ -9134,9 +9134,9 @@ final object com.eignex.kumulant.schema.spec/Variance : com.eignex.kumulant.sche
 
 final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/FactorisedGaussian> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.toString|toString(){}[0]
@@ -9144,9 +9144,9 @@ final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.ei
 
 final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinUcb|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/LinUcb.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/LinUcb.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinUcb> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/LinUcb.toString|toString(){}[0]
@@ -9154,9 +9154,9 @@ final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulan
 
 final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/MultivariateGaussian> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.toString|toString(){}[0]
@@ -9164,9 +9164,9 @@ final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.
 
 final object com.eignex.kumulant.stat.regression.glm/PointPosterior : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/PointPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PointPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PointPosterior.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorView // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/PointPosterior> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PointPosterior.toString|toString(){}[0]
@@ -9192,14 +9192,14 @@ final object com.eignex.kumulant.stat.regression.tree/InformationGain : com.eign
 
 final object com.eignex.kumulant.stat.regression.tree/MeanForestPosterior : com.eignex.kumulant.stat.regression.tree/ForestPosterior { // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.toString|toString(){}[0]
 }
 
 final object com.eignex.kumulant.stat.regression.tree/MeanTreePosterior : com.eignex.kumulant.stat.regression.tree/TreePosterior { // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.toString|toString(){}[0]
 }
@@ -9280,8 +9280,8 @@ final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.k
 final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.kumulant.stat.score/pitKsDistance(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.score/pitKsDistance|pitKsDistance@com.eignex.kumulant.stat.quantile.SparseHistogramResult(kotlin.Int){}[0]
 final fun (com.eignex.kumulant.stat.quantile/TDigestResult).com.eignex.kumulant.stat.quantile/toSparseHistogram(): com.eignex.kumulant.stat.quantile/SparseHistogramResult // com.eignex.kumulant.stat.quantile/toSparseHistogram|toSparseHistogram@com.eignex.kumulant.stat.quantile.TDigestResult(){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<*>).com.eignex.kumulant.stat.regression.tree/aggregate(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/aggregate|aggregate@com.eignex.kumulant.stat.regression.tree.RegressionNode<*>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/VectorView>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.VectorView>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorView>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.VectorView>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/F64VectorView>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.F64VectorView>(){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.F64VectorView>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/SplitMetric).com.eignex.kumulant.stat.regression.tree/rank(com.eignex.kumulant.stat.summary/WeightedVarianceResult, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin/Double, kotlin/Double): com.eignex.kumulant.stat.regression.tree/SplitInfo // com.eignex.kumulant.stat.regression.tree/rank|rank@com.eignex.kumulant.stat.regression.tree.SplitMetric(com.eignex.kumulant.stat.summary.WeightedVarianceResult;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.Double;kotlin.Double){}[0]
 final fun (com.eignex.kumulant.stat.sketch/BloomFilterResult).com.eignex.kumulant.stat.sketch/contains(kotlin/Long): kotlin/Boolean // com.eignex.kumulant.stat.sketch/contains|contains@com.eignex.kumulant.stat.sketch.BloomFilterResult(kotlin.Long){}[0]
 final fun (com.eignex.kumulant.stat.sketch/CountMinSketchResult).com.eignex.kumulant.stat.sketch/estimate(kotlin/Long): kotlin/Long // com.eignex.kumulant.stat.sketch/estimate|estimate@com.eignex.kumulant.stat.sketch.CountMinSketchResult(kotlin.Long){}[0]

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import java.util.concurrent.TimeUnit
 
 plugins {
     id("com.eignex.kmp") version "1.3.1"
@@ -131,3 +132,11 @@ tasks.withType<Test>().configureEach {
         jvmArgs("--add-modules=jdk.incubator.vector")
     }
 }
+
+// koblas is an unpinned SNAPSHOT. Gradle caches a changing module for 24 hours by default, so a
+// build that resolved yesterday's snapshot keeps compiling against it while a fresh checkout gets
+// today's; the same tree then succeeds on one machine and fails on another. Always re-resolve.
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
+}
+

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 
@@ -108,7 +108,7 @@ interface UnivariateBandit : Bandit {
  *
  * The standard contextual lifecycle:
  *
- * 1. Caller observes `x: VectorView` (e.g. a user feature vector).
+ * 1. Caller observes `x: F64VectorView` (e.g. a user feature vector).
  * 2. Caller calls [choose] with `x`; the bandit picks an arm by combining
  *    the per-arm model with the context.
  * 3. Caller plays the arm and observes a reward.
@@ -132,14 +132,14 @@ interface ContextualBandit : Bandit {
      * configurable [com.eignex.kumulant.stat.regression.RegressionPosterior]
      * (or analogue) and returns the argmax / sampled choice.
      */
-    fun choose(x: VectorView): Int
+    fun choose(x: F64VectorView): Int
 
     /**
      * Fold a single `(x, reward)` observation into the arm at [armIndex].
      * The `weight` is the same observation-weight running through the
      * library; typically `1.0`, occasionally importance-weighted.
      */
-    fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double = 1.0)
+    fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double = 1.0)
 }
 
 /**
@@ -241,5 +241,5 @@ interface Scorable {
  */
 interface ContextualScorable {
     /** Score the arm at [armIndex] under the current state and context [x]. */
-    fun evaluate(armIndex: Int, x: VectorView): Double
+    fun evaluate(armIndex: Int, x: F64VectorView): Double
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec
@@ -183,7 +183,7 @@ fun RegressionContextualSpec.materialize(
 }
 
 /** Resolve a wire-named distance metric to the function that computes it. */
-private fun KnnDistance.resolve(): (VectorView, VectorView) -> Double = when (this) {
+private fun KnnDistance.resolve(): (F64VectorView, F64VectorView) -> Double = when (this) {
     KnnDistance.SquaredL2 -> KnnContextualBandit.Companion::squaredL2
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -89,14 +89,14 @@ class TrackedContextualBandit<B : ContextualBandit>(
         @Suppress("UNCHECKED_CAST")
         (updateArmRewardTemplate?.create(null) as PairedStat<Result>?)
 
-    override fun choose(x: VectorView): Int {
+    override fun choose(x: F64VectorView): Int {
         x.requireFeatureSize(contextFeatureSize)
         val i = inner.choose(x)
         chooseStat?.update(x, i.toDouble(), nowNanos(), 1.0)
         return i
     }
 
-    override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
+    override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         x.requireFeatureSize(contextFeatureSize)
         inner.update(armIndex, x, reward, weight)
         val ts = nowNanos()
@@ -104,7 +104,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
             val joint = DoubleArray(contextFeatureSize + 1)
             joint[0] = armIndex.toDouble()
             for (j in 0 until contextFeatureSize) joint[j + 1] = x[j]
-            updateJointStat.update(DenseVector.of(joint), reward, ts, weight)
+            updateJointStat.update(F64DenseVector.of(joint), reward, ts, weight)
         }
         updateMarginalStat?.update(x, reward, ts, weight)
         updateArmRewardStat?.update(armIndex.toDouble(), reward, ts, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable
@@ -43,7 +43,7 @@ data class Exp4State(
  */
 fun interface Exp4Expert {
     /** Distribution over arms for [x]. Result must sum to 1 and have length `nbrArms`. */
-    fun advise(x: VectorView, nbrArms: Int): DoubleArray
+    fun advise(x: F64VectorView, nbrArms: Int): DoubleArray
 }
 
 /**
@@ -120,7 +120,7 @@ class Exp4Bandit(
     private var lastPlayDist: DoubleArray = DoubleArray(nbrArms) { 1.0 / nbrArms }
 
     /** Build the round's play distribution and sample an arm. */
-    override fun choose(x: VectorView): Int {
+    override fun choose(x: F64VectorView): Int {
         val p = playDistribution(x)
         lastPlayDist = p
         return random.sampleFromDistribution(p)
@@ -128,7 +128,7 @@ class Exp4Bandit(
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with
      *  uniform exploration via [gamma]. */
-    fun playDistribution(x: VectorView): DoubleArray {
+    fun playDistribution(x: F64VectorView): DoubleArray {
         var wSum = 0.0
         for (i in experts.indices) {
             val xi = experts[i].advise(x, nbrArms)
@@ -155,7 +155,7 @@ class Exp4Bandit(
     }
 
     /** Fold a `(context, reward)` observation back into the expert weights. */
-    override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
+    override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64SparseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
@@ -31,7 +31,7 @@ import kotlin.random.Random
 @Serializable
 @SerialName("KnnArmResult")
 data class KnnArmResult(
-    /** Retained contexts (each a copy of the submitted [VectorView]). */
+    /** Retained contexts (each a copy of the submitted [F64VectorView]). */
     val contexts: List<DoubleArray>,
     /** Per-sample rewards, parallel to [contexts]. */
     val rewards: DoubleArray,
@@ -121,7 +121,7 @@ class KnnContextualBandit(
     /** UCB-style exploration scale on `sqrt(ln(totalSteps) / armWeight)`; `0.0` disables. */
     val exploration: Double = 1.0,
     /** Pairwise distance between context vectors; defaults to squared L2. */
-    val distance: (VectorView, VectorView) -> Double = ::squaredL2,
+    val distance: (F64VectorView, F64VectorView) -> Double = ::squaredL2,
     /** Single source of randomness; used only for tie-breaking, currently deterministic. */
     override val random: Random = Random.Default,
 ) : ContextualBandit,
@@ -134,21 +134,21 @@ class KnnContextualBandit(
         require(exploration >= 0.0) { "exploration must be non-negative, got $exploration" }
     }
 
-    private val historyContexts: Array<MutableList<VectorView>> = Array(nbrArms) { mutableListOf() }
+    private val historyContexts: Array<MutableList<F64VectorView>> = Array(nbrArms) { mutableListOf() }
     private val historyRewards: Array<MutableList<Double>> = Array(nbrArms) { mutableListOf() }
     private val historyWeights: Array<MutableList<Double>> = Array(nbrArms) { mutableListOf() }
     private val totalWeights: DoubleArray = DoubleArray(nbrArms)
     private var step: Long = 0L
 
     /** Argmax over per-arm [evaluate] scores. Ties broken by lowest index. */
-    override fun choose(x: VectorView): Int {
+    override fun choose(x: F64VectorView): Int {
         val bestIdx = argmaxArm(nbrArms) { a -> evaluate(a, x) }
         step++
         return bestIdx
     }
 
     /** Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus. */
-    override fun evaluate(armIndex: Int, x: VectorView): Double {
+    override fun evaluate(armIndex: Int, x: F64VectorView): Double {
         requireArmIndex(armIndex, nbrArms)
         val ctx = historyContexts[armIndex]
         if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
@@ -157,7 +157,7 @@ class KnnContextualBandit(
     }
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
-    override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
+    override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
         // An inert observation must not consume a history slot; the eviction below would drop real data.
         if (weight.isInertWeight()) return
@@ -202,7 +202,7 @@ class KnnContextualBandit(
         for (a in 0 until nbrArms) {
             val arm = other[a]
             for (i in arm.contexts.indices) {
-                update(a, DenseVector.of(arm.contexts[i]), arm.rewards[i], arm.weights[i])
+                update(a, F64DenseVector.of(arm.contexts[i]), arm.rewards[i], arm.weights[i])
             }
         }
     }
@@ -230,7 +230,7 @@ class KnnContextualBandit(
         return exploration * sqrt(ln(t) / w)
     }
 
-    private fun knnMean(armIndex: Int, x: VectorView): Double {
+    private fun knnMean(armIndex: Int, x: F64VectorView): Double {
         val ctxs = historyContexts[armIndex]
         val rs = historyRewards[armIndex]
         val ws = historyWeights[armIndex]
@@ -270,17 +270,17 @@ class KnnContextualBandit(
          * stored entries and accumulates dense-only contributions via a baseline
          * pass; sparse/sparse iterates the union of stored indices on both sides.
          */
-        fun squaredL2(a: VectorView, b: VectorView): Double {
+        fun squaredL2(a: F64VectorView, b: F64VectorView): Double {
             require(a.size == b.size) { "size mismatch: ${a.size} vs ${b.size}" }
             return when {
-                a is DenseVector && b is DenseVector -> denseSquaredL2(a, b)
-                a is SparseVector && b is SparseVector -> sparseSquaredL2(a, b)
-                a is SparseVector -> mixedSquaredL2(a, b)
-                else -> mixedSquaredL2(b as SparseVector, a)
+                a is F64DenseVector && b is F64DenseVector -> denseSquaredL2(a, b)
+                a is F64SparseVector && b is F64SparseVector -> sparseSquaredL2(a, b)
+                a is F64SparseVector -> mixedSquaredL2(a, b)
+                else -> mixedSquaredL2(b as F64SparseVector, a)
             }
         }
 
-        private fun denseSquaredL2(a: DenseVector, b: DenseVector): Double {
+        private fun denseSquaredL2(a: F64DenseVector, b: F64DenseVector): Double {
             var s = 0.0
             for (i in 0 until a.size) {
                 val d = a[i] - b[i]
@@ -289,7 +289,7 @@ class KnnContextualBandit(
             return s
         }
 
-        private fun mixedSquaredL2(sparse: SparseVector, dense: VectorView): Double {
+        private fun mixedSquaredL2(sparse: F64SparseVector, dense: F64VectorView): Double {
             // Start from the dense side's full squared norm, then correct the sparse-indexed
             // entries to use (sparse_v - dense_v)^2 instead of dense_v^2.
             var s = 0.0
@@ -305,7 +305,7 @@ class KnnContextualBandit(
             return s
         }
 
-        private fun sparseSquaredL2(a: SparseVector, b: SparseVector): Double {
+        private fun sparseSquaredL2(a: F64SparseVector, b: F64SparseVector): Double {
             var s = 0.0
             a.forEachStored { i, v ->
                 val d = v - b[i]
@@ -319,10 +319,10 @@ class KnnContextualBandit(
         }
     }
 
-    private fun copyOf(x: VectorView): VectorView = when (x) {
-        is DenseVector -> DenseVector.of(x.toDoubleArray())
+    private fun copyOf(x: F64VectorView): F64VectorView = when (x) {
+        is F64DenseVector -> F64DenseVector.of(x.toDoubleArray())
 
-        is SparseVector -> {
+        is F64SparseVector -> {
             val keepIdx = IntArray(x.size)
             val keepVal = DoubleArray(x.size)
             var n = 0
@@ -331,7 +331,7 @@ class KnnContextualBandit(
                 keepVal[n] = v
                 n++
             }
-            SparseVector.of(x.size, keepIdx.copyOf(n), keepVal.copyOf(n))
+            F64SparseVector.of(x.size, keepIdx.copyOf(n), keepVal.copyOf(n))
         }
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
@@ -100,20 +100,20 @@ class RegressionContextualBandit<R : Result>(
     private val arms: Array<RegressionStat<R>> = Array(nbrArms) { template.create(null) }
     private val global: RegressionStat<R>? = globalTemplate?.create(null)
 
-    private fun globalMean(x: VectorView): Double =
+    private fun globalMean(x: F64VectorView): Double =
         global?.let { posterior.evaluate(it.read(0L), x, random, 0.0) } ?: 0.0
 
-    override fun choose(x: VectorView): Int {
+    override fun choose(x: F64VectorView): Int {
         val gMean = globalMean(x)
         return argmaxArm(nbrArms) { i -> gMean + posterior.evaluate(arms[i].read(0L), x, random, exploration) }
     }
 
-    override fun evaluate(armIndex: Int, x: VectorView): Double {
+    override fun evaluate(armIndex: Int, x: F64VectorView): Double {
         requireArmIndex(armIndex, nbrArms)
         return globalMean(x) + posterior.evaluate(arms[armIndex].read(0L), x, random, exploration)
     }
 
-    override fun update(armIndex: Int, x: VectorView, reward: Double, weight: Double) {
+    override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
         val g = global
         if (g == null) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlin.time.Duration
@@ -216,7 +216,7 @@ interface HasShapeMoments : HasSampleVariance {
  */
 interface HasLinearModel : Result {
     /** Fitted weight per feature, indexed by the same `i` as the input `x[i]`. */
-    val weights: VectorView
+    val weights: F64VectorView
 
     /** Fitted bias / intercept term. */
     val bias: Double
@@ -229,7 +229,7 @@ interface HasLinearModel : Result {
      * For Gaussian regression this is the prediction; for non-identity GLMs
      * this is the linear predictor pre-link.
      */
-    fun predict(x: VectorView): Double {
+    fun predict(x: F64VectorView): Double {
         x.requireFeatureSize(weights.size)
         var sum = bias
         for (i in 0 until weights.size) sum += x[i] * weights[i]
@@ -252,7 +252,7 @@ interface HasSlope : HasLinearModel {
     /** Fitted intercept `c`. */
     val intercept: Double
 
-    override val weights: VectorView get() = DenseVector.of(doubleArrayOf(slope))
+    override val weights: F64VectorView get() = F64DenseVector.of(doubleArrayOf(slope))
     override val bias: Double get() = intercept
     override val featureSize: Int get() = 1
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.stream.currentTimeNanos
 
 /**
@@ -284,10 +284,10 @@ interface PairedStat<R : Result> : Stat<R> {
  * ([DecisionTreeRegressionStat][com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat]).
  * They share the update shape and differ in what they expose on [read].
  *
- * Inputs are passed as [VectorView] so callers can submit sparse feature
+ * Inputs are passed as [F64VectorView] so callers can submit sparse feature
  * vectors without materialising them into dense arrays first. The
- * [DoubleArray] convenience overloads wrap the array in a [DenseVector]; the
- * sparse path goes through [com.eignex.koblas.SparseVector].
+ * [DoubleArray] convenience overloads wrap the array in a [F64DenseVector]; the
+ * sparse path goes through [com.eignex.koblas.F64SparseVector].
  *
  * The K-way classifiers
  * ([SoftmaxRegressionStat][com.eignex.kumulant.stat.regression.SoftmaxRegressionStat],
@@ -299,18 +299,18 @@ interface RegressionStat<R : Result> : Stat<R> {
     val featureSize: Int
 
     /** Record an `(x, y)` observation with the given [weight] at the current time. */
-    fun update(x: VectorView, y: Double, weight: Double = 1.0) = update(x, y, currentTimeNanos(), weight)
+    fun update(x: F64VectorView, y: Double, weight: Double = 1.0) = update(x, y, currentTimeNanos(), weight)
 
     /** Record an `(x, y)` observation at [timestampNanos] with the given [weight]. */
-    fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double = 1.0)
+    fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double = 1.0)
 
-    /** Convenience overload that wraps `x` as a [DenseVector]. */
+    /** Convenience overload that wraps `x` as a [F64DenseVector]. */
     fun update(x: DoubleArray, y: Double, weight: Double = 1.0) =
-        update(DenseVector.of(x), y, currentTimeNanos(), weight)
+        update(F64DenseVector.of(x), y, currentTimeNanos(), weight)
 
-    /** Timestamped convenience overload that wraps `x` as a [DenseVector]. */
+    /** Timestamped convenience overload that wraps `x` as a [F64DenseVector]. */
     fun update(x: DoubleArray, y: Double, timestampNanos: Long, weight: Double = 1.0) =
-        update(DenseVector.of(x), y, timestampNanos, weight)
+        update(F64DenseVector.of(x), y, timestampNanos, weight)
 
     override fun create(concurrency: Concurrency?): RegressionStat<R>
 }
@@ -323,23 +323,27 @@ interface RegressionStat<R : Result> : Stat<R> {
  * detector
  * ([HalfSpaceTreesStat][com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat]).
  *
- * Like [RegressionStat], inputs are passed as [VectorView] so sparse callers
+ * Like [RegressionStat], inputs are passed as [F64VectorView] so sparse callers
  * don't pay for dense materialisation. The [DoubleArray] convenience
- * overloads wrap the array in a [DenseVector].
+ * overloads wrap the array in a [F64DenseVector].
  */
 interface VectorStat<R : Result> : Stat<R> {
     /** Record a [vector] observation with the given [weight] at the current time. */
-    fun update(vector: VectorView, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
+    fun update(vector: F64VectorView, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
 
     /** Record a [vector] observation at [timestampNanos] with the given [weight]. */
-    fun update(vector: VectorView, timestampNanos: Long, weight: Double = 1.0)
+    fun update(vector: F64VectorView, timestampNanos: Long, weight: Double = 1.0)
 
-    /** Convenience overload that wraps [vector] as a [DenseVector]. */
-    fun update(vector: DoubleArray, weight: Double = 1.0) = update(DenseVector.of(vector), currentTimeNanos(), weight)
+    /** Convenience overload that wraps [vector] as a [F64DenseVector]. */
+    fun update(vector: DoubleArray, weight: Double = 1.0) = update(
+        F64DenseVector.of(vector),
+        currentTimeNanos(),
+        weight,
+    )
 
-    /** Timestamped convenience overload that wraps [vector] as a [DenseVector]. */
+    /** Timestamped convenience overload that wraps [vector] as a [F64DenseVector]. */
     fun update(vector: DoubleArray, timestampNanos: Long, weight: Double = 1.0) =
-        update(DenseVector.of(vector), timestampNanos, weight)
+        update(F64DenseVector.of(vector), timestampNanos, weight)
 
     override fun create(concurrency: Concurrency?): VectorStat<R>
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 
 /**
  * Reject a context vector whose arity does not match the model's.
@@ -13,10 +13,10 @@ import com.eignex.koblas.VectorView
  * spells its own check out instead, because its receiver is named `vector` and its message says so.
  *
  * @param expected the model's feature count.
- * @throws IllegalArgumentException if [VectorView.size] differs from [expected].
+ * @throws IllegalArgumentException if [F64VectorView.size] differs from [expected].
  */
 @Suppress("NOTHING_TO_INLINE") // as with the weight predicates; the non-JVM targets pay for the call
-internal inline fun VectorView.requireFeatureSize(expected: Int) {
+internal inline fun F64VectorView.requireFeatureSize(expected: Int) {
     require(size == expected) { "x.size=$size, expected $expected" }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -3,9 +3,9 @@
 
 package com.eignex.kumulant.math
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.norm2
@@ -26,7 +26,7 @@ import kotlin.math.sqrt
  * rotations to the rows of L to absorb `s` without breaking triangularity. The rotation loop is
  * carried in `xx` and stays scalar; the substitution goes through the backend's `trsv`.
  */
-internal fun DenseMatrix.choleskyDowndateInPlace(x: VectorView): Double {
+internal fun F64DenseMatrix.choleskyDowndateInPlace(x: F64VectorView): Double {
     require(rows == cols) { "choleskyDowndateInPlace requires a square matrix; got ${rows}x$cols" }
     require(rows == x.size) { "x size ${x.size} must match matrix dim $rows" }
     if (rows == 0) return 0.0 // an empty downdate stays in the cone trivially
@@ -39,7 +39,7 @@ internal fun DenseMatrix.choleskyDowndateInPlace(x: VectorView): Double {
     x.forEachStored { i, v -> s[i] = v }
     trsv(this, s, lower = true)
 
-    val norm = norm2(DenseVector.wrap(s))
+    val norm = norm2(F64DenseVector.wrap(s))
     // Negated so a NaN norm bails too: falling through would write NaN across the whole factor
     // and still report success.
     if (!(norm > 0.0 && norm < 1.0)) return norm
@@ -76,7 +76,7 @@ internal fun DenseMatrix.choleskyDowndateInPlace(x: VectorView): Double {
  * that gets stored in a snapshot is cleaned first: the snapshots are compared and serialised, and
  * two mathematically equal posteriors have to agree entry for entry.
  */
-internal fun DenseMatrix.zeroUpperTriangle(): DenseMatrix {
+internal fun F64DenseMatrix.zeroUpperTriangle(): F64DenseMatrix {
     for (j in 1 until cols) {
         for (i in 0 until minOf(j, rows)) this[i, j] = 0.0
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.core.PairedStat
@@ -79,7 +79,7 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
 ) : VectorStat<I>,
     Stat<I> by inner {
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         primary.update(vector, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(vector.size) { i ->
@@ -117,7 +117,7 @@ internal class FeedbackRegressionStat<P : Result, R : Result>(
 
     override val featureSize: Int get() = inner.featureSize
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         primary.update(x, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(x.size) { i ->

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -45,7 +45,7 @@ internal class FilterVectorStat<R : Result>(
     private val predicate: (DoubleArray) -> Boolean,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         if (predicate(vector.toDoubleArray())) delegate.update(vector, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -19,7 +19,7 @@ internal class FoldVectorStat<R : Result>(
     private val transform: (DoubleArray) -> Double,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
@@ -44,7 +44,7 @@ internal class FoldVectorPairedStat<R : Result>(
     private val foldY: (DoubleArray) -> Double,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         val arr = vector.toDoubleArray()
         delegate.update(foldX(arr), foldY(arr), timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -89,7 +89,7 @@ internal class MapResultVectorStat<R1 : Result, R2 : Result>(
     private val reverse: (R2) -> R1,
 ) : VectorStat<R2>,
     Stat<R2> by MappedResultCore(delegate, forward, reverse) {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) =
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) =
         delegate.update(vector, timestampNanos, weight)
     override fun create(concurrency: Concurrency?): VectorStat<R2> =
         MapResultVectorStat(delegate.create(concurrency), forward, reverse)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -18,16 +18,17 @@ import com.eignex.kumulant.core.requirePositiveFeatureSize
 // `com.eignex.kumulant.schema.Operations.kt` materialise to these wrappers.
 
 /** Forward only updates that pass [predicate]; the predicate sees `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.filter(predicate: (VectorView, Double) -> Boolean): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.filter(predicate: (F64VectorView, Double) -> Boolean): RegressionStat<R> =
     FilterRegressionStat(this, predicate)
 
 /** Rewrite y before update via [transform]; x and weight pass through unchanged. */
-internal fun <R : Result> RegressionStat<R>.transformY(transform: (VectorView, Double) -> Double): RegressionStat<R> =
-    TransformYRegressionStat(this, transform)
+internal fun <R : Result> RegressionStat<R>.transformY(
+    transform: (F64VectorView, Double) -> Double,
+): RegressionStat<R> = TransformYRegressionStat(this, transform)
 
 /** Rewrite x before update via [transform]; y and weight pass through unchanged. */
 internal fun <R : Result> RegressionStat<R>.transformX(
-    transform: (VectorView, Double) -> DoubleArray,
+    transform: (F64VectorView, Double) -> DoubleArray,
 ): RegressionStat<R> = TransformXRegressionStat(this, transform)
 
 /**
@@ -40,7 +41,7 @@ internal fun <R : Result> RegressionStat<R>.withWeight(weight: Double): Regressi
     WithWeightRegressionStat(this, weight)
 
 /** Multiply each update's caller-supplied weight by [weighter] over `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (VectorView, Double) -> Double): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (F64VectorView, Double) -> Double): RegressionStat<R> =
     WeightByRegressionStat(this, weighter)
 
 /** Forward only every [every]th update; drop the rest. */
@@ -64,16 +65,16 @@ internal fun <R : Result> RegressionStat<R>.sample(rate: Double, seed: Long): Re
  */
 internal fun <R : Result> SeriesStat<R>.foldRegression(
     featureSize: Int,
-    project: (VectorView, Double) -> Double,
+    project: (F64VectorView, Double) -> Double,
 ): RegressionStat<R> = FoldRegressionStat(this, featureSize, project)
 
 internal class FilterRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val predicate: (VectorView, Double) -> Boolean,
+    private val predicate: (F64VectorView, Double) -> Boolean,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         if (predicate(x, y)) delegate.update(x, y, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
@@ -82,11 +83,11 @@ internal class FilterRegressionStat<R : Result>(
 
 internal class TransformYRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val transform: (VectorView, Double) -> Double,
+    private val transform: (F64VectorView, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         delegate.update(x, transform(x, y), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
@@ -95,12 +96,12 @@ internal class TransformYRegressionStat<R : Result>(
 
 internal class TransformXRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val transform: (VectorView, Double) -> DoubleArray,
+    private val transform: (F64VectorView, Double) -> DoubleArray,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
-        delegate.update(DenseVector.of(transform(x, y)), y, timestampNanos, weight)
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
+        delegate.update(F64DenseVector.of(transform(x, y)), y, timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
         TransformXRegressionStat(delegate.create(concurrency), transform)
@@ -112,7 +113,7 @@ internal class WithWeightRegressionStat<R : Result>(
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         // `orInert` covers NaN as well as zero, so an inert caller weight stays a no-op rather than
         // being replaced by the constant and becoming a real observation.
         delegate.update(x, y, timestampNanos, weight.orInert(this.weight))
@@ -123,11 +124,11 @@ internal class WithWeightRegressionStat<R : Result>(
 
 internal class WeightByRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val weighter: (VectorView, Double) -> Double,
+    private val weighter: (F64VectorView, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         delegate.update(x, y, timestampNanos, weight * weighter(x, y))
     }
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
@@ -139,7 +140,7 @@ internal class ThrottleRegressionStat<R : Result>(private val delegate: Regressi
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     private val gate = ThrottleGate(every, delegate.concurrency)
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
@@ -160,7 +161,7 @@ internal class SampleRegressionStat<R : Result>(
     Stat<R> by delegate {
     private val gate = SampleGate(rate, seed, delegate.concurrency)
     override val featureSize: Int = delegate.featureSize
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(x, y, timestampNanos, weight)
     }
@@ -177,13 +178,13 @@ internal class SampleRegressionStat<R : Result>(
 internal class FoldRegressionStat<R : Result>(
     private val delegate: SeriesStat<R>,
     override val featureSize: Int,
-    private val project: (VectorView, Double) -> Double,
+    private val project: (F64VectorView, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     init {
         requirePositiveFeatureSize(featureSize)
     }
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         delegate.update(project(x, y), timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -104,7 +104,7 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
     VectorStat<R>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
@@ -183,7 +183,7 @@ internal class SampleVectorStat<R : Result>(
 ) : VectorStat<R>,
     Stat<R> by delegate {
     private val gate = SampleGate(rate, seed, delegate.concurrency)
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -31,7 +31,7 @@ internal class AtYStat<R : Result>(private val delegate: SeriesStat<R>) :
 internal class AtIndexStat<R : Result>(private val delegate: SeriesStat<R>, private val index: Int) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(vector[index], timestampNanos, weight)
     }
 
@@ -44,7 +44,7 @@ internal class AtIndicesStat<R : Result>(
     private val indexY: Int,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(vector[indexX], vector[indexY], timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -52,7 +52,7 @@ internal class TransformVectorStat<R : Result>(
     private val transform: (DoubleArray) -> DoubleArray,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
@@ -17,7 +17,7 @@ import com.eignex.kumulant.core.requireFeatureSize
  * entries; incoming vectors must match [dimensions] exactly.
  *
  * When [skipZeros] is `true`, only the stored entries of the input vector are
- * forwarded to their per-dimension stats. For a [com.eignex.koblas.SparseVector]
+ * forwarded to their per-dimension stats. For a [com.eignex.koblas.F64SparseVector]
  * this turns the per-update cost from `O(dimensions)` into `O(nnz)`, and an
  * unobserved index is treated as "no update" rather than "update with 0.0".
  * Keep the default (`false`) for stats whose semantics distinguish zero from
@@ -35,7 +35,7 @@ internal class VectorizedStat<R : Result>(
 
     override val concurrency: Concurrency get() = template.concurrency
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         vector.requireFeatureSize(dimensions)
         if (skipZeros) {
             vector.forEachStored { i, v -> stats[i].update(v, timestampNanos, weight) }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -64,7 +64,7 @@ internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat
 internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat<R>, private val weight: Double) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(vector, timestampNanos, weight.orInert(this.weight))
     }
 
@@ -134,7 +134,7 @@ internal class WeightByVectorStat<R : Result>(
     private val weighter: (DoubleArray) -> Double,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         delegate.update(vector, timestampNanos, weight * weighter(vector.toDoubleArray()))
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -144,7 +144,7 @@ internal class WindowedVectorStat<R : Result>(
     private val template = template.create(concurrency = this.concurrency)
     private val ring = SliceRing<R, VectorStat<R>>(windowDuration, slices, concurrency) { c -> this.template.create(c) }
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         ring.slotFor(timestampNanos)?.update(vector, timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -159,7 +159,7 @@ internal class VectorListStats<R : Result>(
             concurrency = concurrency,
         )
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         for ((_, stat) in entries) stat.update(vector, timestampNanos, weight)
     }
 
@@ -244,7 +244,7 @@ internal class RegressionListStats<R : Result>(
         }
     }
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         for ((_, stat) in entries) stat.update(x, y, timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -132,7 +132,7 @@ class VectorStatGroup(stats: List<BoundStat<*, out VectorStat<*>, *>>, concurren
     constructor(schema: StatSchema, concurrency: Concurrency? = null) :
         this(stats = vectorSpecs(schema), concurrency = concurrency)
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         for ((_, stat) in stats) stat.update(vector, timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
@@ -86,7 +86,7 @@ data class HalfSpaceTreesResult(
      * means [x] falls into densely populated regions of the reference window;
      * i.e. it looks normal. Lower score flags an anomaly.
      */
-    fun score(x: VectorView): Double {
+    fun score(x: F64VectorView): Double {
         x.requireFeatureSize(featureSize)
         var total = 0.0
         val depthFactor = 1 shl height
@@ -204,7 +204,7 @@ class HalfSpaceTreesStat(
     private val windowCounter: StreamLong = counterMode.newLong(0L)
     private val totalWeightsCell = massMode.newDouble(0.0)
 
-    override fun update(vector: VectorView, timestampNanos: Long, weight: Double) {
+    override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }
         if (weight.isNotPositiveWeight()) return
         for (t in 0 until numTrees) {
@@ -304,7 +304,7 @@ private fun routeToLeaf(
     height: Int,
     numInternal: Int,
     treeIdx: Int,
-    x: VectorView,
+    x: F64VectorView,
 ): Int {
     val treeOffset = treeIdx * numInternal
     var node = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.calibration
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
@@ -70,7 +70,7 @@ class PlattCalibratorStat(
     )
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        inner.update(DenseVector.of(doubleArrayOf(x)), y, timestampNanos, weight)
+        inner.update(F64DenseVector.of(doubleArrayOf(x)), y, timestampNanos, weight)
     }
 
     override fun read(timestampNanos: Long): PlattCalibratorResult {
@@ -89,7 +89,7 @@ class PlattCalibratorStat(
      */
     override fun merge(values: PlattCalibratorResult) {
         val snapshot = StochasticRegressionResult(
-            weights = DenseVector.of(doubleArrayOf(values.slope)),
+            weights = F64DenseVector.of(doubleArrayOf(values.slope)),
             bias = values.intercept,
             totalWeights = values.totalWeights,
             step = 0L,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
@@ -42,11 +42,11 @@ data class GaussianNaiveBayesResult(
     /** Number of classes. */
     val numClasses: Int,
     /** K-by-p matrix of per-class running means; `means[c][i]` is the mean of feature `i` given class `c`. */
-    val means: DenseMatrix,
+    val means: F64DenseMatrix,
     /** K-by-p matrix of per-class running variances (population, weight-normalised). */
-    val variances: DenseMatrix,
+    val variances: F64DenseMatrix,
     /** Cumulative observation weight per class; length [numClasses]. */
-    val classWeights: DenseVector,
+    val classWeights: F64DenseVector,
     /** Total cumulative observation weight across all classes. */
     override val totalWeights: Double,
     /** Lower bound applied to per-class variances at predict time. */
@@ -70,7 +70,7 @@ data class GaussianNaiveBayesResult(
     fun prior(c: Int): Double = if (totalWeights > 0.0) classWeights[c] / totalWeights else 1.0 / numClasses
 
     /** Unnormalised log-posterior `log prior[c] + Sum_i log N(x_i | mu_c, var_c)`. */
-    fun logPosterior(x: VectorView, c: Int): Double {
+    fun logPosterior(x: F64VectorView, c: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = ln(prior(c).coerceAtLeast(SMALL_PROB))
         for (i in 0 until featureSize) {
@@ -83,14 +83,14 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Normalised class probabilities via log-sum-exp on the log-posterior. */
-    fun probabilities(x: VectorView): DoubleArray {
+    fun probabilities(x: F64VectorView): DoubleArray {
         val logs = DoubleArray(numClasses) { logPosterior(x, it) }
         logs.softmaxInPlace()
         return logs
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: VectorView): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
+    fun predict(x: F64VectorView): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
 
     private companion object {
         const val SMALL_PROB: Double = 1e-300
@@ -141,7 +141,7 @@ class GaussianNaiveBayesStat(
     private val classWeightCell: StreamDoubleArray = mode.newDoubleArray(numClasses)
     private val totalWeightCell: StreamDouble = mode.newDouble(0.0)
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
@@ -174,13 +174,13 @@ class GaussianNaiveBayesStat(
         GaussianNaiveBayesResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            means = DenseMatrix.of(
+            means = F64DenseMatrix.of(
                 Array(numClasses) { k -> meansFlat.copyOfRange(k * featureSize, (k + 1) * featureSize) },
             ),
-            variances = DenseMatrix.of(
+            variances = F64DenseMatrix.of(
                 Array(numClasses) { k -> varsFlat.copyOfRange(k * featureSize, (k + 1) * featureSize) },
             ),
-            classWeights = DenseVector.of(cw),
+            classWeights = F64DenseVector.of(cw),
             totalWeights = totalWeightCell.load(),
             varianceFloor = varianceFloor,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 
@@ -23,5 +23,5 @@ interface RegressionPosterior<R : Result> {
      * the posterior-variance scale (Thompson) or the UCB width (LinUcb-style);
      * `0.0` collapses to the point estimate.
      */
-    fun evaluate(snapshot: R, x: VectorView, rng: Random, exploration: Double = 1.0): Double
+    fun evaluate(snapshot: R, x: F64VectorView, rng: Random, exploration: Double = 1.0): Double
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
@@ -41,9 +41,9 @@ data class SoftmaxRegressionResult(
     /** Number of classes (rows of [weights] and length of [biases]). */
     val numClasses: Int,
     /** K-by-p weight matrix; `weights[k][i]` is the coefficient on feature `i` for class `k`. */
-    val weights: DenseMatrix,
+    val weights: F64DenseMatrix,
     /** Per-class intercept; length [numClasses]. */
-    val biases: DenseVector,
+    val biases: F64DenseVector,
     /** Cumulative observation weight folded in. */
     override val totalWeights: Double,
     /** Number of `update` calls absorbed. */
@@ -59,7 +59,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Linear predictor for class [k]: `biases[k] + weights[k] . x`. */
-    fun logit(x: VectorView, k: Int): Double {
+    fun logit(x: F64VectorView, k: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = biases[k]
         for (i in 0 until featureSize) s += weights[k, i] * x[i]
@@ -67,14 +67,14 @@ data class SoftmaxRegressionResult(
     }
 
     /** Softmax probabilities across all classes for [x]; length [numClasses]. */
-    fun probabilities(x: VectorView): DoubleArray {
+    fun probabilities(x: F64VectorView): DoubleArray {
         val etas = DoubleArray(numClasses) { logit(x, it) }
         etas.softmaxInPlace()
         return etas
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: VectorView): Int = argMaxOf(numClasses) { k -> logit(x, k) }
+    fun predict(x: F64VectorView): Int = argMaxOf(numClasses) { k -> logit(x, k) }
 }
 
 /**
@@ -143,7 +143,7 @@ class SoftmaxRegressionStat(
     /** Live view of the accumulated weighted cross-entropy. */
     val crossEntropy: Double by crossEntropyCell
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
@@ -188,8 +188,10 @@ class SoftmaxRegressionStat(
         SoftmaxRegressionResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            weights = DenseMatrix.of(Array(numClasses) { k -> w.copyOfRange(k * featureSize, (k + 1) * featureSize) }),
-            biases = DenseVector.of(b),
+            weights = F64DenseMatrix.of(
+                Array(numClasses) { k -> w.copyOfRange(k * featureSize, (k + 1) * featureSize) },
+            ),
+            biases = F64DenseVector.of(b),
             totalWeights = totalWeightsCell.load(),
             step = stepCell.load(),
             crossEntropy = crossEntropyCell.load(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -3,10 +3,10 @@
 
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.MatrixView
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64MatrixView
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.axpy
 import com.eignex.koblas.dense.CholeskyDecomposition
 import com.eignex.koblas.dense.CholeskyPolicy
@@ -85,8 +85,8 @@ class BayesianRegressionStat(
     /** Canonical GLM link function; [Link.Identity] is the strict closed-form Gaussian posterior. */
     val link: Link = Link.Identity,
     override val concurrency: Concurrency = Concurrency.None,
-    priorMean: VectorView? = null,
-    priorCovariance: MatrixView? = null,
+    priorMean: F64VectorView? = null,
+    priorCovariance: F64MatrixView? = null,
 ) : RegressionStat<CovarianceRegressionResult> {
 
     init {
@@ -106,13 +106,13 @@ class BayesianRegressionStat(
     // `initialCovarianceL` is validated up front via strict (non-regularising) Cholesky
     // so a non-PD user prior throws at construction rather than silently corrupting fits.
     private val initialWeights: DoubleArray = priorMean?.toDoubleArray() ?: DoubleArray(featureSize)
-    private val initialCovariance: DenseMatrix = priorCovariance
-        ?.let { DenseMatrix.of(it.toArray()) }
-        ?: DenseMatrix.diagonal(featureSize, priorVariance)
-    private val initialCovarianceL: DenseMatrix
+    private val initialCovariance: F64DenseMatrix = priorCovariance
+        ?.let { F64DenseMatrix.of(it.toArray()) }
+        ?: F64DenseMatrix.diagonal(featureSize, priorVariance)
+    private val initialCovarianceL: F64DenseMatrix
 
     // Prior precision H_prior = Sigma_prior^-1, cached so merge() can subtract one prior factor.
-    private val priorPrecisionMatrix: DenseMatrix
+    private val priorPrecisionMatrix: F64DenseMatrix
 
     init {
         val chol = initialCovariance.cholesky(CholeskyPolicy.Strict)
@@ -130,16 +130,16 @@ class BayesianRegressionStat(
     }
 
     private val lock = concurrency.serializedLock()
-    private val weights = DenseVector.of(initialWeights.copyOf())
-    private val covariance = DenseMatrix.of(initialCovariance.toArray())
-    private val covarianceL = DenseMatrix.of(initialCovarianceL.toArray())
+    private val weights = F64DenseVector.of(initialWeights.copyOf())
+    private val covariance = F64DenseMatrix.of(initialCovariance.toArray())
+    private val covarianceL = F64DenseMatrix.of(initialCovarianceL.toArray())
     private var bias: Double = 0.0
     private var biasPrecision: Double = 1.0 / priorVariance
     private var totalWeights: Double = 0.0
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
@@ -200,13 +200,13 @@ class BayesianRegressionStat(
 
     override fun read(timestampNanos: Long): CovarianceRegressionResult = lock.guarded {
         CovarianceRegressionResult(
-            weights = DenseVector.of(weights.toDoubleArray()),
+            weights = F64DenseVector.of(weights.toDoubleArray()),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            covariance = DenseMatrix.of(covariance.toArray()),
-            covarianceL = DenseMatrix.of(covarianceL.toArray()),
+            covariance = F64DenseMatrix.of(covariance.toArray()),
+            covarianceL = F64DenseMatrix.of(covarianceL.toArray()),
             link = link,
             sse = sse,
         )
@@ -240,7 +240,7 @@ class BayesianRegressionStat(
             val hOther = CholeskyDecomposition(values.covarianceL).invert()
 
             // H_new = H_self + H_other - H_prior.
-            val hNew = DenseMatrix.zero(n, n)
+            val hNew = F64DenseMatrix.zero(n, n)
             for (i in 0 until n) {
                 for (j in 0 until n) {
                     hNew[i, j] = hSelf[i, j] + hOther[i, j] - priorPrecisionMatrix[i, j]
@@ -304,8 +304,8 @@ class BayesianRegressionStat(
         priorVariance = priorVariance,
         link = link,
         concurrency = concurrency ?: this.concurrency,
-        priorMean = DenseVector.of(initialWeights.copyOf()),
-        priorCovariance = DenseMatrix.of(initialCovariance.toArray()),
+        priorMean = F64DenseVector.of(initialWeights.copyOf()),
+        priorCovariance = F64DenseMatrix.of(initialCovariance.toArray()),
     )
 
     /** Empirical-Bayes / hierarchical helpers that operate on populations of fitted snapshots. */
@@ -350,7 +350,7 @@ class BayesianRegressionStat(
             for (i in 0 until n) muPop[i] /= wTotal
 
             // Sigma_pop = weighted mean of Sigma_i + weighted covariance of (mu_i - mu_pop).
-            val sigmaPop = DenseMatrix.zero(n, n)
+            val sigmaPop = F64DenseMatrix.zero(n, n)
             for (s in snapshots.indices) {
                 val wi = weights[s] / wTotal
                 val cov = snapshots[s].covariance
@@ -364,7 +364,7 @@ class BayesianRegressionStat(
             }
 
             return PopulationPrior(
-                mean = DenseVector.of(muPop),
+                mean = F64DenseVector.of(muPop),
                 covariance = sigmaPop,
                 instanceCount = snapshots.size,
             )
@@ -380,9 +380,9 @@ class BayesianRegressionStat(
 @Serializable
 data class PopulationPrior(
     /** Population mean of the per-instance posterior means. */
-    val mean: DenseVector,
+    val mean: F64DenseVector,
     /** Population covariance: within-instance posterior + between-instance mean spread. */
-    val covariance: DenseMatrix,
+    val covariance: F64DenseMatrix,
     /** Number of per-instance posteriors that contributed to this prior. */
     val instanceCount: Int,
 )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
@@ -85,14 +85,14 @@ class DiagonalRegressionStat(
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
             step++
             val eta = learningRate.eval(step.toDouble())
 
-            val etaPred = bias + (x dot DenseVector.wrap(weights))
+            val etaPred = bias + (x dot F64DenseVector.wrap(weights))
             val mu = link.invMean(etaPred)
             val negResidual = mu - y
             val curvature = link.curvature(etaPred)
@@ -126,12 +126,12 @@ class DiagonalRegressionStat(
 
     override fun read(timestampNanos: Long): DiagonalRegressionResult = lock.guarded {
         DiagonalRegressionResult(
-            weights = DenseVector.of(weights),
+            weights = F64DenseVector.of(weights),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            precision = DenseVector.of(precision),
+            precision = F64DenseVector.of(precision),
             link = link,
             sse = sse,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.requirePositiveFeatureSize
 
@@ -37,8 +37,8 @@ class HierarchicalBayesianRegression(
     /** Concurrency level forwarded to each instance. */
     val concurrency: Concurrency = Concurrency.None,
     initialPriorVariance: Double = 1.0,
-    initialPriorMean: DenseVector? = null,
-    initialPriorCovariance: DenseMatrix? = null,
+    initialPriorMean: F64DenseVector? = null,
+    initialPriorCovariance: F64DenseMatrix? = null,
 ) {
     init {
         requirePositiveFeatureSize(featureSize)
@@ -52,8 +52,8 @@ class HierarchicalBayesianRegression(
      * call [refit] to update it from the current per-instance posteriors.
      */
     var populationPrior: PopulationPrior = PopulationPrior(
-        mean = initialPriorMean ?: DenseVector.zero(featureSize),
-        covariance = initialPriorCovariance ?: DenseMatrix.diagonal(featureSize, initialPriorVariance),
+        mean = initialPriorMean ?: F64DenseVector.zero(featureSize),
+        covariance = initialPriorCovariance ?: F64DenseMatrix.diagonal(featureSize, initialPriorVariance),
         instanceCount = 0,
     )
         private set

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.dot
 import com.eignex.koblas.matVec
 import com.eignex.kumulant.math.nextNormal
@@ -30,7 +30,7 @@ import kotlin.random.Random
 sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosterior<R> {
     /** Draw a weight vector from the posterior at `exploration` variance scale.
      *  `exploration = 0.0` collapses to the point estimate; `1.0` is the calibrated posterior. */
-    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): VectorView
+    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): F64VectorView
 
     /**
      * Score a query point [x] under a fresh posterior draw. Parallels
@@ -45,7 +45,7 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
      * space, so the noise is added before the inverse link, never after: a score has to
      * come back on the same scale as the reward being maximised.
      */
-    override fun evaluate(snapshot: R, x: VectorView, rng: Random, exploration: Double): Double =
+    override fun evaluate(snapshot: R, x: F64VectorView, rng: Random, exploration: Double): Double =
         snapshot.link.invMean(snapshot.bias + (x dot sample(snapshot, rng, exploration)))
 }
 
@@ -57,20 +57,20 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
 @Serializable
 @SerialName("PointPosterior")
 data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
-    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): VectorView {
+    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): F64VectorView {
         if (exploration <= 0.0) return snapshot.weights
         val n = snapshot.weights.size
         val sd = sqrt(exploration)
         val out = DoubleArray(n)
         for (i in 0 until n) out[i] = rng.nextNormal(snapshot.weights[i], sd)
-        return DenseVector.of(out)
+        return F64DenseVector.of(out)
     }
 
     /** Closes to `invMean(eta(x) + sd * ||x|| * N(0,1))` since the per-coord noise terms
      *  are iid; one Gaussian draw instead of one per coordinate. */
     override fun evaluate(
         snapshot: StochasticRegressionResult,
-        x: VectorView,
+        x: F64VectorView,
         rng: Random,
         exploration: Double,
     ): Double {
@@ -88,18 +88,23 @@ data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
 @Serializable
 @SerialName("FactorisedGaussian")
 data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
-    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): VectorView {
+    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): F64VectorView {
         val n = snapshot.weights.size
         val out = DoubleArray(n)
         for (i in 0 until n) {
             val sd = sqrt(exploration / snapshot.precision[i])
             out[i] = rng.nextNormal(snapshot.weights[i], sd)
         }
-        return DenseVector.of(out)
+        return F64DenseVector.of(out)
     }
 
     /** Sum of independent normals: `invMean(eta(x) + sqrt(exploration * Sum x_i^2 / precision[i]) * N(0,1))`. */
-    override fun evaluate(snapshot: DiagonalRegressionResult, x: VectorView, rng: Random, exploration: Double): Double {
+    override fun evaluate(
+        snapshot: DiagonalRegressionResult,
+        x: F64VectorView,
+        rng: Random,
+        exploration: Double,
+    ): Double {
         val eta = snapshot.linearPredictor(x)
         var variance = 0.0
         for (i in 0 until x.size) {
@@ -121,7 +126,7 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
 @Serializable
 @SerialName("MultivariateGaussian")
 data object MultivariateGaussian : LinearPosterior<CovarianceRegressionResult> {
-    override fun sample(snapshot: CovarianceRegressionResult, rng: Random, exploration: Double): VectorView {
+    override fun sample(snapshot: CovarianceRegressionResult, rng: Random, exploration: Double): F64VectorView {
         val n = snapshot.weights.size
         val sd = sqrt(exploration)
         val u = DoubleArray(n) { rng.nextNormal(0.0, sd) }
@@ -131,14 +136,14 @@ data object MultivariateGaussian : LinearPosterior<CovarianceRegressionResult> {
             for (j in 0..i) s += snapshot.covarianceL[i, j] * u[j]
             out[i] = s
         }
-        return DenseVector.of(out)
+        return F64DenseVector.of(out)
     }
 
     /** Closes to `invMean(eta(x) + sqrt(exploration * xT * Sigma * x) * N(0,1))`; one
      *  `matVec` and one `dot` instead of sampling the full weight vector. */
     override fun evaluate(
         snapshot: CovarianceRegressionResult,
-        x: VectorView,
+        x: F64VectorView,
         rng: Random,
         exploration: Double,
     ): Double {
@@ -160,12 +165,12 @@ data object MultivariateGaussian : LinearPosterior<CovarianceRegressionResult> {
 @Serializable
 @SerialName("LinUcb")
 data object LinUcb : LinearPosterior<CovarianceRegressionResult> {
-    override fun sample(snapshot: CovarianceRegressionResult, rng: Random, exploration: Double): VectorView =
+    override fun sample(snapshot: CovarianceRegressionResult, rng: Random, exploration: Double): F64VectorView =
         snapshot.weights
 
     override fun evaluate(
         snapshot: CovarianceRegressionResult,
-        x: VectorView,
+        x: F64VectorView,
         rng: Random,
         exploration: Double,
     ): Double {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result
@@ -18,8 +18,8 @@ import kotlinx.serialization.Serializable
  *  - [DiagonalRegressionResult]: per-coefficient precision (factorised posterior).
  *  - [CovarianceRegressionResult]: full posterior covariance + Cholesky factor.
  *
- * Sealed + `@Serializable`. Concrete weights round-trip as [DenseVector] today;
- * the public field is typed [VectorView] so a sparse variant can swap in without
+ * Sealed + `@Serializable`. Concrete weights round-trip as [F64DenseVector] today;
+ * the public field is typed [F64VectorView] so a sparse variant can swap in without
  * breaking callers. Regression error metrics from [HasRegression] become
  * meaningful once [sse] is tracked; implementations that don't accumulate it
  * return `0.0`.
@@ -29,7 +29,7 @@ sealed interface LinearRegressionResult :
     Result,
     HasLinearModel,
     HasRegression {
-    override val weights: VectorView
+    override val weights: F64VectorView
 
     override val bias: Double
 
@@ -45,7 +45,7 @@ sealed interface LinearRegressionResult :
     val link: Link
 
     /** Linear predictor `eta = bias + x . weights`, before the inverse link. */
-    fun linearPredictor(x: VectorView): Double {
+    fun linearPredictor(x: F64VectorView): Double {
         x.requireFeatureSize(weights.size)
         var sum = bias
         for (i in 0 until weights.size) sum += x[i] * weights[i]
@@ -54,7 +54,7 @@ sealed interface LinearRegressionResult :
 
     /** Mean response: `link.invMean(linearPredictor(x))`. For [Link.Identity] this is
      *  the linear predictor itself, matching plain linear regression. */
-    override fun predict(x: VectorView): Double = link.invMean(linearPredictor(x))
+    override fun predict(x: F64VectorView): Double = link.invMean(linearPredictor(x))
 }
 
 /** SGD weight estimates with no posterior. Cheap, no uncertainty quantification.
@@ -65,14 +65,14 @@ sealed interface LinearRegressionResult :
 @Serializable
 @SerialName("StochasticRegressionResult")
 data class StochasticRegressionResult(
-    override val weights: DenseVector,
+    override val weights: F64DenseVector,
     override val bias: Double,
     override val totalWeights: Double,
     override val step: Long,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
     /** Per-optimiser auxiliary state (e.g. Adam's `m`/`v`); empty for plain SGD. */
-    val updaterState: List<VectorView> = emptyList(),
+    val updaterState: List<F64VectorView> = emptyList(),
 ) : LinearRegressionResult
 
 /**
@@ -83,14 +83,14 @@ data class StochasticRegressionResult(
 @Serializable
 @SerialName("DiagonalRegressionResult")
 data class DiagonalRegressionResult(
-    override val weights: DenseVector,
+    override val weights: F64DenseVector,
     override val bias: Double,
     /** Posterior precision (inverse variance) on the bias term. */
     val biasPrecision: Double,
     override val totalWeights: Double,
     override val step: Long,
     /** Per-coefficient precision (inverse variance). Same length as [weights]. */
-    val precision: DenseVector,
+    val precision: F64DenseVector,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
 ) : LinearRegressionResult
@@ -103,16 +103,16 @@ data class DiagonalRegressionResult(
 @Serializable
 @SerialName("CovarianceRegressionResult")
 data class CovarianceRegressionResult(
-    override val weights: DenseVector,
+    override val weights: F64DenseVector,
     override val bias: Double,
     /** Posterior precision (inverse variance) on the bias term. */
     val biasPrecision: Double,
     override val totalWeights: Double,
     override val step: Long,
     /** Full posterior covariance matrix over [weights]. */
-    val covariance: DenseMatrix,
+    val covariance: F64DenseMatrix,
     /** Lower-triangular Cholesky factor of [covariance], maintained in lockstep for sampling. */
-    val covarianceL: DenseMatrix,
+    val covarianceL: F64DenseMatrix,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
 ) : LinearRegressionResult {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -124,7 +124,7 @@ class StochasticRegressionStat(
     private fun requireSgdLearningRate(): ScalarExpr = sgdLearningRate ?: error("Sgd learning rate required")
     private fun requireSgdBiasRate(): ScalarExpr = sgdBiasRate ?: error("Sgd bias rate required")
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {
@@ -232,7 +232,7 @@ class StochasticRegressionStat(
             }
         }
         StochasticRegressionResult(
-            weights = DenseVector.of(materialised),
+            weights = F64DenseVector.of(materialised),
             bias = biasCell.load(),
             totalWeights = totalWeightsCell.load(),
             step = stepCell.load(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
@@ -17,7 +17,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /** The classification instantiation of the node-shape SPI. */
 internal typealias ClassificationShapeSpi = TreeShape<
-    VectorView,
+    F64VectorView,
     SerializableSplit,
     ClassificationNode,
     ClassificationSplitNode,
@@ -57,22 +57,22 @@ class ClassificationTree(
     )
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: VectorView): ClassificationLeafNode = growth.root.findLeaf(row)
+    fun findLeaf(row: F64VectorView): ClassificationLeafNode = growth.root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
     fun rootNode(): ClassificationNode = growth.root
 
     /** Argmax class at the leaf [row] resolves to. */
-    fun predict(row: VectorView): Int = findLeaf(row).arm.read(0L).predict()
+    fun predict(row: F64VectorView): Int = findLeaf(row).arm.read(0L).predict()
 
     /** Probabilities at the leaf [row] resolves to. */
-    fun probabilities(row: VectorView): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
+    fun probabilities(row: F64VectorView): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
 
     /** Number of internal + leaf nodes currently in the tree. */
     val nodeCount: Int get() = growth.nbrNodes.load()
 
     /** Fold an observation `(row, classLabel)` into the tree, possibly growing it. */
-    fun update(row: VectorView, classLabel: Int, weight: Double = 1.0) {
+    fun update(row: F64VectorView, classLabel: Int, weight: Double = 1.0) {
         if (classLabel !in 0 until numClasses) return
         growth.update(row, classLabel.toDouble(), weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicLong
@@ -14,7 +14,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  */
 sealed interface ClassificationNode {
     /** Walk to the leaf this row resolves to. */
-    fun findLeaf(row: VectorView): ClassificationLeafNode
+    fun findLeaf(row: F64VectorView): ClassificationLeafNode
 }
 
 /** Split mirror; predicate routes to [pos] or [neg]; [carryover] absorbs orphan
@@ -35,7 +35,7 @@ class ClassificationSplitNode(
     @Volatile
     var carryover: SeriesStat<ClassCountsResult>? = carryover
 
-    override fun findLeaf(row: VectorView): ClassificationLeafNode =
+    override fun findLeaf(row: F64VectorView): ClassificationLeafNode =
         if (split.direction(row)) pos.findLeaf(row) else neg.findLeaf(row)
 }
 
@@ -43,7 +43,7 @@ class ClassificationSplitNode(
 sealed class ClassificationLeafNode : ClassificationNode {
     /** The leaf's class-count accumulator. */
     abstract val arm: SeriesStat<ClassCountsResult>
-    final override fun findLeaf(row: VectorView): ClassificationLeafNode = this
+    final override fun findLeaf(row: F64VectorView): ClassificationLeafNode = this
 }
 
 /** Frozen leaf; no further splits considered. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -78,7 +78,7 @@ class DecisionTreeClassifierStat(
         randomSeed = seedRng.nextInt(),
     )
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         // isInertWeight rather than `weight <= 0.0`, which is false for NaN: a class count downdates
         // exactly, so a negative weight is a real retraction while a NaN would pin a count for good.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -71,9 +71,9 @@ class DecisionTreeRegressionStat(
     // Resolved per instance, not captured in the constructor default: create() has to be able
     // to rebind the default arm to the replica's concurrency.
     private val armFactory: () -> SeriesStat<WeightedVarianceResult> = leafArmFactory ?: { VarianceStat(concurrency) }
-    private var tree: RegressionTree<VectorView> = newTree()
+    private var tree: RegressionTree<F64VectorView> = newTree()
 
-    private fun newTree(): RegressionTree<VectorView> = RegressionTree(
+    private fun newTree(): RegressionTree<F64VectorView> = RegressionTree(
         splitCandidates,
         config,
         concurrency,
@@ -81,7 +81,7 @@ class DecisionTreeRegressionStat(
         seedRng.nextInt(),
     )
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         // Return before touching the tree: a zero-weight call would still advance the leaves'
         // observationsSinceLastCheck and shift the split-audit cadence.
@@ -115,5 +115,5 @@ class DecisionTreeRegressionStat(
     )
 
     /** Live underlying tree. Use for inspection / pretty-printing. */
-    fun tree(): RegressionTree<VectorView> = tree
+    fun tree(): RegressionTree<F64VectorView> = tree
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -88,7 +88,7 @@ class RandomForestClassifierStat(
         randomSeed = seedRng.nextInt(),
     )
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         // isInertWeight rather than isNotPositiveWeight: a class count subtracts exactly, so a negative
         // weight is a real downdate here, exactly as it is for the regression forest. Returning before
@@ -163,7 +163,7 @@ data class ForestClassificationResult(
     }
 
     /** Average per-class probability across trees for the leaf each tree routes [x] to. */
-    fun probabilities(x: VectorView): DoubleArray {
+    fun probabilities(x: F64VectorView): DoubleArray {
         val acc = DoubleArray(numClasses)
         for (t in trees) {
             val p = t.probabilities(x)
@@ -175,7 +175,7 @@ data class ForestClassificationResult(
     }
 
     /** Argmax over [probabilities]. */
-    fun predict(x: VectorView): Int {
+    fun predict(x: F64VectorView): Int {
         val p = probabilities(x)
         return argMaxOf(numClasses) { k -> p[k] }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -74,9 +74,9 @@ class RandomForestRegressionStat(
     // Drawn from on the update path, once per tree, with no lock over it - so it has to be a generator
     // that concurrent updates can share. See CounterRandom.
     private val baggingRng = CounterRandom(seedRng.childSeed(), concurrency)
-    private var trees: Array<RegressionTree<VectorView>> = Array(nbrTrees) { newTree() }
+    private var trees: Array<RegressionTree<F64VectorView>> = Array(nbrTrees) { newTree() }
 
-    private fun newTree(): RegressionTree<VectorView> = RegressionTree(
+    private fun newTree(): RegressionTree<F64VectorView> = RegressionTree(
         splitCandidates,
         this.config,
         concurrency,
@@ -84,7 +84,7 @@ class RandomForestRegressionStat(
         seedRng.nextInt(),
     )
 
-    override fun update(x: VectorView, y: Double, timestampNanos: Long, weight: Double) {
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
         // Return before drawing from baggingRng: an inert call that consumed one draw per tree would
         // desynchronise every later bagging draw and change the forest's predictions.
@@ -132,7 +132,7 @@ class RandomForestRegressionStat(
     )
 
     /** Live underlying trees. Use for inspection. */
-    fun trees(): List<RegressionTree<VectorView>> = trees.toList()
+    fun trees(): List<RegressionTree<F64VectorView>> = trees.toList()
 }
 
 /** Snapshot of a [RandomForestRegressionStat]: per-tree immutable snapshots. */
@@ -148,7 +148,7 @@ data class ForestRegressionResult(
 
     /** Merge the leaves that [x] routes to across every tree into a single weighted-
      *  variance aggregate. Useful for ensembled scoring. */
-    fun findLeafMerged(x: VectorView): WeightedVarianceResult {
+    fun findLeafMerged(x: F64VectorView): WeightedVarianceResult {
         // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, which short-circuits only
         // on an exactly-zero weight: a leaf left with negative total weight by an over-reaching
         // downdate would otherwise be folded in, and against a positive sibling of equal magnitude the
@@ -163,7 +163,7 @@ data class ForestRegressionResult(
     }
 
     /** Mean of [findLeafMerged]. */
-    fun predict(x: VectorView): Double = findLeafMerged(x).mean
+    fun predict(x: F64VectorView): Double = findLeafMerged(x).mean
 
     /** Sum of per-tree root totalWeights; `nbrTrees * underlyingWeight` under bagging. */
     val totalWeights: Double get() = trees.sumOf { it.totalWeights }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -34,9 +34,9 @@ internal typealias RegressionShapeSpi<Row> = TreeShape<
  *
  * The engine is **generic over the feature representation**: it only ever inspects a row
  * by calling [Split.direction], so any feature type can drive growth by supplying its own
- * [Split]s (e.g. a dense [com.eignex.koblas.VectorView] for the built-in stats, or
+ * [Split]s (e.g. a dense [com.eignex.koblas.F64VectorView] for the built-in stats, or
  * a typed/constraint-coupled row from a downstream library). Wire-portable serialization
- * of a snapshot is only meaningful for the [com.eignex.koblas.VectorView] case and
+ * of a snapshot is only meaningful for the [com.eignex.koblas.F64VectorView] case and
  * lives in `TreeRegressionResult.kt` as `VectorView`-constrained extensions.
  *
  * Internal split nodes hold no live arm; subtree aggregates (`rootSnapshot`, the `value`

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.schema.expr.BoolExpr
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  *
  * The interface is intentionally **open and non-serializable**: it is the in-memory SPI
  * for growing trees over arbitrary features. Wire-portable splits over a dense
- * [VectorView] context live under the [SerializableSplit] hierarchy, which the
+ * [F64VectorView] context live under the [SerializableSplit] hierarchy, which the
  * serializable tree snapshots ([TreeNodeResult]) embed.
  */
 interface Split<in Row> {
@@ -22,13 +22,13 @@ interface Split<in Row> {
 }
 
 /**
- * Wire-portable [Split] over a dense [VectorView] context. Sealed + serializable so tree
+ * Wire-portable [Split] over a dense [F64VectorView] context. Sealed + serializable so tree
  * snapshots round-trip cleanly through `kotlinx.serialization`. Built-in implementations:
  * [ThresholdSplit] (numeric `x[i] <= t`) and [ExprSplit] (wrapping a [BoolExpr]); callers
  * needing custom predicates compose them as [BoolExpr] AST nodes and wrap in [ExprSplit].
  */
 @Serializable
-sealed interface SerializableSplit : Split<VectorView>
+sealed interface SerializableSplit : Split<F64VectorView>
 
 /** Route by `row[featureIndex] <= threshold`. Threshold is inclusive on the "pos" side. */
 @Serializable
@@ -39,7 +39,7 @@ data class ThresholdSplit(
     /** Inclusive threshold separating pos (<=) from neg (>). */
     val threshold: Double,
 ) : SerializableSplit {
-    override fun direction(row: VectorView): Boolean = row[featureIndex] <= threshold
+    override fun direction(row: F64VectorView): Boolean = row[featureIndex] <= threshold
     override fun toString(): String = "x[$featureIndex] <= $threshold"
 }
 
@@ -55,7 +55,7 @@ data class ExprSplit(
     /** Predicate expression over the context vector. */
     val expr: BoolExpr,
 ) : SerializableSplit {
-    override fun direction(row: VectorView): Boolean {
+    override fun direction(row: F64VectorView): Boolean {
         val arr = row.toDoubleArray()
         val x = if (arr.isNotEmpty()) arr[0] else 0.0
         val y = if (arr.size >= 2) arr[1] else 0.0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,13 +13,13 @@ data class TreeClassificationResult(
     val root: TreeClassificationNodeResult,
 ) : Result {
     /** Walk to the leaf the context [x] resolves to and return its class-count snapshot. */
-    fun findLeaf(x: VectorView): ClassCountsResult = root.findLeaf(x)
+    fun findLeaf(x: F64VectorView): ClassCountsResult = root.findLeaf(x)
 
     /** Class probabilities at the leaf [x] resolves to. */
-    fun probabilities(x: VectorView): DoubleArray = findLeaf(x).probabilities()
+    fun probabilities(x: F64VectorView): DoubleArray = findLeaf(x).probabilities()
 
     /** Argmax class index at the leaf [x] resolves to. */
-    fun predict(x: VectorView): Int = findLeaf(x).predict()
+    fun predict(x: F64VectorView): Int = findLeaf(x).predict()
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -35,7 +35,7 @@ sealed interface TreeClassificationNodeResult {
     val value: ClassCountsResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: VectorView): ClassCountsResult
+    fun findLeaf(x: F64VectorView): ClassCountsResult
 }
 
 /** Immutable classification split-node snapshot. */
@@ -50,7 +50,7 @@ data class TreeClassificationSplitResult(
     val neg: TreeClassificationNodeResult,
     override val value: ClassCountsResult,
 ) : TreeClassificationNodeResult {
-    override fun findLeaf(x: VectorView): ClassCountsResult =
+    override fun findLeaf(x: F64VectorView): ClassCountsResult =
         if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
@@ -58,7 +58,7 @@ data class TreeClassificationSplitResult(
 @Serializable
 @SerialName("TreeClassificationLeafResult")
 data class TreeClassificationLeafResult(override val value: ClassCountsResult) : TreeClassificationNodeResult {
-    override fun findLeaf(x: VectorView): ClassCountsResult = value
+    override fun findLeaf(x: F64VectorView): ClassCountsResult = value
 }
 
 /** Freeze a live classification-tree node into an immutable snapshot. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -25,7 +25,7 @@ sealed interface TreePosterior : RegressionPosterior<TreeRegressionResult>
 
 /** Score is the leaf's running mean; point estimate, no exploration. */
 data object MeanTreePosterior : TreePosterior {
-    override fun evaluate(snapshot: TreeRegressionResult, x: VectorView, rng: Random, exploration: Double): Double =
+    override fun evaluate(snapshot: TreeRegressionResult, x: F64VectorView, rng: Random, exploration: Double): Double =
         snapshot.findLeaf(x).mean
 }
 
@@ -41,7 +41,7 @@ data class ThompsonTreePosterior(
     /** Prior variance applied when the leaf has effectively no signal. */
     val priorVariance: Double = 1.0,
 ) : TreePosterior {
-    override fun evaluate(snapshot: TreeRegressionResult, x: VectorView, rng: Random, exploration: Double): Double {
+    override fun evaluate(snapshot: TreeRegressionResult, x: F64VectorView, rng: Random, exploration: Double): Double {
         val leaf = snapshot.findLeaf(x)
         if (exploration <= 0.0) return leaf.mean
         val n = leaf.totalWeights + priorWeight
@@ -62,7 +62,7 @@ data class UcbTreePosterior(
     /** Prior variance used when the leaf has no signal yet. */
     val priorVariance: Double = 1.0,
 ) : TreePosterior {
-    override fun evaluate(snapshot: TreeRegressionResult, x: VectorView, rng: Random, exploration: Double): Double {
+    override fun evaluate(snapshot: TreeRegressionResult, x: F64VectorView, rng: Random, exploration: Double): Double {
         val leaf = snapshot.findLeaf(x)
         val n = leaf.totalWeights + priorWeight
         val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance
@@ -77,8 +77,12 @@ sealed interface ForestPosterior : RegressionPosterior<ForestRegressionResult>
 
 /** Forest counterpart to [MeanTreePosterior]. */
 data object MeanForestPosterior : ForestPosterior {
-    override fun evaluate(snapshot: ForestRegressionResult, x: VectorView, rng: Random, exploration: Double): Double =
-        snapshot.findLeafMerged(x).mean
+    override fun evaluate(
+        snapshot: ForestRegressionResult,
+        x: F64VectorView,
+        rng: Random,
+        exploration: Double,
+    ): Double = snapshot.findLeafMerged(x).mean
 }
 
 /** Forest counterpart to [ThompsonTreePosterior]. */
@@ -88,7 +92,12 @@ data class ThompsonForestPosterior(
     /** Prior variance used when the leaf has no signal yet. */
     val priorVariance: Double = 1.0,
 ) : ForestPosterior {
-    override fun evaluate(snapshot: ForestRegressionResult, x: VectorView, rng: Random, exploration: Double): Double {
+    override fun evaluate(
+        snapshot: ForestRegressionResult,
+        x: F64VectorView,
+        rng: Random,
+        exploration: Double,
+    ): Double {
         val leaf: WeightedVarianceResult = snapshot.findLeafMerged(x)
         if (exploration <= 0.0) return leaf.mean
         val n = leaf.totalWeights + priorWeight
@@ -104,7 +113,12 @@ data class UcbForestPosterior(
     /** Prior variance used when the leaf has no signal yet. */
     val priorVariance: Double = 1.0,
 ) : ForestPosterior {
-    override fun evaluate(snapshot: ForestRegressionResult, x: VectorView, rng: Random, exploration: Double): Double {
+    override fun evaluate(
+        snapshot: ForestRegressionResult,
+        x: F64VectorView,
+        rng: Random,
+        exploration: Double,
+    ): Double {
         val leaf = snapshot.findLeafMerged(x)
         val n = leaf.totalWeights + priorWeight
         val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,18 +1,18 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorView]
+ * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [F64VectorView]
  * context. Carries the tree structure ([SerializableSplit] predicates + per-node
  * weighted-variance aggregates) so callers can route a context vector to its leaf without
  * reaching back into the live stat.
  *
- * Serialization is only meaningful for the [VectorView] feature representation (the splits
+ * Serialization is only meaningful for the [F64VectorView] feature representation (the splits
  * must be wire-portable); trees grown over other [Split] row types use the live
  * [RegressionTree] directly and are not snapshotted to this type.
  *
@@ -26,10 +26,10 @@ data class TreeRegressionResult(
     val root: TreeNodeResult,
 ) : Result {
     /** Walk to the leaf the context resolves to. */
-    fun findLeaf(x: VectorView): WeightedVarianceResult = root.findLeaf(x)
+    fun findLeaf(x: F64VectorView): WeightedVarianceResult = root.findLeaf(x)
 
     /** Mean of the leaf the context resolves to. */
-    fun predict(x: VectorView): Double = findLeaf(x).mean
+    fun predict(x: F64VectorView): Double = findLeaf(x).mean
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -45,7 +45,7 @@ sealed interface TreeNodeResult {
     val value: WeightedVarianceResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: VectorView): WeightedVarianceResult
+    fun findLeaf(x: F64VectorView): WeightedVarianceResult
 }
 
 /** Immutable split-node snapshot. */
@@ -60,7 +60,7 @@ data class TreeSplitResult(
     val neg: TreeNodeResult,
     override val value: WeightedVarianceResult,
 ) : TreeNodeResult {
-    override fun findLeaf(x: VectorView): WeightedVarianceResult =
+    override fun findLeaf(x: F64VectorView): WeightedVarianceResult =
         if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
@@ -68,19 +68,19 @@ data class TreeSplitResult(
 @Serializable
 @SerialName("TreeLeafResult")
 data class TreeLeafResult(override val value: WeightedVarianceResult) : TreeNodeResult {
-    override fun findLeaf(x: VectorView): WeightedVarianceResult = value
+    override fun findLeaf(x: F64VectorView): WeightedVarianceResult = value
 }
 
 /**
- * Freeze a live [VectorView] tree node into an immutable, serializable snapshot. Internal
+ * Freeze a live [F64VectorView] tree node into an immutable, serializable snapshot. Internal
  * split aggregates are derived from the snapshotted children so the wire format stays
  * stable even though live splits hold no arm.
  *
- * Snapshotting is `VectorView`-only because the wire format requires [SerializableSplit];
- * a `VectorView` tree is always grown from [SerializableSplit] candidates, so the cast on
+ * Snapshotting is `F64VectorView`-only because the wire format requires [SerializableSplit];
+ * a `F64VectorView` tree is always grown from [SerializableSplit] candidates, so the cast on
  * each split is safe by construction.
  */
-fun RegressionNode<VectorView>.snapshot(): TreeNodeResult = when (this) {
+fun RegressionNode<F64VectorView>.snapshot(): TreeNodeResult = when (this) {
     is RegressionSplitNode -> {
         val p = pos.snapshot()
         val n = neg.snapshot()
@@ -95,22 +95,22 @@ fun RegressionNode<VectorView>.snapshot(): TreeNodeResult = when (this) {
 
 /**
  * Snapshot merge using only the immutable result. Mirrors [RegressionTree.merge] but the
- * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `VectorView`
+ * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `F64VectorView`
  * only, for the same reason [snapshot] is.
  *
- * An extension rather than a member because it exists only at `Row = VectorView`, which a member of a
+ * An extension rather than a member because it exists only at `Row = F64VectorView`, which a member of a
  * generic class cannot be constrained to. The algorithm is [TreeGrowth.mergeSnapshot].
  */
-fun RegressionTree<VectorView>.mergeSnapshot(other: TreeNodeResult) {
+fun RegressionTree<F64VectorView>.mergeSnapshot(other: TreeNodeResult) {
     growth.mergeSnapshot(other, RegressionResultShape)
 }
 
 /** Reads the immutable regression snapshot hierarchy on the growth engine's behalf. */
 private object RegressionResultShape :
-    TreeResultShape<Split<VectorView>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
+    TreeResultShape<Split<F64VectorView>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
     override fun asSplitResult(node: TreeNodeResult): TreeSplitResult? = node as? TreeSplitResult
 
-    override fun splitOf(node: TreeSplitResult): Split<VectorView> = node.split
+    override fun splitOf(node: TreeSplitResult): Split<F64VectorView> = node.split
 
     override fun posOf(node: TreeSplitResult): TreeNodeResult = node.pos
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 
 /**
  * A feature vector, for the tests that need one.
  *
- * One call site for `DenseVector.of` across the suite: koblas moved its dense storage to column-major
+ * One call site for `F64DenseVector.of` across the suite: koblas moved its dense storage to column-major
  * after `v0.1.0`, a change no compiler catches, so the next one should be a single edit.
  */
-internal fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)
+internal fun feat(vararg xs: Double): F64DenseVector = F64DenseVector.of(xs)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BernoulliArm
@@ -26,7 +26,7 @@ class ArmIndexContractSweepTest {
 
     private class Probe(val name: String, val calls: List<Pair<String, (Int) -> Any?>>)
 
-    private val x: VectorView = feat(1.0, 1.0)
+    private val x: F64VectorView = feat(1.0, 1.0)
 
     private fun probes(): List<Probe> {
         val multiArmed = MultiArmedBandit(ARMS, ThompsonSampling(BernoulliArm(), BetaPosterior), Random(0))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
@@ -100,7 +100,7 @@ class BanditInterfaceTest {
             posterior = MultivariateGaussian,
             random = Random(5),
         )
-        val x = DenseVector.of(doubleArrayOf(1.0, 0.0))
+        val x = F64DenseVector.of(doubleArrayOf(1.0, 0.0))
         cb.update(1, x, 2.0)
         val asBandit: PerArmBandit<*> = cb
         assertEquals(asBandit.snapshot()[1], asBandit.armResult(1))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.univariate.Exp3ArmResult
@@ -48,7 +48,7 @@ class BanditTuningTest {
         val alwaysFirst = Exp4Expert { _, k -> DoubleArray(k) { if (it == 0) 1.0 else 0.0 } }
         val alwaysSecond = Exp4Expert { _, k -> DoubleArray(k) { if (it == 1) 1.0 else 0.0 } }
         val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(alwaysFirst, alwaysSecond), random = Random(3))
-        val x: VectorView = DenseVector.of(doubleArrayOf(1.0))
+        val x: F64VectorView = F64DenseVector.of(doubleArrayOf(1.0))
 
         repeat(500) {
             bandit.update(0, x, 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
@@ -73,7 +73,7 @@ class StandaloneBanditExtraTest {
     fun `Exp4 expertWeights sum to 1`() {
         val experts: List<Exp4Expert> = listOf(
             Exp4Expert { _, n -> DoubleArray(n) { 1.0 / n } },
-            Exp4Expert { _: VectorView, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
+            Exp4Expert { _: F64VectorView, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
         )
         val b = Exp4Bandit(nbrArms = 3, experts = experts, random = Random(1))
         repeat(20) { b.update(b.choose(feat(0.0)), feat(0.0), 1.0) }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
@@ -39,7 +39,7 @@ class TrackedBanditTest {
             updateMarginalTemplate = BayesianRegressionStat(featureSize = 1),
             updateArmRewardTemplate = CovarianceStat(),
         )
-        val x = DenseVector.of(doubleArrayOf(0.3))
+        val x = F64DenseVector.of(doubleArrayOf(0.3))
         tracked.update(0, x, reward = 1.0)
         tracked.update(0, x, reward = 0.5)
         tracked.update(1, x, reward = 0.0)
@@ -82,7 +82,7 @@ class TrackedBanditTest {
             random = Random(7),
         )
         val tracked = TrackedContextualBandit(inner = inner, contextFeatureSize = 1)
-        val x = DenseVector.of(doubleArrayOf(0.1))
+        val x = F64DenseVector.of(doubleArrayOf(0.1))
         tracked.update(0, x, reward = 1.0)
         tracked.choose(x)
         assertNull(tracked.chooseResult())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random
@@ -88,10 +88,10 @@ class Exp4BanditTest {
     @Test
     fun `context-aware experts win on context-dependent rewards`() {
         // Expert "left" picks arm 0 when x<0, arm 1 when x>=0; opposite for "right".
-        val left = Exp4Expert { x: VectorView, n: Int ->
+        val left = Exp4Expert { x: F64VectorView, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 0 else 1] = 1.0 }
         }
-        val right = Exp4Expert { x: VectorView, n: Int ->
+        val right = Exp4Expert { x: F64VectorView, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 1 else 0] = 1.0 }
         }
         val rng = Random(5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.SparseVector
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
 import com.eignex.kumulant.feat
 import kotlin.random.Random
@@ -86,14 +86,14 @@ class KnnContextualBanditTest {
 
     @Test
     fun `squaredL2 dense and sparse agree across storage combinations`() {
-        val aDense = DenseVector.of(doubleArrayOf(1.0, 0.0, -2.0, 3.0, 0.0))
-        val bDense = DenseVector.of(doubleArrayOf(0.0, 4.0, -2.0, 1.0, 5.0))
-        val aSparse = SparseVector.of(
+        val aDense = F64DenseVector.of(doubleArrayOf(1.0, 0.0, -2.0, 3.0, 0.0))
+        val bDense = F64DenseVector.of(doubleArrayOf(0.0, 4.0, -2.0, 1.0, 5.0))
+        val aSparse = F64SparseVector.of(
             size = 5,
             indices = intArrayOf(0, 2, 3),
             values = doubleArrayOf(1.0, -2.0, 3.0),
         )
-        val bSparse = SparseVector.of(
+        val bSparse = F64SparseVector.of(
             size = 5,
             indices = intArrayOf(1, 2, 3, 4),
             values = doubleArrayOf(4.0, -2.0, 1.0, 5.0),
@@ -114,11 +114,11 @@ class KnnContextualBanditTest {
             doubleArrayOf(0.5, 0.0, 0.0, 1.5) to 1.0,
         )
         for ((x, r) in rows) {
-            denseInput.update(0, DenseVector.of(x), r)
+            denseInput.update(0, F64DenseVector.of(x), r)
             val nz = x.withIndex().filter { it.value != 0.0 }
             sparseInput.update(
                 0,
-                SparseVector.of(
+                F64SparseVector.of(
                     size = x.size,
                     indices = nz.map { it.index }.toIntArray(),
                     values = nz.map { it.value }.toDoubleArray(),
@@ -126,7 +126,7 @@ class KnnContextualBanditTest {
                 r,
             )
         }
-        val q = DenseVector.of(doubleArrayOf(0.5, 0.0, 0.0, 1.5))
+        val q = F64DenseVector.of(doubleArrayOf(0.5, 0.0, 0.0, 1.5))
         assertEquals(denseInput.evaluate(0, q), sparseInput.evaluate(0, q), 1e-12)
     }
 
@@ -142,8 +142,8 @@ class KnnContextualBanditTest {
 
     @Test
     fun `squaredL2 counts a stored zero once`() {
-        val a = SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
-        val b = SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
+        val a = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
+        val b = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
         assertEquals(9.0, squaredL2(a, b))
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.LinUcb
@@ -46,7 +46,7 @@ class RegressionContextualBanditTest {
 
         repeat(3000) {
             val x = doubleArrayOf(rng.nextDouble() * 2 - 1, rng.nextDouble() * 2 - 1)
-            val xv = DenseVector.of(x)
+            val xv = F64DenseVector.of(x)
             val arm = bandit.choose(xv)
             val reward = trueWeights[arm][0] * x[0] + trueWeights[arm][1] * x[1] +
                 rng.nextDouble() * 0.1 - 0.05
@@ -226,7 +226,7 @@ class RegressionContextualBanditTest {
         // while the global picks up the signal.
         repeat(500) {
             val x = doubleArrayOf(rng.nextDouble(), rng.nextDouble())
-            val xv = DenseVector.of(x)
+            val xv = F64DenseVector.of(x)
             val reward = 2.0 * x[0] + 0.5 * x[1]
             pooled.update(0, xv, reward)
             pooled.update(1, xv, reward)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionStat
@@ -19,7 +19,7 @@ class ClassLabelAdmissionTest {
     private class Probe(val name: String, val update: (Double, Double) -> Unit, val snapshot: () -> String)
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
-    private val x = DenseVector.of(DoubleArray(2) { 1.0 })
+    private val x = F64DenseVector.of(DoubleArray(2) { 1.0 })
 
     // Fresh instances per test. Every snapshot reads the learned numbers out explicitly rather than
     // stringifying the result: ClassCountsResult has no toString override, so on the JVM a stringified

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.math
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.SparseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64SparseVector
 import com.eignex.koblas.dense.cholesky
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 class CholeskyTest {
 
     // Reconstruct A = L * LT from the lower triangle of a factor.
-    private fun product(l: DenseMatrix): Array<DoubleArray> {
+    private fun product(l: F64DenseMatrix): Array<DoubleArray> {
         val n = l.rows
         return Array(n) { i ->
             DoubleArray(n) { j ->
@@ -37,9 +37,9 @@ class CholeskyTest {
             doubleArrayOf(1.0, 3.0),
         )
         val x = doubleArrayOf(0.5, 0.25)
-        val l = DenseMatrix.of(a).cholesky().l
+        val l = F64DenseMatrix.of(a).cholesky().l
 
-        val norm = l.choleskyDowndateInPlace(DenseVector.of(x))
+        val norm = l.choleskyDowndateInPlace(F64DenseVector.of(x))
 
         assertEquals(0.0, norm, "downdate inside the cone reports success")
         val expected = Array(2) { i -> DoubleArray(2) { j -> a[i][j] - x[i] * x[j] } }
@@ -54,9 +54,9 @@ class CholeskyTest {
             doubleArrayOf(0.5, 2.0, 4.0),
         )
         val x = doubleArrayOf(0.3, -0.6, 0.2)
-        val l = DenseMatrix.of(a).cholesky().l
+        val l = F64DenseMatrix.of(a).cholesky().l
 
-        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(x)))
+        assertEquals(0.0, l.choleskyDowndateInPlace(F64DenseVector.of(x)))
 
         val expected = Array(3) { i -> DoubleArray(3) { j -> a[i][j] - x[i] * x[j] } }
         assertMatrixEquals(expected, product(l))
@@ -64,7 +64,7 @@ class CholeskyTest {
 
     @Test
     fun `downdate reports a norm at or above one when it would leave the cone`() {
-        val l = DenseMatrix.of(
+        val l = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 0.0),
                 doubleArrayOf(0.0, 1.0),
@@ -72,7 +72,7 @@ class CholeskyTest {
         ).cholesky().l
 
         // x with ||L^-1 x|| >= 1 cannot be subtracted and stay positive-definite.
-        val norm = l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(3.0, 4.0)))
+        val norm = l.choleskyDowndateInPlace(F64DenseVector.of(doubleArrayOf(3.0, 4.0)))
 
         assertTrue(norm >= 1.0, "expected a rejected downdate, got norm=$norm")
     }
@@ -80,7 +80,7 @@ class CholeskyTest {
     @Test
     fun `downdate reports the norm at the cone boundary rather than silently doing nothing`() {
         // ||L^-1 x|| == 1 exactly: the downdate cannot proceed, and the factor is left alone.
-        val l = DenseMatrix.of(
+        val l = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(4.0, 0.0),
                 doubleArrayOf(0.0, 4.0),
@@ -88,7 +88,7 @@ class CholeskyTest {
         ).cholesky().l
         val before = product(l)
 
-        val norm = l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(2.0, 0.0)))
+        val norm = l.choleskyDowndateInPlace(F64DenseVector.of(doubleArrayOf(2.0, 0.0)))
 
         assertEquals(1.0, norm, 1e-12, "the boundary reports rejection, not success")
         assertMatrixEquals(before, product(l))
@@ -101,11 +101,11 @@ class CholeskyTest {
             doubleArrayOf(1.0, 4.0, 1.0),
             doubleArrayOf(0.0, 1.0, 3.0),
         )
-        val l = DenseMatrix.of(a).cholesky().l
+        val l = F64DenseMatrix.of(a).cholesky().l
         val x = doubleArrayOf(0.0, 0.4, 0.0)
 
         val norm = l.choleskyDowndateInPlace(
-            SparseVector.of(size = 3, indices = intArrayOf(1), values = doubleArrayOf(0.4)),
+            F64SparseVector.of(size = 3, indices = intArrayOf(1), values = doubleArrayOf(0.4)),
         )
 
         assertEquals(0.0, norm)
@@ -115,16 +115,16 @@ class CholeskyTest {
 
     @Test
     fun `downdate handles a one by one factor`() {
-        val l = DenseMatrix.of(arrayOf(doubleArrayOf(4.0))).cholesky().l
+        val l = F64DenseMatrix.of(arrayOf(doubleArrayOf(4.0))).cholesky().l
 
-        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(1.0))))
+        assertEquals(0.0, l.choleskyDowndateInPlace(F64DenseVector.of(doubleArrayOf(1.0))))
 
         assertEquals(3.0, product(l)[0][0], 1e-12)
     }
 
     @Test
     fun `downdate of a zero vector leaves the factor unchanged`() {
-        val l = DenseMatrix.of(
+        val l = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(2.0, 0.5),
                 doubleArrayOf(0.5, 1.0),
@@ -132,14 +132,14 @@ class CholeskyTest {
         ).cholesky().l
         val before = product(l)
 
-        assertEquals(0.0, l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(0.0, 0.0))))
+        assertEquals(0.0, l.choleskyDowndateInPlace(F64DenseVector.of(doubleArrayOf(0.0, 0.0))))
 
         assertMatrixEquals(before, product(l))
     }
 
     @Test
     fun `zeroUpperTriangle clears everything above the diagonal`() {
-        val m = DenseMatrix.of(
+        val m = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 2.0, 3.0),
                 doubleArrayOf(4.0, 5.0, 6.0),
@@ -160,13 +160,13 @@ class CholeskyTest {
 
     @Test
     fun `downdate through a singular factor leaves the factor finite`() {
-        val l = DenseMatrix.of(
+        val l = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(0.0, 0.0),
                 doubleArrayOf(0.0, 1.0),
             ),
         )
-        l.choleskyDowndateInPlace(DenseVector.of(doubleArrayOf(1.0, 0.0)))
+        l.choleskyDowndateInPlace(F64DenseVector.of(doubleArrayOf(1.0, 0.0)))
         for (i in 0 until 2) {
             for (j in 0 until 2) assertTrue(l[i, j].isFinite(), "entry ($i, $j) = ${l[i, j]}")
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.SumStat
@@ -66,7 +66,7 @@ class SamplingTest {
     @Test
     fun `vector throttle forwards every Nth update`() {
         val stat = VectorizedStat(2, SumStat()).throttle(every = 2)
-        repeat(6) { stat.update(DenseVector.of(doubleArrayOf(1.0, 1.0))) }
+        repeat(6) { stat.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0))) }
         assertEquals(3.0, stat.read().results[0].sum, DELTA)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.SparseVector
+import com.eignex.koblas.F64SparseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.CountStat
@@ -81,8 +81,8 @@ class VectorizedStatTest {
     @Test
     fun `skipZeros with sparse input only touches stored entries`() {
         val stat = VectorizedStat(dimensions = 5, template = CountStat(), skipZeros = true)
-        stat.update(SparseVector.of(size = 5, indices = intArrayOf(1, 3), values = doubleArrayOf(2.5, 7.0)))
-        stat.update(SparseVector.of(size = 5, indices = intArrayOf(3), values = doubleArrayOf(1.0)))
+        stat.update(F64SparseVector.of(size = 5, indices = intArrayOf(1, 3), values = doubleArrayOf(2.5, 7.0)))
+        stat.update(F64SparseVector.of(size = 5, indices = intArrayOf(3), values = doubleArrayOf(1.0)))
         val r = stat.read()
         assertEquals(0.0, r.results[0].sum, DELTA)
         assertEquals(1.0, r.results[1].sum, DELTA)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
@@ -96,7 +96,7 @@ class WeightsTest {
             assertEquals(0.0, discrete.read().estimate, "discrete moved on weight $inert")
 
             val regression = StochasticRegressionStat(featureSize = 2).withWeight(2.0)
-            regression.update(DenseVector.of(doubleArrayOf(1.0, 1.0)), 1.0, weight = inert)
+            regression.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0)), 1.0, weight = inert)
             assertEquals(0.0, regression.read().totalWeights, DELTA, "regression moved on weight $inert")
         }
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.BoolExpr
 import com.eignex.kumulant.schema.expr.Const
@@ -168,14 +168,14 @@ class ExprKotlinConstructionTest {
         // Materialising and driving one proves the whole path works, not just that the type exists.
         val reordered = Vectorized(dimensions = 3, template = Sum).transformVector(vectorOf(V(2), V(0), V(1)))
         val stat = reordered.materialize()
-        stat.update(DenseVector.of(doubleArrayOf(1.0, 2.0, 3.0)))
+        stat.update(F64DenseVector.of(doubleArrayOf(1.0, 2.0, 3.0)))
 
         // Coordinate 0 of the output is input coordinate 2.
         assertEquals(3.0, stat.read().results[0].let { (it as com.eignex.kumulant.stat.summary.SumResult).sum }, DELTA)
 
         val regression = StochasticRegression(featureSize = 3).transformX(vectorOf(V(0), V(1), V(2)))
         val model = regression.materialize()
-        model.update(DenseVector.of(doubleArrayOf(1.0, 1.0, 1.0)), 1.0)
+        model.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0, 1.0)), 1.0)
         assertEquals(1.0, model.read().totalWeights, DELTA, "the regression transform did not accept an update")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.X
 import com.eignex.kumulant.schema.expr.isFinite
@@ -74,11 +74,11 @@ class FilterFiniteTest {
         // The modality where this matters most, because a poisoned coefficient never recovers: every
         // later gradient step multiplies the NaN forward.
         for (bad in NON_FINITE) {
-            val good = DenseVector.of(doubleArrayOf(1.0, 1.0))
+            val good = F64DenseVector.of(doubleArrayOf(1.0, 1.0))
 
             val onFeature = StochasticRegression(featureSize = 2).filterFinite().materialize()
             onFeature.update(good, 1.0)
-            onFeature.update(DenseVector.of(doubleArrayOf(bad, 1.0)), 1.0)
+            onFeature.update(F64DenseVector.of(doubleArrayOf(bad, 1.0)), 1.0)
             onFeature.update(good, 1.0)
             val f = onFeature.read()
             assertEquals(2.0, f.totalWeights, DELTA, "a non-finite feature ($bad) was absorbed")
@@ -100,10 +100,10 @@ class FilterFiniteTest {
         // rather than as sugar over V(0).isFinite(): the bad coordinate can be any of them.
         for (index in 0 until 4) {
             val stat = StochasticRegression(featureSize = 4).filterFinite().materialize()
-            stat.update(DenseVector.of(DoubleArray(4) { 1.0 }), 1.0)
+            stat.update(F64DenseVector.of(DoubleArray(4) { 1.0 }), 1.0)
 
             val poisoned = DoubleArray(4) { if (it == index) Double.NaN else 1.0 }
-            stat.update(DenseVector.of(poisoned), 1.0)
+            stat.update(F64DenseVector.of(poisoned), 1.0)
 
             assertEquals(1.0, stat.read().totalWeights, DELTA, "a NaN at coordinate $index slipped through")
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
@@ -617,7 +617,7 @@ class VectorStatGroupTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: VectorView, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())
@@ -734,7 +734,7 @@ class VectorListStatsTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: VectorView, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,8 +29,8 @@ class HalfSpaceTreesStatTest {
             stat.update(doubleArrayOf(3.0 + rng.nextDouble() * 0.5, 3.0 + rng.nextDouble() * 0.5))
         }
         val r = stat.read()
-        val inlierScore = r.score(DenseVector.of(doubleArrayOf(3.2, 3.4)))
-        val outlierScore = r.score(DenseVector.of(doubleArrayOf(9.0, 9.0)))
+        val inlierScore = r.score(F64DenseVector.of(doubleArrayOf(3.2, 3.4)))
+        val outlierScore = r.score(F64DenseVector.of(doubleArrayOf(9.0, 9.0)))
         // Outliers route to leaves with little reference-window mass.
         assertTrue(inlierScore > outlierScore, "inlier=$inlierScore outlier=$outlierScore")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import kotlin.math.PI
 import kotlin.math.ln
 import kotlin.math.sqrt
@@ -23,9 +23,9 @@ class GaussianNaiveBayesResultTest {
     ) = GaussianNaiveBayesResult(
         featureSize = featureSize,
         numClasses = numClasses,
-        means = DenseMatrix.of(means),
-        variances = DenseMatrix.of(variances),
-        classWeights = DenseVector.of(classWeights),
+        means = F64DenseMatrix.of(means),
+        variances = F64DenseMatrix.of(variances),
+        classWeights = F64DenseVector.of(classWeights),
         totalWeights = totalWeights,
         varianceFloor = varianceFloor,
     )
@@ -88,16 +88,16 @@ class GaussianNaiveBayesResultTest {
         val logTwoPi = ln(2.0 * PI)
         val expectedClass0 = ln(0.5) + -0.5 * (logTwoPi + ln(0.5))
         val expectedClass1 = ln(0.5) + -0.5 * (logTwoPi + ln(0.5) + 100.0 / 0.5)
-        assertEquals(expectedClass0, r.logPosterior(DenseVector.of(doubleArrayOf(0.0)), 0), 1e-9)
-        assertEquals(expectedClass1, r.logPosterior(DenseVector.of(doubleArrayOf(0.0)), 1), 1e-9)
-        assertEquals(0, r.predict(DenseVector.of(doubleArrayOf(0.0))))
+        assertEquals(expectedClass0, r.logPosterior(F64DenseVector.of(doubleArrayOf(0.0)), 0), 1e-9)
+        assertEquals(expectedClass1, r.logPosterior(F64DenseVector.of(doubleArrayOf(0.0)), 1), 1e-9)
+        assertEquals(0, r.predict(F64DenseVector.of(doubleArrayOf(0.0))))
     }
 
     @Test
     fun `logPosterior rejects wrong feature size`() {
         val r = result(numClasses = 2, featureSize = 2)
         assertFailsWith<IllegalArgumentException> {
-            r.logPosterior(DenseVector.of(doubleArrayOf(1.0)), 0)
+            r.logPosterior(F64DenseVector.of(doubleArrayOf(1.0)), 0)
         }
     }
 
@@ -111,7 +111,7 @@ class GaussianNaiveBayesResultTest {
             classWeights = doubleArrayOf(1.0, 2.0, 1.0),
             totalWeights = 4.0,
         )
-        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.3)))
+        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.3)))
         assertEquals(1.0, p.sum(), 1e-12)
         for (pk in p) assertTrue(pk in 0.0..1.0, "prob out of [0,1]: $pk")
         // Sanity: stddev away from each mean still leaves nonzero mass everywhere.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random
@@ -56,7 +56,7 @@ class GaussianNaiveBayesStatTest {
         val n = 300
         repeat(n) {
             val c = rng.nextInt(3)
-            val x = DenseVector.of(
+            val x = F64DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() - 0.5,
                     centers[c][1] + rng.nextDouble() - 0.5,
@@ -73,10 +73,10 @@ class GaussianNaiveBayesStatTest {
         repeat(10) { stat.update(doubleArrayOf(0.0), 0.0) }
         repeat(10) { stat.update(doubleArrayOf(10.0), 1.0) }
         val r = stat.read()
-        val p = r.probabilities(DenseVector.of(doubleArrayOf(9.5)))
+        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(9.5)))
         assertEquals(1.0, p.sum(), 1e-9)
         assertTrue(p[1] > p[0])
-        assertEquals(1, r.predict(DenseVector.of(doubleArrayOf(9.5))))
+        assertEquals(1, r.predict(F64DenseVector.of(doubleArrayOf(9.5))))
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.optimizer.Adagrad
@@ -88,7 +88,7 @@ class OptimizerTest {
         var correct = 0
         repeat(300) {
             val c = rng.nextInt(3)
-            val x = DenseVector.of(
+            val x = F64DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() * 0.4 - 0.2,
                     centers[c][1] + rng.nextDouble() * 0.4 - 0.2,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
@@ -42,7 +42,7 @@ class RegressionArityGuardTest {
         val violations = mutableListOf<String>()
         for ((name, stat) in stats) {
             for (size in listOf(FEATURES - 1, FEATURES + 1)) {
-                val x = DenseVector.of(DoubleArray(size) { 1.0 })
+                val x = F64DenseVector.of(DoubleArray(size) { 1.0 })
                 val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
                 when {
                     thrown == null -> violations += "$name accepted a vector of size $size"
@@ -61,7 +61,7 @@ class RegressionArityGuardTest {
         // change, and because RegressionOpsTest greps it.
         for ((name, stat) in stats) {
             val thrown = runCatching {
-                stat.update(DenseVector.of(doubleArrayOf(1.0)), 1.0)
+                stat.update(F64DenseVector.of(doubleArrayOf(1.0)), 1.0)
             }.exceptionOrNull()
             val message = thrown?.message.orEmpty()
             assertTrue("x.size=1" in message, "$name did not report the size it got: $message")
@@ -73,7 +73,7 @@ class RegressionArityGuardTest {
     fun `a correctly sized vector is still accepted`() {
         // Guards the guard: a require that rejected everything would satisfy both tests above.
         for ((name, stat) in stats) {
-            val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+            val x = F64DenseVector.of(DoubleArray(FEATURES) { 1.0 })
             val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
             assertEquals(null, thrown?.message, "$name rejected a correctly sized vector")
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.stat.anomaly.FeatureRange
 import com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat
 import com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult
@@ -58,14 +58,14 @@ class RegressionMergeGuardTest {
         val ranges = List(1) { FeatureRange(0.0, 1.0) }
         val source = HalfSpaceTreesStat(featureSize = 1, featureRanges = ranges, windowSize = 50)
         repeat(200) { source.update(doubleArrayOf(0.5)) }
-        val sourceScore = source.read().score(DenseVector.of(doubleArrayOf(0.5)))
+        val sourceScore = source.read().score(F64DenseVector.of(doubleArrayOf(0.5)))
 
         val target = source.create()
         target.merge(source.read())
 
         // The reference window is what score() reads, so folding into the latest window alone would
         // leave a merged model scoring every input maximally anomalous.
-        val mergedScore = target.read().score(DenseVector.of(doubleArrayOf(0.5)))
+        val mergedScore = target.read().score(F64DenseVector.of(doubleArrayOf(0.5)))
         assertTrue(mergedScore > 0.0, "a merged model scored $mergedScore, i.e. maximally anomalous")
         assertEquals(sourceScore, mergedScore, sourceScore * 1e-9)
     }
@@ -112,7 +112,7 @@ class RegressionMergeGuardTest {
 
         // A zero-weight call that drew once per tree from baggingRng would desynchronise every later
         // draw and change the forest's predictions.
-        val at = DenseVector.of(doubleArrayOf(3.0))
+        val at = F64DenseVector.of(doubleArrayOf(3.0))
         assertEquals(clean.read().predict(at), probed.read().predict(at), 1e-12)
 
         val tree = DecisionTreeRegressionStat(featureSize = 1, splitCandidates = splits)
@@ -130,13 +130,13 @@ class RegressionMergeGuardTest {
     fun `a non-square covariance is rejected by name`() {
         val error = assertFailsWith<IllegalArgumentException> {
             CovarianceRegressionResult(
-                weights = DenseVector.of(doubleArrayOf(1.0, 2.0)),
+                weights = F64DenseVector.of(doubleArrayOf(1.0, 2.0)),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 1.0,
                 step = 1L,
-                covariance = DenseMatrix.zero(2, 3),
-                covarianceL = DenseMatrix.zero(2, 2),
+                covariance = F64DenseMatrix.zero(2, 3),
+                covarianceL = F64DenseMatrix.zero(2, 2),
             )
         }
         assertTrue(error.message?.contains("2x3") == true, "expected the shape in the message, got ${error.message}")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
@@ -56,7 +56,7 @@ class RegressionStatConcurrencyTest {
     fun `StochasticRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = StochasticRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)
@@ -70,7 +70,7 @@ class RegressionStatConcurrencyTest {
     fun `DiagonalRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = DiagonalRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)
@@ -84,7 +84,7 @@ class RegressionStatConcurrencyTest {
     fun `BayesianRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = BayesianRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
@@ -29,12 +29,12 @@ class RegressionWeightContractTest {
     private class Model(
         val name: String,
         val y: Double,
-        val update: (VectorView, Double, Double) -> Unit,
+        val update: (F64VectorView, Double, Double) -> Unit,
         val snapshot: () -> String,
     )
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
-    private val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+    private val x = F64DenseVector.of(DoubleArray(FEATURES) { 1.0 })
 
     // Bagging is off on the two forests. With it on, each tree draws Poisson(1) per observation and can
     // legitimately draw zero, so a single update may reach no tree at all. The early return that stops an
@@ -151,7 +151,7 @@ class RegressionWeightContractTest {
         val nonFinite = doubleArrayOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
         val violations = mutableListOf<String>()
         for (bad in nonFinite) {
-            val badFeatures = DenseVector.of(doubleArrayOf(bad, 1.0))
+            val badFeatures = F64DenseVector.of(doubleArrayOf(bad, 1.0))
             for (model in models()) {
                 // Feature position. The model is trained first so the bad input meets real state rather
                 // than a fresh accumulator, which is where the arithmetic has more ways to go wrong.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -12,8 +12,8 @@ class SoftmaxRegressionResultTest {
         SoftmaxRegressionResult(
             featureSize = weights[0].size,
             numClasses = weights.size,
-            weights = DenseMatrix.of(weights),
-            biases = DenseVector.of(biases),
+            weights = F64DenseMatrix.of(weights),
+            biases = F64DenseVector.of(biases),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
@@ -25,7 +25,7 @@ class SoftmaxRegressionResultTest {
             weights = arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(-1.0, 0.5)),
             biases = doubleArrayOf(0.5, -0.25),
         )
-        val x = DenseVector.of(doubleArrayOf(3.0, 4.0))
+        val x = F64DenseVector.of(doubleArrayOf(3.0, 4.0))
         assertEquals(0.5 + 1.0 * 3.0 + 2.0 * 4.0, r.logit(x, 0), 1e-12)
         assertEquals(-0.25 + -1.0 * 3.0 + 0.5 * 4.0, r.logit(x, 1), 1e-12)
     }
@@ -34,7 +34,7 @@ class SoftmaxRegressionResultTest {
     fun `logit rejects wrong feature size`() {
         val r = result(arrayOf(doubleArrayOf(1.0, 2.0)), doubleArrayOf(0.0))
         assertFailsWith<IllegalArgumentException> {
-            r.logit(DenseVector.of(doubleArrayOf(1.0)), 0)
+            r.logit(F64DenseVector.of(doubleArrayOf(1.0)), 0)
         }
     }
 
@@ -44,8 +44,8 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 3,
                 numClasses = 2,
-                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
-                biases = DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                weights = F64DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 totalWeights = 0.0,
                 step = 0L,
                 crossEntropy = 0.0,
@@ -59,8 +59,8 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 2,
                 numClasses = 2,
-                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
-                biases = DenseVector.of(doubleArrayOf(0.0)),
+                weights = F64DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                biases = F64DenseVector.of(doubleArrayOf(0.0)),
                 totalWeights = 0.0,
                 step = 0L,
                 crossEntropy = 0.0,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
 import kotlin.math.abs
@@ -17,23 +17,23 @@ class SoftmaxRegressionStatTest {
         val r = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = DenseMatrix.of(
+            weights = F64DenseMatrix.of(
                 arrayOf(
                     doubleArrayOf(1.0, 0.0),
                     doubleArrayOf(0.0, 1.0),
                     doubleArrayOf(-1.0, -1.0),
                 ),
             ),
-            biases = DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
+            biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val p = r.probabilities(DenseVector.of(doubleArrayOf(2.0, 1.0)))
+        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(2.0, 1.0)))
         val total = p.sum()
         assertEquals(1.0, total, 1e-9)
         // Class 0 has the largest logit (eta = 2), so argmax must be 0.
-        assertEquals(0, r.predict(DenseVector.of(doubleArrayOf(2.0, 1.0))))
+        assertEquals(0, r.predict(F64DenseVector.of(doubleArrayOf(2.0, 1.0))))
     }
 
     @Test
@@ -60,7 +60,7 @@ class SoftmaxRegressionStatTest {
         val n = 600
         repeat(n) {
             val c = rng.nextInt(3)
-            val x = DenseVector.of(
+            val x = F64DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() * 0.4 - 0.2,
                     centers[c][1] + rng.nextDouble() * 0.4 - 0.2,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64SparseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
@@ -46,9 +46,9 @@ class VectorSerializationTest {
             var y = 0.0
             for (i in 0 until 5) y += truth[i] * xArr[i]
             y += rng.nextDouble() * 0.02 - 0.01
-            dense.update(DenseVector.of(xArr), y, 1.0)
+            dense.update(F64DenseVector.of(xArr), y, 1.0)
             val nz = (0 until 5).filter { idx -> xArr[idx] != 0.0 }
-            val xs = SparseVector.of(5, nz.toIntArray(), nz.map { idx -> xArr[idx] }.toDoubleArray())
+            val xs = F64SparseVector.of(5, nz.toIntArray(), nz.map { idx -> xArr[idx] }.toDoubleArray())
             sparse.update(xs, y, 1.0)
         }
         val rd = dense.read()
@@ -62,20 +62,20 @@ class VectorSerializationTest {
     }
 
     @Test
-    fun `DenseVector round-trips through JSON`() {
-        val v: VectorView = DenseVector.of(doubleArrayOf(1.0, -2.5, 3.14, 0.0))
-        val wire = json.encodeToString(VectorView.serializer(), v)
-        val decoded = json.decodeFromString(VectorView.serializer(), wire)
-        assertTrue(decoded is DenseVector)
+    fun `F64DenseVector round-trips through JSON`() {
+        val v: F64VectorView = F64DenseVector.of(doubleArrayOf(1.0, -2.5, 3.14, 0.0))
+        val wire = json.encodeToString(F64VectorView.serializer(), v)
+        val decoded = json.decodeFromString(F64VectorView.serializer(), wire)
+        assertTrue(decoded is F64DenseVector)
         assertEquals(v, decoded)
     }
 
     @Test
-    fun `SparseVector round-trips through JSON`() {
-        val v: VectorView = SparseVector.of(10, intArrayOf(2, 5, 9), doubleArrayOf(1.0, -2.0, 0.5))
-        val wire = json.encodeToString(VectorView.serializer(), v)
-        val decoded = json.decodeFromString(VectorView.serializer(), wire)
-        assertTrue(decoded is SparseVector)
+    fun `F64SparseVector round-trips through JSON`() {
+        val v: F64VectorView = F64SparseVector.of(10, intArrayOf(2, 5, 9), doubleArrayOf(1.0, -2.0, 0.5))
+        val wire = json.encodeToString(F64VectorView.serializer(), v)
+        val decoded = json.decodeFromString(F64VectorView.serializer(), wire)
+        assertTrue(decoded is F64SparseVector)
         assertEquals(v, decoded)
     }
 
@@ -133,7 +133,7 @@ class VectorSerializationTest {
             diag.update(xArr, y, 1.0)
             bayes.update(xArr, y, 1.0)
         }
-        val queryX = DenseVector.of(doubleArrayOf(0.4, -0.2, 0.6))
+        val queryX = F64DenseVector.of(doubleArrayOf(0.4, -0.2, 0.6))
         val analyticMean = 0.7 * 0.4 + -0.3 * -0.2 + 1.5 * 0.6
 
         for ((label, m) in listOf(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import kotlin.math.abs
 import kotlin.math.sqrt
 import kotlin.random.Random
@@ -27,8 +27,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `custom prior seeds the initial weights and covariance`() {
-        val mean = DenseVector.of(doubleArrayOf(0.5, -1.0, 2.0))
-        val cov = DenseMatrix.of(
+        val mean = F64DenseVector.of(doubleArrayOf(0.5, -1.0, 2.0))
+        val cov = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 0.3, 0.0),
                 doubleArrayOf(0.3, 1.0, 0.0),
@@ -50,7 +50,7 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `non positive definite prior covariance is rejected at construction`() {
         // Diagonal with a negative entry - immediately non-PD.
-        val bad = DenseMatrix.of(
+        val bad = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 0.0),
                 doubleArrayOf(0.0, -0.1),
@@ -63,8 +63,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `reset restores configured prior`() {
-        val mean = DenseVector.of(doubleArrayOf(1.0, -0.5))
-        val cov = DenseMatrix.diagonal(2, 0.25)
+        val mean = F64DenseVector.of(doubleArrayOf(1.0, -0.5))
+        val cov = F64DenseMatrix.diagonal(2, 0.25)
         val blr = BayesianRegressionStat(featureSize = 2, priorMean = mean, priorCovariance = cov)
         val rng = Random(7)
         repeat(200) {
@@ -86,11 +86,11 @@ class BayesianRegressionStatPriorTest {
     fun `custom prior converges to truth with enough data`() {
         // A confident-but-wrong prior should still be overridden by data.
         val truth = doubleArrayOf(0.5, -1.0, 0.7)
-        val wrongMean = DenseVector.of(doubleArrayOf(-2.0, 3.0, -1.0))
+        val wrongMean = F64DenseVector.of(doubleArrayOf(-2.0, 3.0, -1.0))
         val blr = BayesianRegressionStat(
             featureSize = 3,
             priorMean = wrongMean,
-            priorCovariance = DenseMatrix.diagonal(3, 0.1),
+            priorCovariance = F64DenseMatrix.diagonal(3, 0.1),
         )
         val rng = Random(42)
         repeat(5000) {
@@ -110,8 +110,8 @@ class BayesianRegressionStatPriorTest {
         // Property: merging two instances trained on disjoint data should agree with
         // a single instance trained on the union - independent of the prior, as long
         // as both branches start from the same prior.
-        val priorMean = DenseVector.of(doubleArrayOf(0.2, -0.1))
-        val priorCov = DenseMatrix.of(
+        val priorMean = F64DenseVector.of(doubleArrayOf(0.2, -0.1))
+        val priorCov = F64DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(0.5, 0.1),
                 doubleArrayOf(0.1, 0.5),
@@ -151,15 +151,15 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `fitPopulationPrior returns the simple mean for identical posteriors`() {
         val mean = doubleArrayOf(1.0, -0.5)
-        val cov = DenseMatrix.diagonal(2, 0.4)
+        val cov = F64DenseMatrix.diagonal(2, 0.4)
         val snap = CovarianceRegressionResult(
-            weights = DenseVector.of(mean),
+            weights = F64DenseVector.of(mean),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 100.0,
             step = 100L,
-            covariance = DenseMatrix.of(cov.toArray()),
-            covarianceL = cov.let { c -> DenseMatrix.diagonal(2, sqrt(0.4)) },
+            covariance = F64DenseMatrix.of(cov.toArray()),
+            covarianceL = cov.let { c -> F64DenseMatrix.diagonal(2, sqrt(0.4)) },
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(List(5) { snap })
@@ -175,16 +175,16 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior captures between-instance spread`() {
         // Two posteriors with very different means and tight covariance: the population
         // covariance should be dominated by the between-instance term (~ (mu_diff/2)^2).
-        val tight = DenseMatrix.diagonal(2, 0.01)
+        val tight = F64DenseMatrix.diagonal(2, 0.01)
         val sqrt01 = sqrt(0.01)
         fun snap(mu: DoubleArray) = CovarianceRegressionResult(
-            weights = DenseVector.of(mu),
+            weights = F64DenseVector.of(mu),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 100.0,
             step = 100L,
-            covariance = DenseMatrix.of(tight.toArray()),
-            covarianceL = DenseMatrix.diagonal(2, sqrt01),
+            covariance = F64DenseMatrix.of(tight.toArray()),
+            covarianceL = F64DenseMatrix.diagonal(2, sqrt01),
             sse = 0.0,
         )
         val a = snap(doubleArrayOf(1.0, 0.0))
@@ -201,7 +201,7 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior result seeds a new BLR`() {
         // The output is exactly the shape BLR's constructor wants - feed it straight in
         // and confirm the new instance starts at the fitted population mean.
-        val cov = DenseMatrix.diagonal(2, 0.5)
+        val cov = F64DenseMatrix.diagonal(2, 0.5)
         val sqrt05 = sqrt(0.5)
         val snaps = listOf(
             doubleArrayOf(0.5, 1.0),
@@ -209,13 +209,13 @@ class BayesianRegressionStatPriorTest {
             doubleArrayOf(0.4, 1.2),
         ).map {
             CovarianceRegressionResult(
-                weights = DenseVector.of(it),
+                weights = F64DenseVector.of(it),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 50.0,
                 step = 50L,
-                covariance = DenseMatrix.of(cov.toArray()),
-                covarianceL = DenseMatrix.diagonal(2, sqrt05),
+                covariance = F64DenseMatrix.of(cov.toArray()),
+                covarianceL = F64DenseMatrix.diagonal(2, sqrt05),
                 sse = 0.0,
             )
         }
@@ -246,16 +246,16 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior honours custom weight selector`() {
         // With weight selector returning 1.0 for the first snapshot and 0.0 for the
         // second, the result should equal the first snapshot in isolation.
-        val cov = DenseMatrix.diagonal(2, 0.3)
+        val cov = F64DenseMatrix.diagonal(2, 0.3)
         val sqrt03 = sqrt(0.3)
         fun snap(mu: DoubleArray) = CovarianceRegressionResult(
-            weights = DenseVector.of(mu),
+            weights = F64DenseVector.of(mu),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 1.0,
             step = 1L,
-            covariance = DenseMatrix.of(cov.toArray()),
-            covarianceL = DenseMatrix.diagonal(2, sqrt03),
+            covariance = F64DenseMatrix.of(cov.toArray()),
+            covarianceL = F64DenseMatrix.diagonal(2, sqrt03),
             sse = 0.0,
         )
         val a = snap(doubleArrayOf(2.0, -2.0))
@@ -273,15 +273,15 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `fitPopulationPrior with a single snapshot has zero between-instance variance`() {
-        val cov = DenseMatrix.diagonal(2, 0.4)
+        val cov = F64DenseMatrix.diagonal(2, 0.4)
         val snap = CovarianceRegressionResult(
-            weights = DenseVector.of(doubleArrayOf(0.7, -0.3)),
+            weights = F64DenseVector.of(doubleArrayOf(0.7, -0.3)),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 50.0,
             step = 50L,
-            covariance = DenseMatrix.of(cov.toArray()),
-            covarianceL = DenseMatrix.diagonal(2, sqrt(0.4)),
+            covariance = F64DenseMatrix.of(cov.toArray()),
+            covarianceL = F64DenseMatrix.diagonal(2, sqrt(0.4)),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(listOf(snap))
@@ -298,8 +298,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `create propagates the configured prior to the clone`() {
-        val mean = DenseVector.of(doubleArrayOf(0.4, 1.1))
-        val cov = DenseMatrix.diagonal(2, 0.3)
+        val mean = F64DenseVector.of(doubleArrayOf(0.4, 1.1))
+        val cov = F64DenseMatrix.diagonal(2, 0.3)
         val original = BayesianRegressionStat(
             featureSize = 2,
             priorMean = mean,
@@ -320,7 +320,7 @@ class BayesianRegressionStatPriorTest {
         assertFailsWith<IllegalArgumentException> {
             BayesianRegressionStat(
                 featureSize = 3,
-                priorMean = DenseVector.of(doubleArrayOf(1.0, 2.0)),
+                priorMean = F64DenseVector.of(doubleArrayOf(1.0, 2.0)),
             )
         }
     }
@@ -330,7 +330,7 @@ class BayesianRegressionStatPriorTest {
         assertFailsWith<IllegalArgumentException> {
             BayesianRegressionStat(
                 featureSize = 3,
-                priorCovariance = DenseMatrix.diagonal(2, 1.0),
+                priorCovariance = F64DenseMatrix.diagonal(2, 1.0),
             )
         }
     }
@@ -339,8 +339,8 @@ class BayesianRegressionStatPriorTest {
     fun `strong prior dominates with very little data`() {
         // 5 noisy observations vs a very tight prior at the wrong mean: posterior
         // should sit much closer to the prior than to the data-only UnivariateRegression() fit.
-        val priorMean = DenseVector.of(doubleArrayOf(0.0, 0.0))
-        val tight = DenseMatrix.diagonal(2, 1e-4)
+        val priorMean = F64DenseVector.of(doubleArrayOf(0.0, 0.0))
+        val tight = F64DenseMatrix.diagonal(2, 1e-4)
         val blr = BayesianRegressionStat(
             featureSize = 2,
             priorMean = priorMean,
@@ -363,13 +363,13 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `PopulationPrior round-trips through JSON`() {
         val snap = CovarianceRegressionResult(
-            weights = DenseVector.of(doubleArrayOf(0.5, -0.5)),
+            weights = F64DenseVector.of(doubleArrayOf(0.5, -0.5)),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 10.0,
             step = 10L,
-            covariance = DenseMatrix.diagonal(2, 0.5),
-            covarianceL = DenseMatrix.diagonal(2, sqrt(0.5)),
+            covariance = F64DenseMatrix.diagonal(2, 0.5),
+            covarianceL = F64DenseMatrix.diagonal(2, sqrt(0.5)),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(listOf(snap, snap))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.fitLine
 import kotlin.math.abs
 import kotlin.math.exp
@@ -126,7 +126,7 @@ class BayesianRegressionStatTest {
         assertEquals(Link.Identity, stat.link)
         val snap = stat.read()
         assertEquals(Link.Identity, snap.link)
-        val x = DenseVector.of(doubleArrayOf(0.5, -0.3))
+        val x = F64DenseVector.of(doubleArrayOf(0.5, -0.3))
         assertEquals(snap.linearPredictor(x), snap.predict(x))
     }
 
@@ -142,10 +142,10 @@ class BayesianRegressionStatTest {
             stat.update(x, y, 1.0)
         }
         val snap = stat.read()
-        val p1 = snap.predict(DenseVector.of(doubleArrayOf(1.0, 0.0)))
+        val p1 = snap.predict(F64DenseVector.of(doubleArrayOf(1.0, 0.0)))
         assertTrue(p1 in 0.0..1.0, "predict returned $p1, expected probability")
         assertTrue(p1 > 0.7, "predicted P(positive | (1,0)) = $p1, expected > 0.7")
-        val pNeg = snap.predict(DenseVector.of(doubleArrayOf(-1.0, 1.0)))
+        val pNeg = snap.predict(F64DenseVector.of(doubleArrayOf(-1.0, 1.0)))
         assertTrue(pNeg < 0.3, "predicted P(positive | (-1,1)) = $pNeg, expected < 0.3")
     }
 
@@ -159,7 +159,7 @@ class BayesianRegressionStatTest {
             stat.update(x, rate, 1.0)
         }
         val snap = stat.read()
-        val x = DenseVector.of(doubleArrayOf(0.5, 0.5))
+        val x = F64DenseVector.of(doubleArrayOf(0.5, 0.5))
         val pred = snap.predict(x)
         val expected = exp(0.75)
         assertTrue(abs(pred - expected) / expected < 0.3, "pred=$pred, expected $expected")
@@ -170,7 +170,7 @@ class BayesianRegressionStatTest {
         val stat = BayesianRegressionStat(featureSize = 2, link = Link.Logit)
         stat.update(doubleArrayOf(1.0, 0.5), 1.0, 5.0)
         val snap = stat.read()
-        val x = DenseVector.of(doubleArrayOf(0.7, -0.3))
+        val x = F64DenseVector.of(doubleArrayOf(0.7, -0.3))
         val eta = snap.linearPredictor(x)
         val expected = 1.0 / (1.0 + exp(-eta))
         assertEquals(expected, snap.predict(x), absoluteTolerance = 1e-12)
@@ -181,7 +181,7 @@ class BayesianRegressionStatTest {
         val stat = BayesianRegressionStat(featureSize = 2, link = Link.Log)
         stat.update(doubleArrayOf(0.3, 0.4), 2.0, 1.0)
         val snap = stat.read()
-        val x = DenseVector.of(doubleArrayOf(0.1, 0.2))
+        val x = F64DenseVector.of(doubleArrayOf(0.1, 0.2))
         val eta = snap.linearPredictor(x)
         assertEquals(exp(eta), snap.predict(x), absoluteTolerance = 1e-12)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
@@ -131,7 +131,7 @@ class HierarchicalBayesianRegressionTest {
 
     @Test
     fun `caller-supplied initial prior is honoured`() {
-        val seedMean = DenseVector.of(doubleArrayOf(7.0, -3.0))
+        val seedMean = F64DenseVector.of(doubleArrayOf(7.0, -3.0))
         val pop = HierarchicalBayesianRegression(
             featureSize = 2,
             initialPriorMean = seedMean,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseMatrix
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseMatrix
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.schema.optimizer.Sgd
 import kotlin.math.abs
 import kotlin.random.Random
@@ -70,7 +70,7 @@ class LinearPosteriorsTest {
     @Test
     fun `PointPosterior evaluate with zero exploration is the point prediction`() {
         val snap = sgdSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.3, -0.4))
+        val x = F64DenseVector.of(doubleArrayOf(0.3, -0.4))
         val v = PointPosterior.evaluate(snap, x, Random(0), exploration = 0.0)
         assertEquals(snap.predict(x), v, 1e-12)
     }
@@ -78,7 +78,7 @@ class LinearPosteriorsTest {
     @Test
     fun `PointPosterior evaluate with exploration is finite`() {
         val snap = sgdSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.3, -0.4))
+        val x = F64DenseVector.of(doubleArrayOf(0.3, -0.4))
         repeat(50) {
             val v = PointPosterior.evaluate(snap, x, Random(it.toLong()), exploration = 0.5)
             assertTrue(v.isFinite())
@@ -104,7 +104,7 @@ class LinearPosteriorsTest {
     @Test
     fun `FactorisedGaussian evaluate is centered on predict`() {
         val snap = diagonalSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.1, 0.2))
+        val x = F64DenseVector.of(doubleArrayOf(0.1, 0.2))
         val rng = Random(0)
         val n = 600
         var sum = 0.0
@@ -131,7 +131,7 @@ class LinearPosteriorsTest {
     @Test
     fun `MultivariateGaussian evaluate is finite and finite-variance`() {
         val snap = bayesianSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.5, 0.5))
+        val x = F64DenseVector.of(doubleArrayOf(0.5, 0.5))
         val rng = Random(0)
         val n = 300
         var sum = 0.0
@@ -142,7 +142,7 @@ class LinearPosteriorsTest {
     @Test
     fun `LinUcb evaluate is deterministic given the snapshot`() {
         val snap = bayesianSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.3, 0.7))
+        val x = F64DenseVector.of(doubleArrayOf(0.3, 0.7))
         val rng = Random(0)
         val a = LinUcb.evaluate(snap, x, rng, exploration = 1.0)
         val b = LinUcb.evaluate(snap, x, rng, exploration = 1.0)
@@ -152,7 +152,7 @@ class LinearPosteriorsTest {
     @Test
     fun `LinUcb evaluate is mean plus alpha times sqrt xT Sigma x`() {
         val snap = bayesianSnapshot()
-        val x = DenseVector.of(doubleArrayOf(0.5, -0.5))
+        val x = F64DenseVector.of(doubleArrayOf(0.5, -0.5))
         val alpha = 2.0
         val score = LinUcb.evaluate(snap, x, Random(0), exploration = alpha)
         val mean = snap.predict(x)
@@ -174,7 +174,7 @@ class LinearPosteriorsTest {
         val snap = sgdSnapshot()
         assertTrue(snap.featureSize == 2)
         assertFailsWith<IllegalArgumentException> {
-            snap.predict(DenseVector.of(doubleArrayOf(1.0)))
+            snap.predict(F64DenseVector.of(doubleArrayOf(1.0)))
         }
     }
 
@@ -182,13 +182,13 @@ class LinearPosteriorsTest {
     fun `CovarianceRegressionResult rejects shape mismatch`() {
         assertFailsWith<IllegalArgumentException> {
             CovarianceRegressionResult(
-                weights = DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                weights = F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 0.0,
                 step = 0L,
-                covariance = DenseMatrix.zero(3, 3),
-                covarianceL = DenseMatrix.zero(3, 3),
+                covariance = F64DenseMatrix.zero(3, 3),
+                covarianceL = F64DenseMatrix.zero(3, 3),
             )
         }
     }
@@ -254,7 +254,7 @@ class LinearPosteriorsTest {
         val point = sgdSnapshot().copy(link = Link.Logit)
         val diagonal = diagonalSnapshot().copy(link = Link.Logit)
         val bayesian = bayesianSnapshot().copy(link = Link.Logit)
-        val x = DenseVector.of(doubleArrayOf(1.0, 1.0))
+        val x = F64DenseVector.of(doubleArrayOf(1.0, 1.0))
         val rng = Random(3)
         repeat(100) {
             assertTrue(PointPosterior.evaluate(point, x, rng, exploration = 4.0) in 0.0..1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -72,7 +72,7 @@ class StochasticRegressionStatTest {
         val snap = stat.read()
         assertTrue(snap.weights[0] > 0.0, "w[0] = ${snap.weights[0]} should be positive")
         assertTrue(snap.weights[1] < 0.0, "w[1] = ${snap.weights[1]} should be negative")
-        val p1 = snap.predict(DenseVector.of(doubleArrayOf(1.0, -1.0)))
+        val p1 = snap.predict(F64DenseVector.of(doubleArrayOf(1.0, -1.0)))
         assertTrue(p1 in 0.0..1.0)
     }
 
@@ -155,7 +155,7 @@ class StochasticRegressionStatTest {
             optimizer = Sgd(ConstantRate(0.01)),
             penalty = Penalty.L2(0.1),
         )
-        stat.update(DenseVector.of(doubleArrayOf(1.0, 0.5)), 1.0, 0L, weight = 1000.0)
+        stat.update(F64DenseVector.of(doubleArrayOf(1.0, 0.5)), 1.0, 0L, weight = 1000.0)
         val w = stat.read().weights.toDoubleArray()
         for (v in w) assertTrue(v.isFinite(), "weight $v not finite")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,7 +39,7 @@ class DecisionTreeClassifierStatTest {
             val x0 = rng.nextDouble() * 2.0 - 1.0
             val x1 = rng.nextDouble() * 2.0 - 1.0
             val label = if (x0 > 0.0) 1 else 0
-            r.predict(DenseVector.of(doubleArrayOf(x0, x1))) == label
+            r.predict(F64DenseVector.of(doubleArrayOf(x0, x1))) == label
         }
         assertTrue(nRight > 180, "accuracy=$nRight/200, tree=${stat.tree().prettyPrint()}")
     }
@@ -62,7 +62,7 @@ class DecisionTreeClassifierStatTest {
             stat.update(doubleArrayOf(x0, x1), rng.nextInt(3).toDouble())
         }
         val r = stat.read()
-        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.4, -0.4)))
+        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.4, -0.4)))
         assertEquals(1.0, p.sum(), 1e-9)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +21,7 @@ class ForestRegressionResultTest {
                 leaf(3.0, 5.0, 1.0),
             ),
         )
-        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
         val w = 5.0
         val expectedMean = (2.0 * 1.0 + 3.0 * 5.0) / w
         val delta = 5.0 - 1.0
@@ -39,7 +39,7 @@ class ForestRegressionResultTest {
                 leaf(4.0, 2.0, 1.0),
             ),
         )
-        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
         assertEquals(4.0, r.totalWeights, 1e-12)
         assertEquals(2.0, r.mean, 1e-12)
         assertEquals(1.0, r.variance, 1e-12)
@@ -50,7 +50,7 @@ class ForestRegressionResultTest {
         val forest = ForestRegressionResult(
             trees = listOf(leaf(1.0, 3.0, 0.0), leaf(1.0, 5.0, 0.0)),
         )
-        assertEquals(4.0, forest.predict(DenseVector.of(doubleArrayOf(0.0))), 1e-12)
+        assertEquals(4.0, forest.predict(F64DenseVector.of(doubleArrayOf(0.0))), 1e-12)
     }
 
     @Test
@@ -71,7 +71,7 @@ class ForestRegressionResultTest {
         val forest = ForestRegressionResult(
             trees = listOf(leaf(0.0, 0.0, 0.0), leaf(0.0, 0.0, 0.0)),
         )
-        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
         assertEquals(0.0, r.totalWeights, 1e-12)
         assertEquals(0.0, r.variance, 1e-12)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,13 +37,13 @@ class RandomForestClassifierStatTest {
             stat.update(doubleArrayOf(x0, x1), label.toDouble())
         }
         val r = stat.read()
-        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.5, 0.5)))
+        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.5, 0.5)))
         assertEquals(1.0, p.sum(), 1e-9)
         val correct = (0 until 200).count {
             val x0 = rng.nextDouble() * 2.0 - 1.0
             val x1 = rng.nextDouble() * 2.0 - 1.0
             val label = if (x0 > 0.0) 1 else 0
-            r.predict(DenseVector.of(doubleArrayOf(x0, x1))) == label
+            r.predict(F64DenseVector.of(doubleArrayOf(x0, x1))) == label
         }
         assertTrue(correct > 170, "accuracy=$correct/200")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 class TreeClassificationResultTest {
 
     private fun counts(vararg c: Double) = ClassCountsResult(c.size, c)
-    private fun vec(vararg xs: Double) = DenseVector.of(xs)
+    private fun vec(vararg xs: Double) = F64DenseVector.of(xs)
 
     private fun stubTree(): TreeClassificationResult {
         // x[0] <= 0 routes pos (class 0 dominant); otherwise neg (class 1 dominant)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +21,7 @@ class TreeGrowthParityTest {
 
     private val candidates = listOf(ThresholdSplit(0, 0.5), ThresholdSplit(1, 0.5))
 
-    private fun regressionStructure(node: RegressionNode<VectorView>): String = when (node) {
+    private fun regressionStructure(node: RegressionNode<F64VectorView>): String = when (node) {
         is RegressionSplitNode -> "(${node.split} ? ${regressionStructure(node.pos)}" +
             " : ${regressionStructure(node.neg)})"
 
@@ -35,8 +35,8 @@ class TreeGrowthParityTest {
         is ClassificationLeafNode -> "leaf"
     }
 
-    private fun grownPair(observations: Int): Pair<RegressionTree<VectorView>, ClassificationTree> {
-        val regression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 7)
+    private fun grownPair(observations: Int): Pair<RegressionTree<F64VectorView>, ClassificationTree> {
+        val regression = RegressionTree<F64VectorView>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(
             numClasses = 2,
             splitCandidates = candidates,
@@ -71,7 +71,7 @@ class TreeGrowthParityTest {
 
     @Test
     fun `neither tree splits while the candidates carry no signal`() {
-        val regression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 7)
+        val regression = RegressionTree<F64VectorView>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 7)
         // A constant label leaves every candidate at zero impurity reduction, so shouldSplit must refuse
         // in both trees no matter how much weight piles up.
@@ -88,7 +88,7 @@ class TreeGrowthParityTest {
     fun `snapshot merge into a fresh tree reproduces the grown shape on both sides`() {
         val (regression, classification) = grownPair(observations = 4000)
 
-        val freshRegression = RegressionTree<VectorView>(splitCandidates = candidates, randomSeed = 9)
+        val freshRegression = RegressionTree<F64VectorView>(splitCandidates = candidates, randomSeed = 9)
         freshRegression.mergeSnapshot(regression.rootNode().snapshot())
 
         val freshClassification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 9)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
@@ -2,8 +2,8 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorView
+import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 
 class TreeNodeTest {
 
-    private fun wvLeaf(): RegressionTerminalLeaf<VectorView> = RegressionTerminalLeaf(VarianceStat())
+    private fun wvLeaf(): RegressionTerminalLeaf<F64VectorView> = RegressionTerminalLeaf(VarianceStat())
     private fun ccLeaf(numClasses: Int = 2) = ClassificationTerminalLeaf(ClassCountsStat(numClasses))
 
     @Test
@@ -21,10 +21,10 @@ class TreeNodeTest {
         val pos = wvLeaf()
         val neg = wvLeaf()
         val node = RegressionSplitNode(ThresholdSplit(0, 0.0), pos = pos, neg = neg)
-        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(-1.0))))
-        assertSame(neg, node.findLeaf(DenseVector.of(doubleArrayOf(1.0))))
+        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(-1.0))))
+        assertSame(neg, node.findLeaf(F64DenseVector.of(doubleArrayOf(1.0))))
         // Threshold is inclusive on the pos side.
-        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(0.0))))
+        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(0.0))))
     }
 
     @Test
@@ -34,7 +34,7 @@ class TreeNodeTest {
         val node = RegressionSplitNode(ThresholdSplit(0, 0.0), pos = original, neg = wvLeaf())
         assertSame(original, node.pos)
         node.pos = replacement
-        assertSame(replacement, node.findLeaf(DenseVector.of(doubleArrayOf(-1.0))))
+        assertSame(replacement, node.findLeaf(F64DenseVector.of(doubleArrayOf(-1.0))))
     }
 
     @Test
@@ -67,8 +67,8 @@ class TreeNodeTest {
         val pos = ccLeaf()
         val neg = ccLeaf()
         val node = ClassificationSplitNode(ThresholdSplit(0, 0.5), pos = pos, neg = neg)
-        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(0.0))))
-        assertSame(neg, node.findLeaf(DenseVector.of(doubleArrayOf(1.0))))
+        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(0.0))))
+        assertSame(neg, node.findLeaf(F64DenseVector.of(doubleArrayOf(1.0))))
     }
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stream
 
-import com.eignex.koblas.DenseVector
+import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.Stat
@@ -193,7 +193,7 @@ class ConcurrentReadInvariantsTest {
             val writers = 6
             val iters = 3_000
             assertReadInvariants("HalfSpaceTreesStat[$level]", stat, writers = writers, iters = iters, write = { t, i ->
-                val v = DenseVector.of(
+                val v = F64DenseVector.of(
                     doubleArrayOf(
                         ((t * 7 + i) % 100) / 100.0,
                         ((t * 13 + i * 3) % 100) / 100.0,
@@ -204,7 +204,7 @@ class ConcurrentReadInvariantsTest {
             }) { r ->
                 assertTrue(r.totalWeights >= 0.0, "totalWeights=${r.totalWeights}")
                 for (m in r.referenceMass) assertTrue(m >= 0.0 && m.isFinite(), "referenceMass entry $m")
-                val s = r.score(DenseVector.of(doubleArrayOf(0.5, 0.5, 0.5)))
+                val s = r.score(F64DenseVector.of(doubleArrayOf(0.5, 0.5, 0.5)))
                 assertTrue(s.isFinite() && s >= 0.0, "score=$s")
             }
             val fed = (writers * iters).toDouble()


### PR DESCRIPTION
## What changed

- Migrated to the koblas F64 type names across 89 files: F64VectorView, F64DenseVector, F64SparseVector, F64DenseMatrix and the rest.
- Regenerated both ABI dumps.

## Why

koblas renamed its numeric types with an F64 prefix and kept the old names as typealiases. Source still compiled, but the ABI dump no longer matched the compiled surface and a dokka link to VectorView.size stopped resolving, so check and lintDocs both failed. This is upstream drift rather than anything in the fixes below it: the pre-existing commit on main fails the same ABI check with the same diff.

## Testing

The rename was scoped to files that import each koblas type, plus fully qualified references in docs. That scoping matters, since a whole-word rename would have rewritten the phrase "apply Givens rotations" in a comment; Givens is imported nowhere. The ABI change was verified to be a pure rename by normalising the F64 prefix back out of both new dumps and diffing against the committed versions, which gives zero residual lines. `./gradlew check lintDocs` passes on every target.

One caveat for whoever lands this: koblas is an unpinned SNAPSHOT and the web artifacts lagged the jvm and native ones in the local cache, so the same tree compiled on some targets and not others until --refresh-dependencies converged them. Pinning koblas or setting cacheChangingModulesFor to zero would stop that recurring.
