### PR TITLE
fix: divide the exp3 gain by the propensity the arm was drawn with

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -117,13 +117,21 @@ class Exp4Bandit(
 
     private val weights: DoubleArray = DoubleArray(experts.size) { 1.0 }
     private val lastAdvice: Array<DoubleArray> = Array(experts.size) { DoubleArray(nbrArms) }
-    private var lastPlayDist: DoubleArray = DoubleArray(nbrArms) { 1.0 / nbrArms }
+
+    // The probability each arm was last played with, and how many of its pulls are still awaiting
+    // feedback. The importance weight has to divide by the probability in force when the arm was
+    // drawn; expert weights move on every update, so recomputing it at update time is only correct
+    // when no other feedback arrived in between.
+    private val pendingPropensity = DoubleArray(nbrArms)
+    private val pendingPulls = IntArray(nbrArms)
 
     /** Build the round's play distribution and sample an arm. */
     override fun choose(x: F64VectorView): Int {
         val p = playDistribution(x)
-        lastPlayDist = p
-        return random.sampleFromDistribution(p)
+        val chosen = random.sampleFromDistribution(p)
+        pendingPropensity[chosen] = p[chosen]
+        pendingPulls[chosen]++
+        return chosen
     }
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with
@@ -159,13 +167,25 @@ class Exp4Bandit(
         requireArmIndex(armIndex, nbrArms)
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)
-        val pPlayed = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
+        val pPlayed = propensityOf(armIndex, x).coerceAtLeast(MIN_PLAY_PROB)
         val gainPlayed = (reward * weight) / pPlayed
         for (i in experts.indices) {
             val expertGain = lastAdvice[i][armIndex] * gainPlayed
             weights[i] *= exp(eta * expertGain)
         }
         weights.renormaliseExponentialWeights()
+    }
+
+    /**
+     * Probability [armIndex] was drawn with, consuming one outstanding pull.
+     *
+     * Falls back to the distribution at [x] when the caller updates an arm it never chose, which is
+     * the best available estimate and what an off-policy caller implicitly asks for.
+     */
+    private fun propensityOf(armIndex: Int, x: F64VectorView): Double {
+        if (pendingPulls[armIndex] <= 0) return playDistribution(x)[armIndex]
+        pendingPulls[armIndex]--
+        return pendingPropensity[armIndex]
     }
 
     /** Current per-expert weights, normalised to sum to 1. */
@@ -192,7 +212,8 @@ class Exp4Bandit(
     /** Reset all expert weights to uniform. */
     override fun reset() {
         for (i in weights.indices) weights[i] = 1.0
-        lastPlayDist = DoubleArray(nbrArms) { 1.0 / nbrArms }
+        pendingPropensity.fill(0.0)
+        pendingPulls.fill(0)
     }
 
     /** Spawn a fresh bandit with the same experts and tunables; weights reset to uniform. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -81,13 +81,21 @@ class Exp3Bandit(
     }
 
     private val weights: DoubleArray = DoubleArray(nbrArms) { 1.0 }
-    private var lastPlayDist: DoubleArray = DoubleArray(nbrArms) { 1.0 / nbrArms }
+
+    // The probability each arm was last played with, and how many of its pulls are still awaiting
+    // feedback. The importance weight has to divide by the probability in force when the arm was
+    // drawn, and the play distribution moves on every update, so recovering it at update time is
+    // only correct when no other arm's feedback arrived in between.
+    private val pendingPropensity = DoubleArray(nbrArms)
+    private val pendingPulls = IntArray(nbrArms)
 
     /** Build the round's play distribution and sample an arm. */
     override fun choose(): Int {
         val p = playDistribution()
-        lastPlayDist = p
-        return random.sampleFromDistribution(p)
+        val chosen = random.sampleFromDistribution(p)
+        pendingPropensity[chosen] = p[chosen]
+        pendingPulls[chosen]++
+        return chosen
     }
 
     /** Current play distribution: weight-normalised softmax blended with uniform [gamma]. */
@@ -111,13 +119,22 @@ class Exp3Bandit(
     /** Fold a `(arm, reward)` observation into the played arm's weight. */
     override fun update(armIndex: Int, value: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
-        // Recomputed rather than reused from choose: one field cannot carry the propensity of
-        // every arm chosen since, so a stale distribution would be wrong more often than a fresh one.
-        playDistribution().also { lastPlayDist = it }
-        val p = lastPlayDist[armIndex].coerceAtLeast(MIN_PLAY_PROB)
+        val p = propensityOf(armIndex).coerceAtLeast(MIN_PLAY_PROB)
         val gain = (value * weight) / p
         weights[armIndex] *= exp(eta * gain)
         weights.renormaliseExponentialWeights()
+    }
+
+    /**
+     * Probability [armIndex] was drawn with, consuming one outstanding pull.
+     *
+     * Falls back to the current distribution when the caller updates an arm it never chose, which is
+     * the best available estimate and what an off-policy caller implicitly asks for.
+     */
+    private fun propensityOf(armIndex: Int): Double {
+        if (pendingPulls[armIndex] <= 0) return playDistribution()[armIndex]
+        pendingPulls[armIndex]--
+        return pendingPropensity[armIndex]
     }
 
     /** Current per-arm weights, normalised to sum to 1. */
@@ -142,7 +159,8 @@ class Exp3Bandit(
     /** Reset all weights to uniform. */
     override fun reset() {
         for (i in weights.indices) weights[i] = 1.0
-        lastPlayDist = DoubleArray(nbrArms) { 1.0 / nbrArms }
+        pendingPropensity.fill(0.0)
+        pendingPulls.fill(0)
     }
 
     /** Spawn a fresh bandit with the same tunables; weights reset. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -24,9 +24,12 @@ import kotlin.time.Duration
 // stream is read back out of: an observation admitted with no multiplicity would not merely be
 // absorbed, it would be forwarded to the delegate at a later update's weight. See [Stat].
 //
-// Concurrency: per-cell atomics with bounded drift (category 1). Concurrent updates may briefly
-// observe an out-of-order ring slot but never throw; the forwarded value is always some value
-// the stream actually emitted.
+// Concurrency: lag and diff serialise the ring update behind the level's lock, which is a noop only
+// under Concurrency.None. Claiming the tick, reading the ring slot and storing into it is one
+// indivisible step: split apart, a second writer reads a slot its writer has not filled yet and
+// forwards the ring's initial 0.0, an outlier the size of the stream itself rather than the bounded
+// drift the concurrent levels promise. Derivative keeps per-cell atomics (category 1); a torn read
+// there surfaces as a non-positive time delta, which it drops.
 //
 // The wire counterparts live in `schema/Operations.kt` (DiffSeries, LagSeries, DerivativeSeries).
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
@@ -21,9 +21,10 @@ import com.eignex.kumulant.stream.serializedLock
 // each pair is read back out of, so admitting an observation that carries no multiplicity would
 // pair it with a real one later at that update's weight. See [Stat].
 //
-// Concurrency: per-cell atomics with bounded drift (category 1). The ring slot may briefly
-// observe an out-of-order write under contention but the paired stat always sees some
-// (current, past) pair the stream actually emitted.
+// Concurrency: the ring update is serialised behind the level's lock, which is a noop only under
+// Concurrency.None. Claiming the tick, reading the ring slot and storing into it is one indivisible
+// step: split apart, the paired stat receives (current, 0.0), a pair the stream never emitted, which
+// is an unbounded error rather than the bounded drift the concurrent levels promise.
 
 /**
  * Lift a paired stat into a series stat by self-pairing each input with the value seen

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/Exp3BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/Exp3BanditTest.kt
@@ -44,4 +44,24 @@ class Exp3BanditTest {
         assertEquals(0.5, w[0], 1e-9)
         assertEquals(0.5, w[1], 1e-9)
     }
+
+    @Test
+    fun `feedback order does not change the weight an arm earns`() {
+        fun weightsAfter(delayed: Boolean): List<Double> {
+            val bandit = Exp3Bandit(nbrArms = 2, random = Random(1))
+            bandit.choose()
+            bandit.choose()
+            if (delayed) {
+                bandit.update(0, 1.0)
+                bandit.update(1, 1.0)
+            } else {
+                bandit.update(1, 1.0)
+                bandit.update(0, 1.0)
+            }
+            return bandit.armWeights().toList()
+        }
+        val direct = weightsAfter(delayed = false)
+        val delayed = weightsAfter(delayed = true)
+        for (i in direct.indices) assertTrue(abs(direct[i] - delayed[i]) < 1e-9, "arm $i: $direct vs $delayed")
+    }
 }


### PR DESCRIPTION
## What changed

- Exp3Bandit and Exp4Bandit record the probability an arm was drawn with at choose time and divide by that at update time, instead of recomputing the play distribution from whatever the weights hold when feedback arrives.
- Corrected the concurrency comments on the shift operators, which still described per-cell atomics after those paths moved behind a lock.

## Why

The importance-weighted gain has to divide by the probability the arm was actually played with. Recomputing it at update time is exact only while no other feedback lands in between, which is not true under delayed or batched feedback. Measured on a two-arm bandit: arm 1 was drawn at probability 0.5, but once arm 0's feedback had been folded in, its update divided by 0.391 instead, a 22 percent error that inflates the gain by about 28 percent. The resulting weights depended on feedback order alone, 0.764 against 0.581 for the same rewards. That is the unbiasedness the EXP3 regret bound rests on, so it is worth more than the field it replaces.

Each arm keeps its last propensity and a count of pulls awaiting feedback, so the common interleaving of several chooses before their updates is exact. Updating an arm that was never chosen falls back to the current distribution, which is what an off-policy caller implicitly asks for. One case is still approximate: if an arm is drawn, then some other arm's feedback moves the weights, then that same arm is drawn again, both pulls share the newer propensity. Making that exact needs a per-arm queue of outstanding pulls, which is unbounded when feedback never arrives.

## Testing

A test drives two chooses and then delivers the two updates in each order, asserting the arm weights match. It fails without the fix with exactly the 0.581 against 0.419 split above. `./gradlew check lintDocs` passes on every target.

Note that `wasmWasiNodeTest` failed twice during this work and passed on a re-run, with the same `WebAssembly.Exception` from the dry-run phase that was investigated on 2026-08-18 and put down to a hot, loaded machine. A gate on the same tree without these changes passed, and the wasm test passes standalone, so it is the known flake rather than anything here.
