### PR TITLE
fix: audit a leaf split on the weight its candidates attributed

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowth.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowth.kt
@@ -286,13 +286,21 @@ internal class TreeGrowth<Row, S : Split<Row>, N : Any, SN : N, AL : N, P : HasO
             if (ticks.load() < config.splitPeriod) return@guarded node
             ticks.store(0L)
 
-            // A merged leaf holds mass in `arm` that no candidate arm ever saw, so this weight can
-            // exceed the candidates'. Sound anyway: rankCandidates gates on the attributed weight.
-            val total = arm.read(0L)
-            val ranked = shape.rank(total, posArms.map { it.read(0L) }, negArms.map { it.read(0L) })
+            // Every candidate partitions the same locally routed observations, so either side of the
+            // first one sums back to exactly what this leaf can attribute. That, not the leaf arm, is
+            // the evidence a split decision rests on: a merge folds mass into the arm that no
+            // candidate ever saw, and a larger n both shrinks the Hoeffding bound and clears the
+            // weight floor on data the comparison never examined.
+            // An audit leaf is only ever born with a non-empty candidate subset (canGrow gates that),
+            // but mtry is caller data, so index nothing without checking.
+            if (candidates.isEmpty()) return@guarded node
+            val posResults = posArms.map { it.read(0L) }
+            val negResults = negArms.map { it.read(0L) }
+            val attributed = shape.mergePayload(posResults[0], negResults[0])
+            val ranked = shape.rank(attributed, posResults, negResults)
             // shouldSplit holds every gate: the weight floor, a scorable winner, and the
             // Hoeffding-versus-tau disjunction.
-            if (!shouldSplit(ranked, total.totalWeights, depth, config)) return@guarded node
+            if (!shouldSplit(ranked, attributed.totalWeights, depth, config)) return@guarded node
 
             // Stash the pre-split aggregate as the new split's carryover so it shows up in subtree
             // aggregates without burdening the hot path. New leaves start empty, so prior-driven

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStatTest.kt
@@ -228,4 +228,36 @@ class DecisionTreeRegressionStatTest {
             "node count stuck at $afterMerge after merging a snapshot",
         )
     }
+
+    @Test
+    fun `merged mass does not tighten the hoeffding bound`() {
+        // Two candidates that split the stream equally well, so the margin is zero and the decision
+        // rests entirely on the bound. tau sits between the bound at 10 observations (0.387) and at
+        // 20 (0.274), so counting the donor's merged mass as evidence is the only way to clear it.
+        val candidates = listOf(ThresholdSplit(0, 0.0), ThresholdSplit(0, 0.5))
+        fun newStat(seed: Int) = DecisionTreeRegressionStat(
+            featureSize = 1,
+            splitCandidates = candidates,
+            config = RegressionTreeConfig(
+                splitPeriod = 10,
+                minSamplesSplit = 8.0,
+                minSamplesLeaf = 2.0,
+                tau = 0.30,
+            ),
+            randomSeed = seed,
+        )
+        fun drive(stat: DecisionTreeRegressionStat, n: Int) {
+            repeat(n) { stat.update(feat(if (it % 2 == 0) -1.0 else 1.0), if (it % 2 == 0) -1.0 else 1.0) }
+        }
+
+        val donor = newStat(11)
+        drive(donor, 10)
+        val merged = newStat(12)
+        merged.merge(donor.read(0L))
+        drive(merged, 10)
+
+        val control = newStat(12)
+        drive(control, 10)
+        assertEquals(control.tree().nodeCount, merged.tree().nodeCount)
+    }
 }


### PR DESCRIPTION
## What changed

- The split audit ranks candidates and tests the Hoeffding bound against the weight its candidate arms attributed, rather than the leaf's own arm.

## Why

The leaf arm accumulates every observation routed to it plus anything a merge folded in, while the candidate arms only ever see locally routed observations, because a merge cannot attribute foreign mass to a candidate's two sides. The two therefore disagree on a merged leaf: two replicas of 20 observations each, merged, leave the arm at 40 and every candidate at 10 plus 10.

The weight floor was already safe, since rankCandidates independently rejects a candidate whose two sides sum below minSamplesSplit. What was not safe is the bound. A larger n shrinks `sqrt(-ln(delta * decay^depth) / 2n)`, so a merged leaf tested its margin against a tighter epsilon than the compared statistics justify, and the tau tie-break fired sooner. The effect is one-sided: always more permissive, never less.

Every candidate partitions the same locally routed observations, so either side of the first one sums back to exactly the attributable weight. Without a merge that equals the arm, so nothing changes for an ordinary tree.

## Testing

Two candidates that split the stream equally well, so the margin is zero and the decision rests entirely on the bound, with tau placed between the bound at 10 observations (0.387) and at 20 (0.274). A leaf that merged a 10-observation donor and then saw 10 of its own splits under the old code and does not under the new one, matching a control that saw the same 10 local observations. The test fails without the fix with 3 nodes against the control's 1.

`./gradlew check lintDocs` passes on every target.
