### PR TITLE
fix: saturate sketch counters instead of wrapping them negative

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchStat.kt
@@ -148,7 +148,7 @@ class CountMinSketchStat(
         val w = weight.toCounterStep()
         for (row in 0 until depth) {
             val idx = (hasher.mix(value xor rowSalts[row]) and mask).toInt()
-            counters.add(row * width + idx, w)
+            counters.addSaturating(row * width + idx, w)
         }
         totalSeen.add(1L)
     }
@@ -166,11 +166,9 @@ class CountMinSketchStat(
         require(values.counters.size == counterCount) {
             "Cannot merge CountMinSketchStat: expected $counterCount counters, got ${values.counters.size}"
         }
-        // Unclamped by design: MAX_COUNTER_STEP bounds one increment, never the running total, which
-        // an ordinary update stream grows past the same bound just as merging does.
         for (i in 0 until counterCount) {
             val incoming = values.counters[i]
-            if (incoming != 0L) counters.add(i, incoming)
+            if (incoming != 0L) counters.addSaturating(i, incoming)
         }
         totalSeen.add(values.totalSeen)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SketchInternals.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.sketch
 
 import com.eignex.kumulant.math.HasherRef
+import com.eignex.kumulant.stream.StreamLongArray
 import kotlin.math.ceil
 
 /**
@@ -10,6 +11,31 @@ import kotlin.math.ceil
  * update cannot wrap it negative, either of which breaks the one-sided guarantee.
  */
 internal const val MAX_COUNTER_STEP: Long = Long.MAX_VALUE / 1024
+
+/**
+ * Sum that pins at [Long.MAX_VALUE] instead of wrapping.
+ *
+ * [MAX_COUNTER_STEP] bounds one increment, never the running total, so a long enough stream overflows a
+ * counter whatever the step was. A wrapped counter reads *below* the true count, which is the one thing
+ * a sketch built on a one-sided overestimate must never do; pinned at the ceiling it stays useless but
+ * sound. Only upward overflow is guarded, since a sketch never subtracts its way past the floor.
+ */
+internal fun saturatingPlus(a: Long, b: Long): Long = if (b > 0L && a > Long.MAX_VALUE - b) Long.MAX_VALUE else a + b
+
+/**
+ * Add [delta] at [index], pinning at [Long.MAX_VALUE] rather than wrapping.
+ *
+ * A read-modify-write rather than a blind add, which a striped adder would not support - but the
+ * HighWrite mode hands array cells to the atomic backing rather than striping them, so the
+ * compare-and-set is there on every concurrency level.
+ */
+internal fun StreamLongArray.addSaturating(index: Int, delta: Long) {
+    while (true) {
+        val current = load(index)
+        val next = saturatingPlus(current, delta)
+        if (next == current || compareAndSet(index, current, next)) return
+    }
+}
 
 /**
  * Round a fractional observation weight up to the integer counter step a sketch can hold.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/sketch/SpaceSavingStat.kt
@@ -167,8 +167,8 @@ class SpaceSavingStat(
     private fun admitClassic(key: Long, addCount: Long, addError: Long) {
         for (i in 0 until capacity) {
             if (counts.load(i) > 0L && keys.load(i) == key) {
-                counts.add(i, addCount)
-                errors.add(i, addError)
+                counts.addSaturating(i, addCount)
+                errors.addSaturating(i, addError)
                 return
             }
         }
@@ -190,8 +190,8 @@ class SpaceSavingStat(
             }
         }
         keys.store(minIdx, key)
-        counts.store(minIdx, minCount + addCount)
-        errors.store(minIdx, minCount + addError)
+        counts.store(minIdx, saturatingPlus(minCount, addCount))
+        errors.store(minIdx, saturatingPlus(minCount, addError))
     }
 
     /**
@@ -204,8 +204,8 @@ class SpaceSavingStat(
             var matched = false
             for (i in 0 until capacity) {
                 if (counts.load(i) > 0L && keys.load(i) == key) {
-                    counts.add(i, addCount)
-                    errors.add(i, addError)
+                    counts.addSaturating(i, addCount)
+                    errors.addSaturating(i, addError)
                     matched = true
                     break
                 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/sketch/CountMinSketchTest.kt
@@ -135,4 +135,14 @@ class CountMinSketchTest {
         assertFailsWith<IllegalArgumentException> { CountMinSketchStat(depth = 5, width = 0) }
         assertFailsWith<IllegalArgumentException> { CountMinSketchStat(depth = 5, width = 1000) }
     }
+
+    @Test
+    fun `a saturating counter never reads below the true count`() {
+        val cms = CountMinSketchStat(depth = 5, width = 1024)
+        // MAX_COUNTER_STEP is the largest single increment, so a little over 1024 of them is what it
+        // takes to run a counter past Long.MAX_VALUE.
+        val step = (Long.MAX_VALUE / 1024).toDouble()
+        repeat(1100) { cms.update(42L, weight = step) }
+        assertEquals(Long.MAX_VALUE, cms.read(0L).estimate(42L))
+    }
 }


### PR DESCRIPTION
## What changed

- Added `saturatingPlus` and `StreamLongArray.addSaturating` to the sketch internals.
- CountMinSketchStat uses them on both its update and merge paths.
- SpaceSavingStat uses them wherever a counter or error accumulates, which also covers its merge, since merge routes through the two admit paths.

## Why

`MAX_COUNTER_STEP` bounds a single increment at `Long.MAX_VALUE / 1024`, never the running total, so a little over 1024 saturated operations overflow a counter. That happens on the update path exactly as readily as on merge, so the older reading of this as a merge-only hole was wrong.

Wrapping is the one failure a count-min sketch cannot absorb. `estimate(x) >= true count(x)` is the whole contract, and a wrapped counter reads far below the true count: driving one key past the boundary returned an estimate of -8538824893494461516. In SpaceSavingStat a wrapped count also drops the entry out of `read()`'s `count > 0` filter, so a heavy hitter disappears rather than being reported wrong.

Pinned at `Long.MAX_VALUE` the counter is useless but still an overestimate, so the guarantee holds at every magnitude. That tradeoff is deliberate: with a fixed-width counter you cannot both refuse to wrap and refuse to undercount once true counts exceed the width, and saturating picks the side the sketch's contract is stated in terms of.

The read-modify-write is available on every concurrency level because the HighWrite mode hands array cells to the atomic backing rather than striping them, so no mode change and no lock was needed.

## Testing

A test drives one key past the boundary with maximum-weight updates and asserts the estimate pins at `Long.MAX_VALUE`. It fails without the fix with the negative estimate quoted above. `./gradlew check lintDocs` passes on every target.
