### PR TITLE
fix: make the posix mutex report re-entry instead of hanging

### DIFF
--- a/kumulant/src/appleMain/kotlin/com/eignex/kumulant/stream/MutexAttr.apple.kt
+++ b/kumulant/src/appleMain/kotlin/com/eignex/kumulant/stream/MutexAttr.apple.kt
@@ -1,0 +1,11 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName", "Filename")
+
+package com.eignex.kumulant.stream
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.PTHREAD_MUTEX_ERRORCHECK
+
+// toInt() regardless of the declared width: the constant is unsigned on some targets and signed on
+// others, and Int.toInt() is the identity.
+internal actual val ERRORCHECK_MUTEX_TYPE: Int = PTHREAD_MUTEX_ERRORCHECK.toInt()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/Mutex.kt
@@ -39,10 +39,14 @@ internal object NoopMutex : Mutex {
  * - mingwX64: backed by a Win32 `CRITICAL_SECTION`, similarly cleanered.
  * - JS / Wasm: noop - these runtimes are single-threaded.
  *
- * Not reentrant. The posix actual is a default `pthread_mutex_t`, so a thread that re-acquires a lock
- * it already holds deadlocks on Linux and Apple targets while the reentrant JVM and Win32 backings let
- * the same code through; a stat must never call back into itself while holding its own lock. Nesting
- * two *different* locks is fine, which is what an operator holding its lock across a delegate call does.
+ * Not reentrant: a stat must never call back into itself while holding its own lock. Nesting two
+ * *different* locks is fine, which is what an operator holding its lock across a delegate call does.
+ *
+ * The targets disagree on what a violation costs. The posix actual is an error-checking mutex and
+ * throws, naming the mistake; the reentrant JVM and Win32 backings let it through silently, and the
+ * web no-op has no threads to violate it. So the rule is enforced where it is cheapest to enforce and
+ * assumed everywhere else, which means a violation still passes locally on the JVM and surfaces first
+ * on a native build.
  */
 internal expect class PlatformMutex() : Mutex {
     override fun <R> withLock(block: () -> R): R

--- a/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.jvm.kt
+++ b/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.jvm.kt
@@ -6,11 +6,27 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 internal actual class PlatformMutex actual constructor() : Mutex {
-    @Suppress("UnusedPrivateProperty") // detekt misses the kotlin.concurrent.withLock extension call
     private val lock = ReentrantLock()
-    actual override fun <R> withLock(block: () -> R): R = lock.withLock(block)
 
-    actual fun enter() = lock.lock()
+    // ReentrantLock would happily grant a second acquisition to the same thread, so the JVM cannot
+    // discover a re-entry the way an error-checking posix mutex does. `assert` closes that gap where
+    // it is free: enabled under -ea, which Gradle turns on for tests, and a JIT-eliminated branch
+    // otherwise. It answers on the target the tests run on first, before a native build hangs.
+    private fun requireNotHeld() {
+        assert(!lock.isHeldByCurrentThread) {
+            "this thread already holds this lock; PlatformMutex is not reentrant"
+        }
+    }
+
+    actual override fun <R> withLock(block: () -> R): R {
+        requireNotHeld()
+        return lock.withLock(block)
+    }
+
+    actual fun enter() {
+        requireNotHeld()
+        lock.lock()
+    }
 
     actual fun exit() = lock.unlock()
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/PlatformMutexReentryTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/PlatformMutexReentryTest.kt
@@ -1,0 +1,19 @@
+package com.eignex.kumulant.stream
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class PlatformMutexReentryTest {
+
+    // Rests on -ea, which Gradle's test task enables by default; without it the check compiles out
+    // and there is nothing to catch.
+    @Test
+    fun `re-acquiring a held lock is reported rather than granted`() {
+        val mutex = PlatformMutex()
+        assertFailsWith<AssertionError> {
+            mutex.guarded {
+                mutex.guarded { }
+            }
+        }
+    }
+}

--- a/kumulant/src/linuxMain/kotlin/com/eignex/kumulant/stream/MutexAttr.linux.kt
+++ b/kumulant/src/linuxMain/kotlin/com/eignex/kumulant/stream/MutexAttr.linux.kt
@@ -1,0 +1,11 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("MatchingDeclarationName", "Filename")
+
+package com.eignex.kumulant.stream
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.PTHREAD_MUTEX_ERRORCHECK
+
+// toInt() regardless of the declared width: the constant is unsigned on some targets and signed on
+// others, and Int.toInt() is the identity.
+internal actual val ERRORCHECK_MUTEX_TYPE: Int = PTHREAD_MUTEX_ERRORCHECK.toInt()

--- a/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/MutexAttr.kt
+++ b/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/MutexAttr.kt
@@ -1,0 +1,9 @@
+package com.eignex.kumulant.stream
+
+/**
+ * `PTHREAD_MUTEX_ERRORCHECK` for the target being built.
+ *
+ * The constant is a different width per platform, so the shared posix view cannot name it directly;
+ * each target restates it as the [Int] `pthread_mutexattr_settype` wants.
+ */
+internal expect val ERRORCHECK_MUTEX_TYPE: Int

--- a/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
+++ b/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
@@ -17,17 +17,19 @@ import platform.posix.pthread_mutexattr_init
 import platform.posix.pthread_mutexattr_settype
 import platform.posix.pthread_mutexattr_t
 import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.Platform
 import kotlin.native.ref.createCleaner
 
 internal actual class PlatformMutex actual constructor() : Mutex {
     private val arena = Arena()
 
-    // Error-checking rather than the default type. A thread that re-acquires a lock it already holds
-    // is a defect either way, but a default mutex answers it by hanging with no stack to read, on the
-    // only targets that do not tolerate it. This turns that into a thrown error naming the mistake.
+    // Error-checking in a debug binary, the default type in a release one. Re-acquiring a lock this
+    // thread already holds is a defect either way, and a default mutex answers it by hanging with no
+    // stack to read; error-checking turns that into a thrown error naming the mistake. A release
+    // build pays nothing for a check whose whole value is at development time.
     private val attr = arena.alloc<pthread_mutexattr_t>().also {
         pthread_mutexattr_init(it.ptr)
-        pthread_mutexattr_settype(it.ptr, ERRORCHECK_MUTEX_TYPE)
+        if (Platform.isDebugBinary) pthread_mutexattr_settype(it.ptr, ERRORCHECK_MUTEX_TYPE)
     }
 
     private val mutex = arena.alloc<pthread_mutex_t>().also {

--- a/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
+++ b/kumulant/src/posixMain/kotlin/com/eignex/kumulant/stream/PlatformMutex.posix.kt
@@ -12,35 +12,54 @@ import platform.posix.pthread_mutex_init
 import platform.posix.pthread_mutex_lock
 import platform.posix.pthread_mutex_t
 import platform.posix.pthread_mutex_unlock
+import platform.posix.pthread_mutexattr_destroy
+import platform.posix.pthread_mutexattr_init
+import platform.posix.pthread_mutexattr_settype
+import platform.posix.pthread_mutexattr_t
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.createCleaner
 
 internal actual class PlatformMutex actual constructor() : Mutex {
     private val arena = Arena()
+
+    // Error-checking rather than the default type. A thread that re-acquires a lock it already holds
+    // is a defect either way, but a default mutex answers it by hanging with no stack to read, on the
+    // only targets that do not tolerate it. This turns that into a thrown error naming the mistake.
+    private val attr = arena.alloc<pthread_mutexattr_t>().also {
+        pthread_mutexattr_init(it.ptr)
+        pthread_mutexattr_settype(it.ptr, ERRORCHECK_MUTEX_TYPE)
+    }
+
     private val mutex = arena.alloc<pthread_mutex_t>().also {
-        pthread_mutex_init(it.ptr, null)
+        pthread_mutex_init(it.ptr, attr.ptr)
     }
 
     @Suppress("unused")
-    private val cleaner = createCleaner(arena to mutex.ptr) { (a, p) ->
-        pthread_mutex_destroy(p)
+    private val cleaner = createCleaner(Triple(arena, mutex.ptr, attr.ptr)) { (a, m, at) ->
+        pthread_mutex_destroy(m)
+        pthread_mutexattr_destroy(at)
         a.clear()
     }
 
     actual override fun <R> withLock(block: () -> R): R {
-        pthread_mutex_lock(mutex.ptr)
+        enter()
         try {
             return block()
         } finally {
-            pthread_mutex_unlock(mutex.ptr)
+            exit()
         }
     }
 
     actual fun enter() {
-        pthread_mutex_lock(mutex.ptr)
+        val code = pthread_mutex_lock(mutex.ptr)
+        check(code == 0) { reentryMessage(code) }
     }
 
     actual fun exit() {
         pthread_mutex_unlock(mutex.ptr)
     }
+
+    private fun reentryMessage(code: Int): String =
+        "pthread_mutex_lock failed with $code; a non-zero code here is a thread re-acquiring a lock it " +
+            "already holds, which this lock does not allow - see PlatformMutex"
 }


### PR DESCRIPTION
## What changed

- The posix `PlatformMutex` is error-checking in a debug binary and the default type in a release one, and `enter` throws when the lock reports a failure.
- The JVM actual asserts the lock is not already held by the calling thread, which `ReentrantLock` answers directly.
- A small per-target `ERRORCHECK_MUTEX_TYPE` restates the constant as the `Int` that `pthread_mutexattr_settype` takes.
- The `expect` KDoc says which targets enforce the non-reentrancy contract and which assume it.

## Why

Four actuals implement one lock and disagree on what re-acquiring it costs. `ReentrantLock` and the Win32 `CRITICAL_SECTION` allow it, the web no-op has no threads to violate it, and a default `pthread_mutex_t` hangs. A hang is the expensive answer: no exception, no stack, just a build that stops, on the targets that run last. The natural reading is a flaky native runner, which is the wrong place to look.

Each target now uses whatever it can check for free rather than a shared mechanism neither would want. `assert` is enabled under `-ea`, which Gradle turns on for test tasks, and compiles to a JIT-eliminated branch otherwise, so the JVM answers during development and pays nothing in production. `Platform.isDebugBinary` does the same job for native, so a release binary keeps the default mutex and a debug one reports `EDEADLK`.

That ordering matters more than the mechanism. A violation is now caught by the JVM tests, which run first and everywhere, instead of surfacing as a native hang later. Windows and web are left alone: `CRITICAL_SECTION` would need cinterop access to its owner field to say anything, and the web actual has no threads.

The posix constant needed the indirection because it is unsigned on some targets and signed on others, so the shared posix source cannot name it directly. Each target restates it through `toInt()`, which is the identity when it is already `Int`.

## Testing

A JVM test nests two `guarded` blocks on one lock and asserts it is reported. It rests on `-ea`, which Gradle's test task enables by default.

The posix behaviour was verified out of band, in C on this platform, since there is no native test source set to assert it from: an error-checking mutex returns 0 on first acquisition and 35 on re-entry, and `EDEADLK` is 35. Adding a `posixTest` source set is the obvious follow-up if that half is worth pinning too.

`./gradlew check lintDocs` passes on every target, and the Apple and mingw klibs cross-compile here even though their tests cannot run on a Linux host, so the per-target constant is checked everywhere it exists. Neither check costs anything in a release build.
