### PR TITLE
fix: keep stateful operator state alive across window slices

### DIFF
--- a/docs/internal/BUG_HUNT_2026-08-19.md
+++ b/docs/internal/BUG_HUNT_2026-08-19.md
@@ -1,0 +1,440 @@
+# Bug hunt 2026-08-19
+
+Eight parallel read-only audits over the whole library, partitioned by package. Prior sweeps
+(`BUG_HUNT_2026-08-15.md`, `BUG_HUNT_2026-08-18.md`) were read first by every auditor; nothing below
+repeats a finding from either, and several of their fixes were re-verified as still in place.
+
+49 findings. Severity is about blast radius on a correct caller, not about how hard the fix is.
+
+## Cross-cutting themes
+
+- **`isInertWeight()` used where `isNotPositiveWeight()` belongs.** Seven stats admit a negative weight
+  and then run it as a forward observation, because the guard that permits downdates was applied to a
+  recurrence that has no inverse: #17, #24, #26 (four stats), #40. Related but distinct: #11, where an
+  inverse exists but bagging randomises it away.
+- **NaN admitted as a real observation.** `coerceIn`/`coerceAtLeast`/`< 0.0` are all false for NaN, so a
+  NaN slips past four different guards that look like they cover it: #8, #20, #28, #43.
+- **`WindowsInside` only half-wired.** The 08-18 #20 fix introduced the interface but left three stateful
+  operators unclassified and three of the four `windowed` entry points never consulting it: #3, #4, #16.
+- **State mutated outside the lock that rotates or clears it.** #14, #27, #45, and the `reset()` half of #6.
+
+---
+
+## Critical
+
+### 1. `SpaceSavingStat` Misra-Gries admission spins once per unit of the minimum count
+`stat/sketch/SpaceSavingStat.kt:201-243`
+
+`admitMisraGries` retries `while (true)` and frees a slot only by decrementing every count by exactly 1
+per iteration, so the loop runs `min(counts)` times regardless of `addCount`. Classic MG does one
+decrement round and discards the item; the amortisation argument that makes MG O(1) does not apply here.
+
+`SpaceSavingStat(capacity = 1)`; `update(1L, weight = 1e18)` gives count `9_007_199_254_740_992`
+(`toCounterStep` caps at `Long.MAX_VALUE / 1024`), then `update(2L, weight = 1.0)` performs ~9e15 atomic
+decrements and never returns. The ordinary shard-and-merge path hits it too: `merge` feeds every incoming
+triple through the same routine, so merging two capacity-1024 shards with counts ~1e6 costs ~1e12 atomic ops.
+
+Fix: decrement by the minimum (or by `addCount`) in one round and charge the deficit by that amount, as
+`admitClassic` already does in a single step.
+
+## High
+
+### 2. One future-dated timestamp permanently kills a `SliceRing` bucket
+`stream/SliceRing.kt:57-69`, `operation/WindowedStats.kt:78`
+
+`slotFor` rotates a bucket to any newer slice start and thereafter returns `null` — a silent drop — for
+every timestamp mapping to that bucket but older than the installed start. `forEachActive` also excludes
+the poisoned slot. One stamp accidentally produced in milliseconds, or from a skewed producer, costs
+`Mean.windowed(60.seconds)` exactly 1/10 of its input until wall clock reaches the bogus start.
+
+The 08-15 doc justified the `null` return as "only drops writes a full window stale", which holds for late
+stamps, not future ones. Fix: reject or clamp a stamp more than one window ahead rather than rotating on it.
+
+### 3. `withSelfLag` is not `WindowsInside`, so a window resets its ring every slice
+`operation/WithSelfLag.kt:38-40`
+
+Same `tick` + `ring` state as `LagSeriesStat` and `DiffSeriesStat`, both of which implement the interface.
+`Covariance.withSelfLag(1).windowed(60_000)` at one observation per 10 s: every observation lands in a
+freshly created slice whose `tick` goes 0 to 1, `n > k` is false, and the inner stat receives nothing —
+`read()` reports count 0 forever. Reachable from `PairedStatSpec.withSelfLag` then `.windowed`.
+
+### 4. `windowed()` on paired / vector / discrete stats never consults `WindowsInside`
+`operation/WindowedStats.kt:36-40, 43-47, 50-54`
+
+Only the `SeriesStat` overload dispatches on the interface, and the three `Throttle{Paired,Vector,Discrete}`
+wrappers do not implement it. `Covariance.throttle(10).windowed(60_000)` at 1 update/s gives each 6-second
+slice a fresh gate at count 0, so `tick % 10 == 0` never fires and the inner covariance stays empty for the
+lifetime of the stream. `Mean.throttle(10).windowed(60_000)` is correct — the same composition behaves
+differently purely by modality.
+
+### 5. `DecayingSumStat` returns NaN for timestamps behind its construction landmark
+`stat/decay/DecayingSumStat.kt:78-80, 88-95, 104-109`
+
+The landmark seeds to `currentTimeNanos()` (nanoseconds since *process start*) and never snaps to the first
+observation. A process up 120 s constructing `DecayingSumStat(100.milliseconds)` and replaying a stream
+numbered from its own epoch: `update(5.0, 0L)` folds in `5.0 * exp(-831) == 0.0`, and `read(0L)` multiplies
+by `exp(+831)` giving `0.0 * Infinity == NaN`. Threshold is ~1075 half-lives of offset. Propagates to
+`DecayingMeanStat` and `DecayingRateStat`.
+
+`DecayingVarianceStat.advanceTo:92-99` defends against exactly this and says so in a comment; the two
+time-decay stats disagree on the same input.
+
+### 6. `DecayingSumStat` epoch rotation drops concurrent updates
+`stat/decay/DecayingSumStat.kt:87-93, 98-101`
+
+`update` loads the epoch then adds into `epoch.accumulator`; `tryRotateEpoch` snapshots the old accumulator
+and CASes a whole new `Epoch` with a fresh cell. A thread that loads E1, is preempted, and adds after the
+swap writes into an orphaned accumulator that is never read again. The stat takes no lock at any level.
+Rotation fires whenever `now - landmark > 50 * halfLife` — roughly every 50 s at a 1 s half-life — so the
+window opens repeatedly. Violates the never-drop-an-update rule.
+
+### 7. `CounterRateStat` ignores a counter reset to exactly `0.0`
+`stat/rate/CounterRateStat.kt:88-100`
+
+The decrease-as-reset branch clears the total and re-anchors only inside `if (scaledDelta > 0.0)`. A counter
+restarting at exactly `0.0` — the most common Prometheus-style `*_total` restart — never registers the reset:
+`totalDelta` keeps every pre-reset increment and the window stays anchored at the old start, while
+`lastCounter` advances to `0.0`. A stream restarting at `50.0` instead reports `8/s` where restarting at
+`0.0` reports `4.33/s` over the same events.
+
+### 8. One NaN reward pins `BoltzmannBandit.choose()` to the last arm forever
+`bandit/univariate/BoltzmannBandit.kt:88-96`
+
+`playDistribution()` discards the `Boolean` that `softmaxInPlace` returns to signal an unusable distribution.
+`MeanStat` never guards `value`, so `update(0, Double.NaN)` makes that arm's mean NaN permanently; one NaN
+logit makes `z` NaN, `z <= 0.0` is false for NaN, and `sampleFromDistribution` falls through to
+`return p.size - 1` for every draw. Absorbing — no recovery path.
+
+`Exp3Bandit:105-109` and `Exp4Bandit:147-151` already fix this exact defect and carry a comment naming the
+symptom. Boltzmann was missed.
+
+### 9. `PageHinkleyStat.merge` manufactures an alarm from two non-alarming traces
+`stat/change/PageHinkleyStat.kt:123-126`
+
+The alarm statistic is `cumPos - minPos`, but the two halves merge by different operators: `cumPos` is
+averaged toward the other trace while `minPos` takes the extremum. The merged pair is one neither trace ever
+held. A downward-shift trace (`cumPos = minPos = -208.6`, no alarm) merged with a flat trace
+(`cumPos = minPos = -0.6`, no alarm) gives `cumPos = -104.6`, `minPos = -208.6`, so `104.0 > 50` fires.
+Symmetric on the `alarmDown` side. Fix: average the baseline the same way as the signal.
+
+### 10. `HdrHistogramStat.merge` indexes `counts` with a negative index
+`stat/quantile/HdrHistogramStat.kt:152-161, 110-119, 131-143`
+
+`update` enforces `require(!(value < 0.0))`; `merge` enforces nothing and converts each incoming
+`lowerBounds[i]` straight to an internal Long. `getIndex` returns it unchanged when below `subBucketCount`,
+which is true for every negative value, so `addInternal` does `counts[-5000]`. Reachable through public API:
+`hdr.merge(ddSketch.read().toSparseHistogram())` where the DDSketch saw any negative value. Silent variant:
+a `LinearHistogramStat` underflow row has `-Infinity` as its bound, whose `.toLong().toInt()` is `0`, so the
+weight is filed into bucket 0 instead of throwing.
+
+### 11. Bagging destroys the negative-weight downdate both forests advertise
+`stat/regression/tree/RandomForestRegressionStat.kt:96-99`, `RandomForestClassifierStat.kt:274-277`
+
+Both admit negative weights via `isInertWeight()` and both comment that a negative weight is a real
+downdate. But with `bagging = true` each tree's weight is multiplied by a *fresh* `Poisson(1)` draw, so the
+retraction gets a different multiplier than the insertion. Insert with `k = 2` then retract with `k' = 3`
+leaves `counts[0] = -1.0`, and `probabilities()` returns `[-0.25, 1.25]`. The regression forest throws
+instead: `weight = -3.0` into a `VarianceStat` holding `2.0` trips `requireLiveWeight`.
+
+### 12. Tree/forest posteriors collapse to a point on a one-observation leaf
+`stat/regression/tree/TreePosteriors.kt:48, 68, 104, 124`
+
+`priorVariance` applies only when `totalWeights == 0.0`, but a leaf with exactly one observation has
+`totalWeights = 1.0` and `variance` exactly `0.0` (`sst += priorW * delta * r` with `priorW = 0`). So
+`ThompsonTreePosterior` draws `nextNormal(mean, 0.0)` — the same value every round, forever — and
+`UcbTreePosterior` gets no confidence bonus at all. Driving a contextual bandit, an arm whose single
+observation was unlucky is locked out permanently with no exploration left to recover it. Both forest
+variants collapse identically. The KDoc claims a "weak prior" on the precision; there is none in the code.
+
+### 13. Group `merge` mutates children before validating, and three declarable stats abort it midway
+`schema/runtime/StatGroup.kt:54-56`, `schema/runtime/ListStats.kt:56-63`
+
+`merge` walks entries in declaration order with no pre-validation. `QuantileFilterStat:86`,
+`IsotonicCalibratorStat:169` and `Band.kt:35` all throw unconditionally from `merge` and are all reachable
+from a `StatSpec`. A schema declaring `hits`, `p99`, `total` in that order merges `hits`, throws on `p99`,
+and never touches `total` — so a caller that catches the exception around a shard roll-up is left with
+`hits` counting both shards and `total` counting one. Entry order decides the damage.
+
+## Medium
+
+### 14. `reset()` on the three ring operators runs outside the lock their `update` holds
+`operation/Shifts.kt:78-82, 116-120`, `operation/WithSelfLag.kt:64-68`
+
+`update` guards the tick-claim/ring-load/ring-store triple precisely because splitting it lets a writer read
+an unfilled slot and forward the ring's initial `0.0`. `reset()` then zeroes every slot without the lock. On
+a stream around 1e6, a `reset()` landing between a writer's `tick.addAndGet` and its `ring.load` makes the
+writer forward a fabricated `1_000_000.0` difference into a stat that was just supposed to be empty.
+`ResampleByTimeStat.reset:145` shows the correct pattern one file over.
+
+### 15. `ResampleByTimeStat` rejects a legal downdate using the wrong bucket's prior
+`operation/Resample.kt:89` vs `:95-99`
+
+The guard distinguishes two destinations but there are three: when `newBucket < cur` the weight is routed
+into the open bucket, yet the guard already charged it against a prior of `0.0`. With `bucket = 1000 ns`,
+after seeding bucket 1 with weight 3.0, `update(20.0, t = 500, w = -1.0)` throws — while the same weight at
+`t = 1500` is accepted and lands in the same bucket. Whether a legal downdate throws depends only on a
+timestamp the operator then ignores.
+
+### 16. `withFeedback` and the scalers are not `WindowsInside`
+`operation/Feedback.kt:41-46`, `operation/Scalers.kt:37-45`
+
+A slice rotation rebuilds the primary from scratch, and both projections degrade to a constant while the
+primary is degenerate. `Mean.standardScaler().windowed(60_000)` at one observation per 10 s: every
+observation is the first into a fresh `VarianceStat`, variance is 0, the projection emits `0.0`, and the
+inner mean reports `0.0` regardless of input. On a fast stream the first observation of each of the 10
+slices per window is still forced to `0.0`.
+
+### 17. `CounterRateStat` destroys a counter increment on a negative weight
+`stat/rate/CounterRateStat.kt:63, 79`
+
+A counter high-water mark has no inverse: line 79 clamps with `.coerceAtLeast(0.0)` so the delta is dropped,
+then lines 84-85 advance `lastCounter`/`lastTimestampNanos` anyway, so no later sample recovers it. The
+file's own comment at 59-62 documents exactly this for zero weight; the negative half was left unfixed.
+
+### 18. `RateStat.merge` discards the window of any shard whose total is `0.0`
+`stat/rate/RateStat.kt:89`, `stat/rate/CounterRateStat.kt:132`
+
+`totalValue == 0.0` is used as a proxy for "never observed anything", but a shard that observed only
+zero-valued events has a real `startTimestampNanos`. Merging a shard spanning 0-8 s (total 0.0) with one
+observation at 9 s gives `100/1s`; one stat fed both streams reports `100/10s`. Needs a `hasObservation`
+flag on `RateResult`, the pattern `RecencyResult` already uses.
+
+### 19. `SojournStat` drags the state-entry timestamp backwards
+`stat/event/SojournStat.kt:94-98`
+
+`elapsed` is clamped to `>= 0`, but `enterTimestamp.store(timestampNanos)` then commits the earlier stamp, so
+the next transition measures dwell from before it happened. Three events at t=100, 50, 200 report 150 ns of
+dwell across a stream spanning 100 ns; in-order replay gives 50.
+
+### 20. `RouletteWheelBandit`: NaN passes the `minWeight` floor
+`bandit/univariate/RouletteWheelBandit.kt:136-137, 99-108`
+
+`coerceAtLeast` is `if (this < min) min else this`, and `NaN < 0.01` is false — so the floor that exists to
+keep weights sane does not catch NaN. `total` is then NaN, `total <= 0.0` is false, and `choose()` returns
+`nbrArms - 1` on every call. Same shape as #8.
+
+### 21. `NormalArm.warmStart` doubles the evidence weight and halves the variance it claims to preserve
+`bandit/univariate/Arms.kt:297-307, 309-319` vs `:176-187`
+
+`createStat` seeds three pseudo-observations totalling `2 * priorWeight`, but `warmStart` computes
+`priorSquaredDeviations = global.variance * priorWeight` assuming the stat will carry `priorWeight`. The
+realised variance is half the global's. `warmStart(global(w=200, var=9), shrinkage = 0.5).createStat()`
+yields `totalWeights = 200.0` (should be 100.0) and `variance = 4.5` (should be 9.0). The KDoc states both
+halves of what does not happen. Downstream the arm is ~2.8x over-confident. `ArmsTest` pins `createStat` but
+never the `warmStart -> createStat` round trip.
+
+### 22. `UCB1Normal` forced exploration uses `ln(nbrArms)` where Auer uses `ln(total pulls)`
+`bandit/univariate/BanditPolicies.kt:227`
+
+`8 * ln(2)` is 5.55, so with two arms forced exploration stops permanently once each arm has ~5.6 weight and
+never returns. The intended threshold at t = 10_000 is ~73.7. The comment ten lines below identifies this
+exact confusion for the log term inside the bound and fixes it with `maxOf(step, nj)`; the gate above was
+left on `nbrArms`.
+
+### 23. Epsilon policies draw the explore coin from `Random(step)`, not `Bandit.random`
+`bandit/univariate/BanditPolicies.kt:331, 371`
+
+`Random(step).nextDouble() < epsilon` makes the decision a fixed function of `t` alone. Two bandits seeded
+`Random(1)` and `Random(2)` explore on exactly the same rounds — an ensemble built via `create(random)` to
+decorrelate exploration explores in lockstep. Worse, a caller who drives `update` + `evaluate` without
+`choose()` leaves `step` at 0, so the coin is one constant: the policy either always explores or never does,
+for its whole lifetime. Separately `evaluate` passes `step.load()` while `choose` passes `step - 1`, so they
+report from different branches.
+
+### 24. EXP3/EXP4 have no inert-weight guard, so a zero-weight update corrupts a later propensity
+`bandit/univariate/Exp3Bandit.kt:120-126`, `bandit/contextual/Exp4Bandit.kt:166-177`
+
+`propensityOf` consumes a pending pull before `weight` is consulted. A `weight = 0.0` update leaves the
+exponential weights untouched but still advances the bookkeeping, so the real feedback for that pull later
+falls back to the *current* distribution: `p = 0.05` instead of the recorded `0.9`, giving `exp(10)` instead
+of `exp(0.56)`. `RouletteWheelBandit:119` and `KnnContextualBandit:162` already apply the early return.
+
+### 25. Stateful policies mutate a shared non-atomic `Double` counter
+`bandit/univariate/BanditPolicies.kt:183/188, 268/273, 361/367, 427/432, 505/510, 556/561`
+
+`UCB1`, `UCB1Tuned`, `EpsilonDecreasing`, `KlUcb`, `Moss` and `UcbV` each do `totalSamples += weight` on a
+plain field, while `MultiArmedBandit`'s KDoc promises racing updates on different arms never block. Lost
+read-modify-write cycles leave the counter well below the true total and it never re-syncs, so every arm's
+exploration bonus is systematically too small. A non-volatile 64-bit field additionally permits a torn read
+on the JVM.
+
+### 26. Four order-dependent stats run a negative weight as a full forward observation
+`stat/change/CusumStat.kt:88`, `PageHinkleyStat.kt:93`, `AdwinStat.kt:90`, `stat/forecast/RecursiveVarianceStat.kt:66`
+
+All four guard with `isInertWeight()` and then never use `weight` at all — none has an inverse. Retracting a
+sample with `CusumStat(threshold = 5.0)` via `update(10.0, weight = -1.0)` sets `cusumPositive = 9.5` and
+raises a change alarm. `AdwinStat` *grows* its window on a retraction. `RecursiveVarianceStat` raises
+variance by 10. As a secondary consequence a weight of `3.0` is also counted as one observation.
+
+### 27. `HalfSpaceTreesStat` reads, updates and merges the mass arrays outside `swapLock`
+`stat/anomaly/HalfSpaceTreesStat.kt:207-217, 229, 256-271` vs `:219-227, 273-280`
+
+`rotateWindow` and `reset` take the lock; `update`, `read` and `merge` do not. `rotateWindow` does a blind
+per-leaf `load` then `store`, not an accumulate. A `merge`'s `referenceMass.add(i, ...)` landing between them
+is overwritten and lost while `totalWeightsCell` still records it — the stat reports a `totalWeights` its
+mass does not back, exactly the failure the merge KDoc says it was fixing. A `read()` mid-rotation snapshots
+a profile that never existed, which is what `Strict` is meant to rule out.
+
+### 28. A NaN prediction is credited to bin 0 as a real observation
+`stat/calibration/ReliabilityStat.kt:120-124`
+
+The comment above these lines describes the defect but no guard follows it: `coerceIn` passes NaN through and
+`NaN.toInt()` is 0. `ReliabilityResult` does go NaN, so the propagation contract holds there — but
+`IsotonicCalibratorStat.read` divides `sumOutcome/totalWeights`, both of which received finite values, so the
+NaN vanishes into a plausible-looking corruption. 100 x `update(0.9, 1.0)` plus 100 x `update(NaN, 1.0)` makes
+PAV return `[1.0, 1.0, 1.0, 1.0]` and `calibrate(0.05)` return `1.0`; without the NaN inputs it is
+`[0.0, 0.0, 0.0, 1.0]`.
+
+### 29. JVM `AdderMode.store()` is a non-atomic two-step, so `HighWrite` tears where no other platform does
+`jvmMain/.../stream/AdderMode.kt:46-49, 72-75`
+
+`ref.reset(); ref.add(value)` — and `Striped64.reset()` zeroes `base` then each cell in turn while `sum()`
+walks the same table. Every non-JVM target maps `highWriteMode` to `AtomicMode`, whose `store` is one atomic
+write. `SumStat(Concurrency.HighWrite)` with a concurrent `reset()` and `read()` returns the partial residue
+of the not-yet-zeroed cells — a value that was never the sum at any instant. `DoubleAdder.reset()` is
+documented as effective only with no concurrent updates; `StreamDouble.store` promises more.
+
+### 30. JVM `AdderMode.addAndGet()` is add-then-sum, not atomic
+`jvmMain/.../stream/AdderMode.kt:55-58, 81-84`
+
+`addAndGet(1L) == 1L` is the library's first-writer election (`CrossingStat:59`, `HoltStat:106`,
+`ExcursionStat:77`, `SeasonalSmoothingStat:210`, `Shifts:141`). With `LongAdder`, two racing threads produce
+`add;add;sum;sum` and both read `2`, so nobody wins and the baseline is never seeded. Not currently reachable
+— every one of those sites is on `monotonicMode()`/`firstWriterMode()` — but the divergence is invisible at
+the call site, and unlike the sibling `compareAndSet` it fails silently instead of throwing.
+
+### 31. `MinHashResult.jaccard` compares signatures without checking the hasher
+`stat/sketch/MinHashStat.kt:71-89` vs `:141`
+
+`merge` refuses a hasher mismatch via `requireSameHasher`; `jaccard` validates only `numHashes` and `seed`.
+Two sketches over identical 1000-element sets built with different mixers report a Jaccard of ~0.0 instead
+of 1.0 — while `merge` on the same pair throws.
+
+### 32. The Hoeffding bound assumes a criterion range of 1, which `VarianceReduction` does not have
+`stat/regression/tree/TreeInternals.kt:157-161`
+
+The VFDT bound is `sqrt(R^2 * ln(1/delta) / 2n)` with `R` the criterion range; `R` is hard-coded to 1 while
+`VarianceReduction` is in units of the variance of `y`. At defaults `eps = 0.223`. With `y ~ N(0, 100^2)`,
+candidate splits on pure noise differ by ~1e2, so `100 > 0.223` passes trivially and the tree splits on
+noise. With `y` in `[0, 1]`, differences are ~5e-3 and the Hoeffding branch is dead — every split comes from
+the `eps < tau` tie-break, i.e. the tree splits on a schedule, not on evidence. `InformationGain` in nats has
+range `ln(K)`, so the bound is 2.3x too narrow at K = 10. Only `GiniReduction` is safely conservative.
+
+### 33. Forest posteriors treat N bagged leaves as N independent samples
+`stat/regression/tree/RandomForestRegressionStat.kt:151-163`, `TreePosteriors.kt:103-104, 123`
+
+`findLeafMerged` Chan-merges the leaf each tree routes `x` to, and the posteriors divide by the merged
+`totalWeights` — but under bagging those are N correlated views of one sample. With 10 trees over 100
+observations the merged weight is ~1000, so Thompson draws with `sd = 0.032` where the honest standard error
+is `0.1`: under-explores by `sqrt(nbrTrees)`. `ForestRegressionResult.totalWeights`'s own KDoc admits the
+inflation.
+
+### 34. Schema-declared `regression` entries have no public group to materialize into
+`schema/runtime/StatSchema.kt:58, 94-100`, `schema/runtime/ListStats.kt:219-235`
+
+The declarator is public but its only consumer, `RegressionListStats`, is `internal`. Every public group
+filters by modality with `mapNotNull`, so a regression entry is silently skipped: `StatGroup(S)` builds an
+empty group and `g.read()[S.model]` throws "Result key 'model' not found. Available: []". The only working
+path is `materializeRegression()` returning a bare list the caller drives by hand.
+
+### 35. A nested `group()` is series-only: mixed nesting hard-fails, non-series nesting silently vanishes
+`schema/runtime/StatSchema.kt:61-63`, `schema/spec/GroupStatSpec.kt:15-18`, `schema/runtime/StatFactory.kt:253-261`
+
+`group(nestedSchema)` accepts any schema but `GroupStatSpec` is a `SeriesStatSpec` and requires every child
+to be one. A schema mixing `series` and `discrete` is legal at the root and fatal one level down —
+`StatGroup(Outer)` throws, while `DiscreteStatGroup(Outer)` silently produces no entries because
+`GroupStatSpec` is not a `DiscreteStatSpec`. The discrete view of a nested subtree is unreachable by any means.
+
+### 36. `band(k)` accepts any series spec and fails with a bare `ClassCastException` at read
+`schema/ops/Operations.kt:214`, `schema/runtime/StatFactory.kt:343-349`
+
+The `HasCenterScale` bound is enforced on the live op but erased on the spec path, and `BandSeries` checks
+nothing at materialize time. `Sum.band(2.0)` compiles, materializes, and accepts updates; the first `read()`
+throws `ClassCastException: SumResult cannot be cast to HasCenterScale` with no mention of `band`, the stat,
+or the schema key — and inside a `StatGroup` it takes down the whole `read()`.
+
+### 37. `transformX` misreports `featureSize` as the post-transform width
+`schema/spec/Operations.kt:780-788`, `operation/RegressionOps.kt:97-108`
+
+`featureSize` is contractually the width expected on `update`, but the wrapper reports the inner
+post-transform width. `StochasticRegression(featureSize = 3).transformX(vectorOf(V(0), V(1), V(0) * V(1)))`
+reports 3 while `update` wants 2; a caller sizing its input from `featureSize` sends 3 coordinates and the
+third is silently dropped. `RegressionListStats` then rejects it beside a genuine 2-feature regressor, the
+honest number being the one it calls wrong. `FoldRegression` already carries an explicit pre-transform width.
+
+### 38. `DDSketchStat` and `TDigestStat` share their `probabilities` array with every snapshot and replica
+`stat/quantile/DDSketchStat.kt:109, 163, 208`, `stat/quantile/TDigestStat.kt:373, 429, 470`
+
+The constructor array is stored by reference, handed out in every `read()` result, and passed to every
+`create()` replica. Mutating what looks like a caller's own copy re-labels the stat's quantiles and every
+replica in a shard fan-out. `ThresholdBucketStat` already does `thresholds.copyOf()` in `create` and
+`toList()` in `read`.
+
+## Low
+
+### 39. `CrossingStat.merge` never validates the level
+`stat/event/CrossingStat.kt:70-73` — folding a snapshot taken at `level = 100.0` into a `CrossingStat(level = 0.0)`
+adds counts from a different predicate and reports them under the local level. Same class as 08-18 #12;
+`SojournStat:104` shows the missing pattern. `merge` also leaves `initialized`/`lastSide` untouched, so the
+first update after merging into a fresh stat is consumed as a baseline.
+
+### 40. `KnnContextualBandit` treats its reservoir as invertible
+`bandit/contextual/KnnContextualBandit.kt:163` — a bounded k-NN history has no inverse, so
+`update(0, x, 10.0, -1.0)` appends a *second* phantom sample carrying weight `-1.0`. With `k = 1` and both at
+distance 0, `sumW` is `-1.0`, so `evaluate` reports the cold-start score and bonus while two real
+observations have consumed history slots. `ReservoirHistogramStat` uses `isNotPositiveWeight()`.
+
+### 41. `KnnContextualBandit` never validates the context dimension
+`bandit/contextual/KnnContextualBandit.kt:151-177` — the only check is inside `squaredL2`, which runs once an
+arm has `k` stored contexts. Four `dim3` updates then a `dim7` update all succeed; the fifth `choose(dim3)` is
+the first to throw, from a distance kernel rather than the entry point that accepted the bad data. Custom
+`distance` functions that skip the check compute garbage instead. `RegressionContextualBandit` and
+`TrackedContextualBandit` both validate.
+
+### 42. `SeasonalSmoothingResult.forecast` overflows `Int` in the seasonal-index arithmetic
+`stat/forecast/SeasonalSmoothingStat.kt:235` — `currentSlot + steps - 1` is `Int`. The `+ period) % period`
+renormalisation keeps the index in range so nothing throws, but the slot is wrong whenever `period` is not a
+power of two: `period = 3, currentSlot = 2, forecast(Int.MAX_VALUE)` returns `seasons[1]` where `seasons[2]`
+is correct. `dampedTrendSum` was given a closed form precisely so huge horizons are cheap.
+
+### 43. A NaN downdate norm skips the repair branch and desynchronises `covariance` from `covarianceL`
+`stat/regression/glm/BayesianRegressionStat.kt:176, 183` — `choleskyDowndateInPlace` was hardened to *return* a
+NaN norm rather than write NaN through the factor, but the caller's guard `norm >= 1.0` is false for NaN, so
+it falls through to the `ger` that the comment above it says must not happen without the factor. Requires a
+non-finite already in `covarianceL` or an `Inf` at a coordinate `x` does not store, so it is a robustness hole
+rather than a demonstrated failure — but the desync is permanent. Guard should be `if (!(norm < 1.0))`.
+
+### 44. `add(0.0)` is a no-op under `AtomicMode` but not under `SerialMode`/`AdderMode`
+`stream/AtomicMode.kt:40, 109` early-return on `delta == 0.0`; `SerialMode.kt:51-53, 99-101` and
+`jvmMain/.../AdderMode.kt:51-53` do not. A cell holding `-0.0` stays `-0.0` under `Relaxed`/`Strict` and
+becomes `+0.0` under `None` and JVM `HighWrite` — a mode-dependent difference in the reported sign of zero.
+
+### 45. `SpaceSavingStat.merge` mutates the policy and deficit cells outside `outerLock`
+`stat/sketch/SpaceSavingStat.kt:277-278` vs `:294-305` — `reset()` clears both inside the lock and `read()`
+observes both inside it. A `reset()` interleaving between those two lines and the guarded admission leaves an
+empty table with a non-zero deficit and a permanently degraded `MisraGries` policy that `effectivePolicy()`
+reports forever.
+
+### 46. `ClassCountsStat` has no `StatSpec`
+`stat/regression/tree/ClassCounts.kt:104-108` — a public `SeriesStat` whose KDoc advertises standalone use,
+and the only public stat class in the library with no spec (diffed every `class *Stat` against the symbols
+reachable from `StatFactory`). It cannot be declared in a schema, cannot round-trip through `StatSchemaDef`,
+and a group containing one has no wire form.
+
+### 47. `Identity.loss` and `Identity.curvature` disagree by a factor of 2
+`stat/regression/glm/Link.kt:44-47` — `loss` returns `r*r`, twice the Gaussian negative log-likelihood, while
+`curvature` returns `1.0`, the second derivative of `0.5*r^2`. The interface contract names both as the NLL and
+its second derivative. Harmless today because `sse` is only accumulated and `r*r` is what `mse`/`rSquared`
+want, but any consumer comparing `sse` across links, or using `loss` for a line search against `curvature`,
+gets a factor-of-2 error on Identity only.
+
+### 48. `mtry` is not validated
+`stat/regression/tree/HoeffdingTreeConfig.kt:76-79` — `requireValidBoundParameters` checks `delta` and
+`deltaDecay` but not `mtry`. `mtry = 0` silently disables growth while each audit leaf still takes the
+per-tree split lock every `splitPeriod` observations forever; `mtry < 0` throws from `List.take` inside
+`pickCandidates` at leaf birth, with a message naming neither `mtry` nor the tree.
+
+### 49. The tree reference is a plain `var` on the update path
+`stat/regression/tree/DecisionTreeRegressionStat.kt:74`, `DecisionTreeClassifierStat.kt:189`, and both forests'
+`trees` — read on the update path and rewritten by `reset()`, unlike `TreeGrowth.root` which is `@Volatile`.
+Under `Concurrency.Strict` a concurrent updater can keep writing into the pre-reset tree indefinitely.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
@@ -17,7 +17,7 @@ internal fun <R> SeriesStat<R>.band(k: Double): SeriesStat<BandResult>
     BandSeriesStat(this, k)
 
 internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private val k: Double) :
-    WindowsInside<BandResult>,
+    WindowsInside<BandResult, SeriesStat<BandResult>>,
     SeriesStat<BandResult> where R : HasCenterScale {
 
     override val concurrency: Concurrency get() = delegate.concurrency

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -11,6 +11,7 @@ import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
 import com.eignex.kumulant.schema.expr.ScalarExpr
+import kotlin.time.Duration
 
 // withFeedback is the streaming-feature-engineering primitive: each update is first sent
 // to a `primary` stat that maintains running state, then the raw value and `primary`'s
@@ -25,6 +26,12 @@ import com.eignex.kumulant.schema.expr.ScalarExpr
 //
 // The primary stat is owned by the wrapper. To inspect its snapshot directly, read it
 // through the [primary] property (the wrapper exposes its primary instance).
+//
+// Windowing wraps the inner stat and leaves the primary whole-stream: the primary is the running
+// state the projection is measured against, and a slice rotation that rebuilt it would hand every
+// slice's first observation a degenerate snapshot, which the scaler projections answer with their
+// neutral value. So `Mean.standardScaler().windowed(d)` is the windowed mean of z-scores taken
+// against the whole stream's distribution. See [WindowsInside].
 //
 // Concurrency: order-dependent cascade. Each update touches primary then inner in
 // sequence; the effective model is the stricter of primary's and inner's. Under
@@ -43,6 +50,7 @@ internal class FeedbackSeriesStat<P : Result, I : Result>(
     val primary: SeriesStat<P>,
     private val project: ScalarExpr,
 ) : SeriesStat<I>,
+    WindowsInside<I, SeriesStat<I>>,
     Stat<I> by inner {
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
@@ -55,6 +63,9 @@ internal class FeedbackSeriesStat<P : Result, I : Result>(
         primary.reset()
         inner.reset()
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<I> =
+        FeedbackSeriesStat(inner.windowed(duration, slices, concurrency), primary, project)
 
     override fun create(concurrency: Concurrency?): SeriesStat<I> =
         FeedbackSeriesStat(inner.create(concurrency), primary.create(concurrency), project)
@@ -77,6 +88,7 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
     val primary: VectorStat<ResultList<P>>,
     private val project: ScalarExpr,
 ) : VectorStat<I>,
+    WindowsInside<I, VectorStat<I>>,
     Stat<I> by inner {
 
     override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
@@ -92,6 +104,9 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
         primary.reset()
         inner.reset()
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): VectorStat<I> =
+        FeedbackVectorStat(inner.windowed(duration, slices, concurrency), primary, project)
 
     override fun create(concurrency: Concurrency?): VectorStat<I> =
         FeedbackVectorStat(inner.create(concurrency), primary.create(concurrency), project)
@@ -154,6 +169,7 @@ internal class FeedbackPairedStat<P : Result, R : Result>(
     val primaryY: SeriesStat<P>,
     private val project: ScalarExpr,
 ) : PairedStat<R>,
+    WindowsInside<R, PairedStat<R>>,
     Stat<R> by inner {
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
@@ -169,6 +185,9 @@ internal class FeedbackPairedStat<P : Result, R : Result>(
         primaryY.reset()
         inner.reset()
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): PairedStat<R> =
+        FeedbackPairedStat(inner.windowed(duration, slices, concurrency), primaryX, primaryY, project)
 
     override fun create(concurrency: Concurrency?): PairedStat<R> = FeedbackPairedStat(
         inner.create(concurrency),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Hysteresis.kt
@@ -36,7 +36,7 @@ internal class HysteresisSeriesStat<R : Result>(
     private val low: Double,
     private val high: Double,
 ) : SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
 
     init {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Resample.kt
@@ -50,7 +50,7 @@ internal class ResampleByTimeStat<R : Result>(
     private val bucket: Duration,
     private val aggregator: ResampleAggregator,
 ) : SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
 
     private val bucketNanos: Long = bucket.inWholeNanoseconds
@@ -81,18 +81,23 @@ internal class ResampleByTimeStat<R : Result>(
             val cur = currentBucket.load()
             // The same guard the Welford stats downstream apply, for the same reason: Mean divides by
             // the bucket's accumulated weight, so a downdate that takes it to zero publishes an
-            // infinity that every later read inherits. A downdate can only remove what the open bucket
-            // already holds, and a bucket not yet open holds nothing, hence the zero prior.
+            // infinity that every later read inherits.
+            //
+            // The prior is whatever the bucket this weight will actually land in already holds. A late
+            // arrival joins the open bucket rather than its own, so charging it against a zero prior
+            // would reject a downdate the open bucket can absorb, on the strength of a timestamp the
+            // operator then ignores. Only the seed paths start from nothing.
             //
             // Checked before any cell is written, so a rejected update leaves the stat as it was
             // rather than half-applied.
-            requireLiveWeight(if (cur == newBucket) bucketWeight.load() else 0.0, weight)
+            val joinsOpenBucket = cur != NO_BUCKET && newBucket <= cur
+            requireLiveWeight(if (joinsOpenBucket) bucketWeight.load() else 0.0, weight)
             if (cur == NO_BUCKET) {
                 currentBucket.store(newBucket)
                 seed(value, timestampNanos, weight)
                 return@guarded
             }
-            if (newBucket <= cur) {
+            if (joinsOpenBucket) {
                 // A late arrival joins the open bucket rather than closing it: its own bucket was
                 // already emitted, and closing on any change would emit the open one twice.
                 accumulate(value, timestampNanos, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -64,7 +64,7 @@ internal fun checkRate(rate: Double) = require(rate in 0.0..1.0) { "sample rate 
 
 internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val every: Int) :
     SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
@@ -85,6 +85,7 @@ internal class ThrottleSeriesStat<R : Result>(private val delegate: SeriesStat<R
 
 internal class ThrottlePairedStat<R : Result>(private val delegate: PairedStat<R>, private val every: Int) :
     PairedStat<R>,
+    WindowsInside<R, PairedStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
@@ -96,12 +97,16 @@ internal class ThrottlePairedStat<R : Result>(private val delegate: PairedStat<R
         delegate.reset()
     }
 
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): PairedStat<R> =
+        ThrottlePairedStat(delegate.windowed(duration, slices, concurrency), every)
+
     override fun create(concurrency: Concurrency?): PairedStat<R> =
         ThrottlePairedStat(delegate.create(concurrency), every)
 }
 
 internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R>, private val every: Int) :
     VectorStat<R>,
+    WindowsInside<R, VectorStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(vector: F64VectorView, timestampNanos: Long, weight: Double) {
@@ -113,12 +118,16 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
         delegate.reset()
     }
 
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): VectorStat<R> =
+        ThrottleVectorStat(delegate.windowed(duration, slices, concurrency), every)
+
     override fun create(concurrency: Concurrency?): VectorStat<R> =
         ThrottleVectorStat(delegate.create(concurrency), every)
 }
 
 internal class ThrottleDiscreteStat<R : Result>(private val delegate: DiscreteStat<R>, private val every: Int) :
     DiscreteStat<R>,
+    WindowsInside<R, DiscreteStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(value: Long, timestampNanos: Long, weight: Double) {
@@ -129,6 +138,9 @@ internal class ThrottleDiscreteStat<R : Result>(private val delegate: DiscreteSt
         gate.reset()
         delegate.reset()
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): DiscreteStat<R> =
+        ThrottleDiscreteStat(delegate.windowed(duration, slices, concurrency), every)
 
     override fun create(concurrency: Concurrency?): DiscreteStat<R> =
         ThrottleDiscreteStat(delegate.create(concurrency), every)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Shifts.kt
@@ -50,7 +50,7 @@ private fun requireK(k: Int) = require(k >= 1) { "shift k must be >= 1, got $k" 
 
 internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val k: Int) :
     SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
     init {
         requireK(k)
@@ -75,7 +75,7 @@ internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, pr
         }
     }
 
-    override fun reset() {
+    override fun reset() = lock.guarded {
         delegate.reset()
         tick.store(0L)
         for (i in 0 until k) ring.store(i, 0.0)
@@ -89,7 +89,7 @@ internal class LagSeriesStat<R : Result>(private val delegate: SeriesStat<R>, pr
 
 internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, private val k: Int) :
     SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
     init {
         requireK(k)
@@ -113,7 +113,7 @@ internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, p
         }
     }
 
-    override fun reset() {
+    override fun reset() = lock.guarded {
         delegate.reset()
         tick.store(0L)
         for (i in 0 until k) ring.store(i, 0.0)
@@ -127,7 +127,7 @@ internal class DiffSeriesStat<R : Result>(private val delegate: SeriesStat<R>, p
 
 internal class DerivativeSeriesStat<R : Result>(private val delegate: SeriesStat<R>) :
     SeriesStat<R>,
-    WindowsInside<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
 
     private val mode = delegate.concurrency.monotonicMode()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -23,12 +23,7 @@ internal fun <R : Result> SeriesStat<R>.windowed(
     duration: Duration,
     slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
-): SeriesStat<R> = if (this is WindowsInside<*>) {
-    // Wrap the operator's delegate, not the operator: see WindowsInside for why a slice rotation
-    // would otherwise restart the operator's state, and BandSeriesStat for the merge-side reason.
-    @Suppress("UNCHECKED_CAST")
-    (this as WindowsInside<R>).windowedInside(duration, slices, concurrency)
-} else {
+): SeriesStat<R> = windowedOutsideOrInside(duration, slices, concurrency) {
     WindowedSeriesStat(duration, slices, this, concurrency)
 }
 
@@ -37,21 +32,46 @@ internal fun <R : Result> PairedStat<R>.windowed(
     duration: Duration,
     slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
-): PairedStat<R> = WindowedPairedStat(duration, slices, this, concurrency)
+): PairedStat<R> = windowedOutsideOrInside(duration, slices, concurrency) {
+    WindowedPairedStat(duration, slices, this, concurrency)
+}
 
 /** Vector-stat counterpart of [SeriesStat.windowed]. */
 internal fun <R : Result> VectorStat<R>.windowed(
     duration: Duration,
     slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
-): VectorStat<R> = WindowedVectorStat(duration, slices, this, concurrency)
+): VectorStat<R> = windowedOutsideOrInside(duration, slices, concurrency) {
+    WindowedVectorStat(duration, slices, this, concurrency)
+}
 
 /** Discrete-stat counterpart of [SeriesStat.windowed]. */
 internal fun <R : Result> DiscreteStat<R>.windowed(
     duration: Duration,
     slices: Int = DEFAULT_WINDOW_SLICES,
     concurrency: Concurrency = Concurrency.None,
-): DiscreteStat<R> = WindowedDiscreteStat(duration, slices, this, concurrency)
+): DiscreteStat<R> = windowedOutsideOrInside(duration, slices, concurrency) {
+    WindowedDiscreteStat(duration, slices, this, concurrency)
+}
+
+/**
+ * Route a stateful operator to [WindowsInside.windowedInside] and everything else to [outside].
+ *
+ * Wrapping the operator's delegate rather than the operator itself is what keeps one instance of the
+ * operator's state for the whole stream: see [WindowsInside] for why a slice rotation would otherwise
+ * restart it, and BandSeriesStat for the merge-side reason.
+ */
+private inline fun <R : Result, S : Stat<R>> S.windowedOutsideOrInside(
+    duration: Duration,
+    slices: Int,
+    concurrency: Concurrency,
+    outside: () -> S,
+): S = if (this is WindowsInside<*, *>) {
+    @Suppress("UNCHECKED_CAST")
+    (this as WindowsInside<R, S>).windowedInside(duration, slices, concurrency)
+} else {
+    outside()
+}
 
 /**
  * Build a fresh single-threaded accumulator from [template], merge in every active

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowsInside.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowsInside.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.SeriesStat
+import com.eignex.kumulant.core.Stat
 import kotlin.time.Duration
 
 /**
@@ -14,8 +14,11 @@ import kotlin.time.Duration
  * slice the operator then never fires at all. Windowing the operator's delegate and re-applying the
  * operator on top keeps one instance of the state for the whole stream, which is what the caller
  * asked for.
+ *
+ * [S] is the operator's own modality, so a paired or discrete operator windows into its own kind
+ * rather than being narrowed to a series stat.
  */
-internal interface WindowsInside<R : Result> {
+internal interface WindowsInside<R : Result, S : Stat<R>> {
     /** This operator re-applied over its own windowed delegate. */
-    fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R>
+    fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): S
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WithSelfLag.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.monotonicMode
 import com.eignex.kumulant.stream.serializedLock
+import kotlin.time.Duration
 
 // withSelfLag lifts a PairedStat<R> into a SeriesStat<R> by self-pairing each input
 // with the value seen k updates ago. The first k updates only warm the ring buffer
@@ -37,6 +38,7 @@ internal fun <R : Result> PairedStat<R>.withSelfLag(k: Int): SeriesStat<R> = Wit
 
 internal class WithSelfLagSeriesStat<R : Result>(private val delegate: PairedStat<R>, private val k: Int) :
     SeriesStat<R>,
+    WindowsInside<R, SeriesStat<R>>,
     Stat<R> by delegate {
 
     init {
@@ -61,11 +63,14 @@ internal class WithSelfLagSeriesStat<R : Result>(private val delegate: PairedSta
         }
     }
 
-    override fun reset() {
+    override fun reset() = lock.guarded {
         delegate.reset()
         tick.store(0L)
         for (i in 0 until k) ring.store(i, 0.0)
     }
+
+    override fun windowedInside(duration: Duration, slices: Int, concurrency: Concurrency): SeriesStat<R> =
+        WithSelfLagSeriesStat(delegate.windowed(duration, slices, concurrency), k)
 
     override fun create(concurrency: Concurrency?): SeriesStat<R> =
         WithSelfLagSeriesStat(delegate.create(concurrency), k)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SliceRing.kt
@@ -25,6 +25,11 @@ internal class SliceRing<R : Result, S : Stat<R>>(
 
     private val ringMode: StreamMode = concurrency.additiveMode()
 
+    // Newest slice start the ring has admitted, so a stamp implausibly far ahead of the stream can be
+    // told apart from a stream that has simply been idle. CAS'd, hence monotonicMode rather than the
+    // ring's additive one, whose striped-adder cells do not support compareAndSet.
+    private val newestStart = concurrency.monotonicMode().newLong(Long.MIN_VALUE)
+
     init {
         require(slices > 0) { "SliceRing requires at least 1 slice" }
         windowDurationNanos = windowDuration.inWholeNanoseconds
@@ -44,6 +49,15 @@ internal class SliceRing<R : Result, S : Stat<R>>(
     private fun expectedSliceStart(timestampNanos: Long): Long =
         timestampNanos.floorDiv(sliceDurationNanos) * sliceDurationNanos
 
+    // A stamp more than a full window past everything seen so far cannot belong to the window the ring
+    // represents. Rotating a bucket onto it would evict a live slice and then reject every genuine stamp
+    // that maps there, costing one slice's share of the stream for as long as the bogus start stood.
+    // The first observation has nothing to be measured against, so it always establishes the reference.
+    private fun isBeyondReach(expectedStart: Long): Boolean {
+        val newest = newestStart.load()
+        return newest != Long.MIN_VALUE && expectedStart - newest > windowDurationNanos
+    }
+
     private fun bucketIndex(expectedStart: Long): Int {
         val raw = (expectedStart.floorDiv(sliceDurationNanos) % buckets.size).toInt()
         return if (raw < 0) raw + buckets.size else raw
@@ -56,13 +70,17 @@ internal class SliceRing<R : Result, S : Stat<R>>(
      */
     fun slotFor(timestampNanos: Long): S? {
         val expectedStart = expectedSliceStart(timestampNanos)
+        if (isBeyondReach(expectedStart)) return null
         val bucketRef = buckets[bucketIndex(expectedStart)]
         while (true) {
             val currentSlot = bucketRef.load()
             if (currentSlot.startNanos == expectedStart) return currentSlot.stat
             if (currentSlot.startNanos < expectedStart) {
                 val newSlot = Slot<R, S>(expectedStart, factory(concurrency))
-                if (bucketRef.compareAndSet(currentSlot, newSlot)) return newSlot.stat
+                if (bucketRef.compareAndSet(currentSlot, newSlot)) {
+                    casMax(newestStart, expectedStart)
+                    return newSlot.stat
+                }
             } else {
                 return null
             }
@@ -81,6 +99,7 @@ internal class SliceRing<R : Result, S : Stat<R>>(
      */
     fun mergeAt(timestampNanos: Long, values: R) {
         val expectedStart = expectedSliceStart(timestampNanos)
+        if (isBeyondReach(expectedStart)) return
         val bucketRef = buckets[bucketIndex(expectedStart)]
         while (true) {
             val currentSlot = bucketRef.load()
@@ -94,6 +113,7 @@ internal class SliceRing<R : Result, S : Stat<R>>(
             }
             val newSlot = Slot<R, S>(expectedStart, factory(concurrency))
             if (bucketRef.compareAndSet(currentSlot, newSlot)) {
+                casMax(newestStart, expectedStart)
                 newSlot.stat.merge(values)
                 return
             }
@@ -114,6 +134,7 @@ internal class SliceRing<R : Result, S : Stat<R>>(
         for (bucketRef in buckets) {
             bucketRef.store(Slot(Long.MIN_VALUE, factory(concurrency)))
         }
+        newestStart.store(Long.MIN_VALUE)
     }
 }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ResampleTest.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.Duration.Companion.milliseconds
 
 class ResampleTest {
@@ -151,5 +152,17 @@ class ResampleTest {
         stat.update(value = 5.0, timestampNanos = 3_000_000_000L)
         // Bucket 0 closes as 1.0 and bucket 2 as 4.0; the late 3.0 joins the open bucket.
         assertEquals(5.0, stat.read().sum, DELTA)
+    }
+}
+
+class ResampleDowndateGuardTest {
+
+    @Test
+    fun `a late downdate is charged against the bucket it lands in`() {
+        val s = SumStat().resampleByTime(bucket = 1.microseconds, aggregator = ResampleAggregator.Mean)
+        s.update(10.0, timestampNanos = 100L, weight = 1.0)
+        s.update(20.0, timestampNanos = 1100L, weight = 3.0)
+        s.update(20.0, timestampNanos = 500L, weight = -1.0)
+        assertEquals(10.0, s.read(1200L).sum, DELTA)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -2,12 +2,15 @@ package com.eignex.kumulant.operation
 
 import com.eignex.koblas.F64DenseVector
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
+import com.eignex.kumulant.stat.regression.CovarianceStat
 import com.eignex.kumulant.stat.summary.CountStat
 import com.eignex.kumulant.stat.summary.SumStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class SamplingTest {
 
@@ -125,5 +128,22 @@ class SamplingTest {
         val stat = SumStat().asDiscrete().weightBy { v -> v.toDouble() }
         stat.update(value = 3L, weight = 2.0) // 3 * 2 * 3 = 18
         assertEquals(18.0, stat.read().sum, DELTA)
+    }
+}
+
+class ThrottleWindowedTest {
+
+    @Test
+    fun `a windowed paired throttle keeps one gate for the whole stream`() {
+        val s = CovarianceStat().throttle(every = 10).windowed(duration = 60.seconds, slices = 10)
+        for (i in 0 until 60) s.update(1.0 + i, 2.0 + i, timestampNanos = i * 1_000_000_000L)
+        assertTrue(s.read(59_000_000_000L).totalWeights > 0.0, "the gate never fired in any slice")
+    }
+
+    @Test
+    fun `a windowed discrete throttle keeps one gate for the whole stream`() {
+        val s = HyperLogLogStat().throttle(every = 10).windowed(duration = 60.seconds, slices = 10)
+        for (i in 0 until 60) s.update(i.toLong(), timestampNanos = i * 1_000_000_000L)
+        assertTrue(s.read(59_000_000_000L).estimate > 0.0, "the gate never fired in any slice")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ScalersTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/ScalersTest.kt
@@ -1,12 +1,15 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class ScalersTest {
 
@@ -86,5 +89,15 @@ class ScalersTest {
         s.update(5.0)
         // First post-reset update is again the warm-up zero.
         assertEquals(0.0, s.read().sum, DELTA)
+    }
+}
+
+class ScalerWindowedTest {
+
+    @Test
+    fun `a windowed standard scaler keeps one primary for the whole stream`() {
+        val s = MeanStat().standardScaler().windowed(duration = 60.seconds, slices = 10)
+        for (i in 0 until 6) s.update(100.0 * (i + 1), timestampNanos = i * 10_000_000_000L)
+        assertNotEquals(0.0, s.read(50_000_000_000L).mean, "every observation was standardized against a fresh primary")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WindowedStatsTest.kt
@@ -194,3 +194,15 @@ class WindowedStatsTest {
         assertEquals(plain.read(t).sum, windowed.read(t).sum, DELTA)
     }
 }
+
+class WindowedRingPoisoningTest {
+
+    @Test
+    fun `a future timestamp does not silence the bucket it lands in`() {
+        val w = SumStat().windowed(duration = 10.seconds, slices = 10)
+        w.update(1.0, T0)
+        w.update(1.0, 60_003_000_000_000L)
+        w.update(5.0, T3)
+        assertEquals(6.0, w.read(T9).sum, DELTA)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WithSelfLagTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WithSelfLagTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class WithSelfLagTest {
 
@@ -57,5 +58,15 @@ class WithSelfLagTest {
         val fresh = tpl.create()
         assertEquals(0.0, fresh.read().totalWeights, DELTA)
         assertTrue(tpl.read().totalWeights > 0.0)
+    }
+}
+
+class WithSelfLagWindowedTest {
+
+    @Test
+    fun `windowing pairs across slice boundaries`() {
+        val s = CovarianceStat().withSelfLag(k = 1).windowed(duration = 60.seconds, slices = 10)
+        for (i in 0 until 6) s.update(1.0 + i, timestampNanos = i * 10_000_000_000L)
+        assertTrue(s.read(50_000_000_000L).totalWeights > 0.0, "no pair ever spanned a slice boundary")
     }
 }


### PR DESCRIPTION
## What changed

- SliceRing rejects a timestamp more than one window past everything it has seen, instead of rotating a bucket onto it.
- withSelfLag is classified WindowsInside, so a window wraps its delegate rather than the operator.
- WindowsInside is generic over the operator modality, and the paired, vector and discrete windowed overloads dispatch on it. The three non-series throttle wrappers implement it.
- reset on the lag, diff and withSelfLag rings runs under the lock their update holds.
- The resample downdate guard takes its prior from the bucket the weight actually lands in.
- withFeedback and the scalers window their inner stat and keep one primary for the whole stream.

## Why

The 2026-08-18 sweep introduced WindowsInside but left three stateful operators unclassified and three of the four windowed entry points never consulting it. On a stream slower than one observation per slice those compositions silently produce nothing: Covariance.withSelfLag(1).windowed(60s) reports count 0 forever, Covariance.throttle(10).windowed(60s) never fires its gate, and Mean.standardScaler().windowed(60s) reports 0.0 whatever the input. Mean.throttle(10).windowed(60s) is correct, so the same composition behaved differently purely by modality.

Separately, one future-dated timestamp permanently killed a ring bucket, costing a windowed stat exactly one slice of its input from then on. The unlocked resets could forward a fabricated difference the size of the whole stream into a stat that was just emptied. The resample guard rejected a downdate the open bucket could absorb, on the strength of a timestamp the operator then ignores.

## Why not

The first observation into an empty ring cannot be checked against anything, so a bogus first timestamp still establishes the reference. The described failure is a glitch mid-stream, which is now handled.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. Each finding has a test that was confirmed to fail before the fix and pass after: the SliceRing drop was verified by stashing only that file and re-running.