### PR TITLE
fix: keep decay and rate windows anchored to the observations they cover

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -5772,14 +5772,17 @@ public final class com/eignex/kumulant/stat/decay/EwmaVarianceStat : com/eignex/
 
 public final class com/eignex/kumulant/stat/event/CrossingResult : com/eignex/kumulant/core/Result {
 	public static final field Companion Lcom/eignex/kumulant/stat/event/CrossingResult$Companion;
-	public fun <init> (DJJ)V
+	public fun <init> (DJJLjava/lang/Boolean;)V
+	public synthetic fun <init> (DJJLjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()D
 	public final fun component2 ()J
 	public final fun component3 ()J
-	public final fun copy (DJJ)Lcom/eignex/kumulant/stat/event/CrossingResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/event/CrossingResult;DJJILjava/lang/Object;)Lcom/eignex/kumulant/stat/event/CrossingResult;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (DJJLjava/lang/Boolean;)Lcom/eignex/kumulant/stat/event/CrossingResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/event/CrossingResult;DJJLjava/lang/Boolean;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/event/CrossingResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDownCrossings ()J
+	public final fun getEndedAtOrAboveLevel ()Ljava/lang/Boolean;
 	public final fun getLevel ()D
 	public final fun getUpCrossings ()J
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -5371,10 +5371,12 @@ final class com.eignex.kumulant.stat.decay/EwmaVarianceStat : com.eignex.kumulan
 }
 
 final class com.eignex.kumulant.stat.event/CrossingResult : com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.event/CrossingResult|null[0]
-    constructor <init>(kotlin/Double, kotlin/Long, kotlin/Long) // com.eignex.kumulant.stat.event/CrossingResult.<init>|<init>(kotlin.Double;kotlin.Long;kotlin.Long){}[0]
+    constructor <init>(kotlin/Double, kotlin/Long, kotlin/Long, kotlin/Boolean? = ...) // com.eignex.kumulant.stat.event/CrossingResult.<init>|<init>(kotlin.Double;kotlin.Long;kotlin.Long;kotlin.Boolean?){}[0]
 
     final val downCrossings // com.eignex.kumulant.stat.event/CrossingResult.downCrossings|{}downCrossings[0]
         final fun <get-downCrossings>(): kotlin/Long // com.eignex.kumulant.stat.event/CrossingResult.downCrossings.<get-downCrossings>|<get-downCrossings>(){}[0]
+    final val endedAtOrAboveLevel // com.eignex.kumulant.stat.event/CrossingResult.endedAtOrAboveLevel|{}endedAtOrAboveLevel[0]
+        final fun <get-endedAtOrAboveLevel>(): kotlin/Boolean? // com.eignex.kumulant.stat.event/CrossingResult.endedAtOrAboveLevel.<get-endedAtOrAboveLevel>|<get-endedAtOrAboveLevel>(){}[0]
     final val level // com.eignex.kumulant.stat.event/CrossingResult.level|{}level[0]
         final fun <get-level>(): kotlin/Double // com.eignex.kumulant.stat.event/CrossingResult.level.<get-level>|<get-level>(){}[0]
     final val upCrossings // com.eignex.kumulant.stat.event/CrossingResult.upCrossings|{}upCrossings[0]
@@ -5383,7 +5385,8 @@ final class com.eignex.kumulant.stat.event/CrossingResult : com.eignex.kumulant.
     final fun component1(): kotlin/Double // com.eignex.kumulant.stat.event/CrossingResult.component1|component1(){}[0]
     final fun component2(): kotlin/Long // com.eignex.kumulant.stat.event/CrossingResult.component2|component2(){}[0]
     final fun component3(): kotlin/Long // com.eignex.kumulant.stat.event/CrossingResult.component3|component3(){}[0]
-    final fun copy(kotlin/Double = ..., kotlin/Long = ..., kotlin/Long = ...): com.eignex.kumulant.stat.event/CrossingResult // com.eignex.kumulant.stat.event/CrossingResult.copy|copy(kotlin.Double;kotlin.Long;kotlin.Long){}[0]
+    final fun component4(): kotlin/Boolean? // com.eignex.kumulant.stat.event/CrossingResult.component4|component4(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Long = ..., kotlin/Long = ..., kotlin/Boolean? = ...): com.eignex.kumulant.stat.event/CrossingResult // com.eignex.kumulant.stat.event/CrossingResult.copy|copy(kotlin.Double;kotlin.Long;kotlin.Long;kotlin.Boolean?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.event/CrossingResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.event/CrossingResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.event/CrossingResult.toString|toString(){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStat.kt
@@ -85,6 +85,17 @@ class DecayingSumStat(
         if (weight.isInertWeight()) return
         while (true) {
             val epoch = epochRef.load()
+            // While empty the landmark snaps back to the observation: it starts at process uptime, and
+            // a replay stream numbering from its own epoch is legitimately far behind that. Left alone,
+            // `exp(alpha*dt)` for so negative a dt flushes the contribution to zero and read's matching
+            // positive exponent then multiplies that zero by an infinity, so the stat reports NaN.
+            // DecayingVarianceStat.advanceTo snaps for the same reason. Only backwards, and only while
+            // there is no sum to protect: forwards is what the rotation below is for, and once there is
+            // history a stamp behind the landmark is a late arrival rather than a rewind.
+            if (timestampNanos < epoch.landmarkNanos && epoch.accumulator.load() == 0.0) {
+                epochRef.compareAndSet(epoch, Epoch(timestampNanos, mode.newDouble(0.0)))
+                continue
+            }
             if (timestampNanos - epoch.landmarkNanos > rotationThresholdNanos) {
                 tryRotateEpoch(epoch, timestampNanos)
                 continue
@@ -97,15 +108,38 @@ class DecayingSumStat(
 
     private fun tryRotateEpoch(old: Epoch, now: Long) {
         val dt = now - old.landmarkNanos
-        val carried = old.accumulator.load() * exp(-alpha * dt)
-        epochRef.compareAndSet(old, Epoch(now, mode.newDouble(carried)))
+        val next = Epoch(now, mode.newDouble(0.0))
+        if (!epochRef.compareAndSet(old, next)) return
+        // Drain the retired accumulator rather than snapshotting it: an update that loaded the old
+        // epoch and adds after the swap would otherwise land in a cell nothing reads again. Taking the
+        // residue out before folding it in means a racing add is either still there for the next pass
+        // or already counted here, never both, so no observation is dropped. The loop is bounded by
+        // the writers that were in flight when the swap landed.
+        val factor = exp(-alpha * dt)
+        while (true) {
+            val residue = old.accumulator.load()
+            if (residue == 0.0) return
+            old.accumulator.add(-residue)
+            next.accumulator.add(residue * factor)
+        }
     }
 
     override fun read(timestampNanos: Long): DecayingSumResult {
         val epoch = epochRef.load()
+        val stored = epoch.accumulator.load()
         val dt = (timestampNanos - epoch.landmarkNanos).toDouble()
-        val sum = epoch.accumulator.load() * exp(-alpha * dt)
-        return DecayingSumResult(sum, timestampNanos)
+        return DecayingSumResult(decayTo(stored, dt), timestampNanos)
+    }
+
+    /**
+     * Apply the read-time decay factor without letting the two ends of the exponent meet as
+     * `0.0 * Infinity`. An accumulator flushed to zero by an underflowing `exp(alpha*dt)` on the
+     * update side stays zero here, and one that overflowed stays infinite, rather than both
+     * turning into a NaN that every later read inherits.
+     */
+    private fun decayTo(stored: Double, dt: Double): Double {
+        if (stored == 0.0) return 0.0
+        return stored * exp(-alpha * dt)
     }
 
     /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/CrossingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/CrossingStat.kt
@@ -5,6 +5,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.stream.additiveMode
+import com.eignex.kumulant.stream.casMax
 import com.eignex.kumulant.stream.monotonicMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -19,6 +20,14 @@ data class CrossingResult(
     val upCrossings: Long,
     /** Number of strict transitions from `value >= level` to `value < level`. */
     val downCrossings: Long,
+    /**
+     * Whether the last observed value was at or above [level], or `null` before any observation.
+     *
+     * Carried so a merge into a stat with no baseline of its own can continue from the side the
+     * snapshot left off on, instead of spending its next update establishing one afresh and losing
+     * the crossing that update represents.
+     */
+    val endedAtOrAboveLevel: Boolean? = null,
 ) : Result
 
 /**
@@ -68,8 +77,19 @@ class CrossingStat(
     }
 
     override fun merge(values: CrossingResult) {
+        // The counts only mean anything against the level they were measured at: folding a snapshot
+        // taken at another level in would report crossings of a different predicate as this one's.
+        require(values.level == level) { "merge level ${values.level} != $level" }
         ups.add(values.upCrossings)
         downs.add(values.downCrossings)
+        // Adopt the baseline only when there is none, the way SojournStat keeps its own current state
+        // over an incoming one: with a baseline already established, the local stream's side is the
+        // live one and the snapshot's is a parallel shard's, which nothing here can order against it.
+        val endedAbove = values.endedAtOrAboveLevel ?: return
+        if (initialized.load() == 0L) {
+            lastSide.store(if (endedAbove) 1L else 0L)
+            casMax(initialized, 1L)
+        }
     }
 
     override fun reset() {
@@ -79,7 +99,12 @@ class CrossingStat(
         downs.store(0L)
     }
 
-    override fun read(timestampNanos: Long) = CrossingResult(level, ups.load(), downs.load())
+    override fun read(timestampNanos: Long) = CrossingResult(
+        level = level,
+        upCrossings = ups.load(),
+        downCrossings = downs.load(),
+        endedAtOrAboveLevel = if (initialized.load() == 0L) null else lastSide.load() == 1L,
+    )
 
     override fun create(concurrency: Concurrency?) = CrossingStat(level, concurrency ?: this.concurrency)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/SojournStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/event/SojournStat.kt
@@ -95,7 +95,10 @@ class SojournStat(
             val elapsed = (timestampNanos - priorEnter).coerceAtLeast(0L)
             totalNanos.store(curIdx.toInt(), totalNanos.load(curIdx.toInt()) + elapsed)
             currentStateIndex.store(newIdx.toLong())
-            enterTimestamp.store(timestampNanos)
+            // A stamp behind the landmark is a late arrival, not a rewind: committing it would measure
+            // the next transition's dwell from before this one happened, so the stat could report more
+            // dwell than the stream's stamps span. The clamp above already gave this arrival no dwell.
+            if (timestampNanos > priorEnter) enterTimestamp.store(timestampNanos)
             transitions.store(newIdx, transitions.load(newIdx) + 1L)
         }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/CounterRateStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.rate
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.additiveMode
 import com.eignex.kumulant.stream.firstWriterMode
 import com.eignex.kumulant.stream.guarded
@@ -56,11 +56,13 @@ class CounterRateStat(
     private val lastTimestampNanos = mode.newLong(Long.MIN_VALUE)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        // Return before touching lastCounter: a zero weight contributes no delta, but advancing the
-        // high-water mark anyway would destroy the increment for good, so no later sample could
-        // recover it. NaN is dropped for the same reason it is everywhere; see Stat. Outside the
-        // lock, like every other stat's inert guard - a no-op has no state to protect.
-        if (weight.isInertWeight()) return
+        // Return before touching lastCounter: a weight that contributes no delta would still advance
+        // the high-water mark, destroying the increment for good so no later sample could recover it.
+        // A negative weight is dropped rather than downdated for the same reason - the mark has no
+        // inverse, and the clamp below would swallow the delta while the mark moved on anyway. NaN is
+        // dropped as it is everywhere; see Stat. Outside the lock, like every other stat's inert
+        // guard - a no-op has no state to protect.
+        if (weight.isNotPositiveWeight()) return
         lock.guarded { updateLocked(value, timestampNanos, weight) }
     }
 
@@ -86,15 +88,17 @@ class CounterRateStat(
             }
 
             treatDecreaseAsReset -> {
-                val scaledDelta = (value * weight).coerceAtLeast(0.0)
-                if (scaledDelta > 0.0) {
-                    // Re-anchoring the window without clearing the total would divide every
-                    // pre-reset increment by the short post-reset duration: a counter advancing 105
-                    // units over 11s would report 210/s. The window and the total describe the same
-                    // span, so they have to be reset together.
-                    totalDelta.store(scaledDelta)
-                    startTimestampNanos.store(timestampNanos)
-                }
+                // Registered for any decrease, including a restart to exactly 0.0 - the most common
+                // one a *_total counter makes. Gating on post-reset progress would conflate "the
+                // reset has produced nothing yet" with "no reset happened", keeping every pre-reset
+                // increment and the old anchor while the high-water mark moved on regardless.
+                //
+                // Re-anchoring the window without clearing the total would divide every pre-reset
+                // increment by the short post-reset duration: a counter advancing 105 units over 11s
+                // would report 210/s. The window and the total describe the same span, so they have
+                // to be reset together.
+                totalDelta.store((value * weight).coerceAtLeast(0.0))
+                startTimestampNanos.store(timestampNanos)
                 lastCounter.store(value)
                 lastTimestampNanos.store(timestampNanos)
             }
@@ -129,9 +133,11 @@ class CounterRateStat(
     }
 
     override fun merge(values: RateResult) = lock.guarded {
-        if (values.totalValue == 0.0) return@guarded
-
         totalDelta.add(values.totalValue)
+
+        // See RateStat.merge: an untouched shard reports its read timestamp as the start and so has no
+        // window to adopt, but a zero total does not imply an untouched shard.
+        if (values.startTimestampNanos >= values.timestampNanos) return@guarded
 
         val currentStart = startTimestampNanos.load()
         if (currentStart == Long.MIN_VALUE || values.startTimestampNanos < currentStart) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/rate/RateStat.kt
@@ -86,9 +86,13 @@ class RateStat(override val concurrency: Concurrency = Concurrency.None) : Serie
     }
 
     override fun merge(values: RateResult) {
-        if (values.totalValue == 0.0) return
-
         totalValues.add(values.totalValue)
+
+        // A shard that never observed anything reports its read timestamp as the start (see read), so
+        // it has no window to contribute. A zero total is not the same test: a shard that observed only
+        // zero-valued events, or values that cancel, covers a real span, and dropping that span leaves
+        // the merged denominator shorter than the observations it is dividing.
+        if (values.startTimestampNanos >= values.timestampNanos) return
 
         val currentStart = startTimestampNanos.load()
         if (currentStart == Long.MIN_VALUE || values.startTimestampNanos < currentStart) {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/decay/DecayingSumStatTest.kt
@@ -4,6 +4,7 @@ import com.eignex.kumulant.DELTA
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val T0 = 1_000_000_000L
@@ -77,5 +78,27 @@ class DecayingSumStatTest {
         val s2 = s1.create()
         s2.update(10.0, T1)
         assertTrue(s1.read(T2).sum < s2.read(T2).sum)
+    }
+}
+
+class DecayingSumLandmarkTest {
+
+    // A stream numbered far behind the landmark: the landmark starts at process uptime, so this is
+    // what a replay stream numbering from its own epoch looks like once the process has been up
+    // longer than ~1075 half-lives. A negative stamp reaches the same offset without the wait.
+    private val farBehind = -200_000_000_000L
+
+    @Test
+    fun `a stream far behind the landmark reports a finite sum`() {
+        val s = DecayingSumStat(halfLife = 100.milliseconds)
+        s.update(5.0, timestampNanos = farBehind)
+        assertEquals(5.0, s.read(farBehind).sum, DELTA)
+    }
+
+    @Test
+    fun `a stream far behind the landmark keeps the mean finite`() {
+        val s = DecayingMeanStat(halfLife = 100.milliseconds)
+        s.update(5.0, timestampNanos = farBehind)
+        assertEquals(5.0, s.read(farBehind).mean, DELTA)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/CrossingStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/CrossingStatTest.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.event
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class CrossingStatTest {
 
@@ -80,5 +81,28 @@ class CrossingStatTest {
     fun `result carries the configured level`() {
         val r = CrossingStat(level = 3.14).read()
         assertEquals(3.14, r.level)
+    }
+}
+
+class CrossingMergeLevelTest {
+
+    @Test
+    fun `merge rejects a snapshot measured against another level`() {
+        val s = CrossingStat(level = 0.0)
+        val other = CrossingStat(level = 100.0)
+        other.update(150.0)
+        other.update(50.0)
+        assertFailsWith<IllegalArgumentException> { s.merge(other.read()) }
+    }
+
+    @Test
+    fun `the first update after a merge is compared against the merged side`() {
+        val donor = CrossingStat(level = 0.0)
+        donor.update(5.0)
+        donor.update(-5.0)
+        val s = CrossingStat(level = 0.0)
+        s.merge(donor.read())
+        s.update(5.0)
+        assertEquals(2L, s.read().upCrossings + s.read().downCrossings)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/SojournStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/event/SojournStatTest.kt
@@ -114,3 +114,17 @@ class SojournStatTest {
         assertEquals(1L, fresh.read(1_000L).currentState)
     }
 }
+
+class SojournLateArrivalTest {
+
+    @Test
+    fun `an out-of-order stamp does not rewind the entry landmark`() {
+        val s = SojournStat(states = listOf(0L, 1L))
+        s.update(0L, timestampNanos = 100L)
+        s.update(1L, timestampNanos = 50L)
+        s.update(0L, timestampNanos = 200L)
+        val dwell = s.read(200L).totalNanosByState
+        // The stream's stamps span 100..200, so no more than 100ns of dwell can have been observed.
+        assertEquals(100L, dwell.sum())
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/CounterRateStatTest.kt
@@ -101,3 +101,28 @@ class CounterRateStatTest {
         assertEquals(0.0, r.read(T2).totalValue, DELTA)
     }
 }
+
+class CounterRateZeroResetTest {
+
+    @Test
+    fun `a counter restarting at zero re-anchors the window`() {
+        val s = CounterRateStat()
+        s.update(0.0, timestampNanos = 0L)
+        s.update(100.0, timestampNanos = 10_000_000_000L)
+        s.update(0.0, timestampNanos = 20_000_000_000L)
+        s.update(30.0, timestampNanos = 30_000_000_000L)
+
+        val r = s.read(30_000_000_000L)
+        assertEquals(30.0, r.totalValue, DELTA)
+        assertEquals(20_000_000_000L, r.startTimestampNanos)
+    }
+
+    @Test
+    fun `a negative weight leaves the counter increment recoverable`() {
+        val s = CounterRateStat()
+        s.update(0.0, timestampNanos = 0L, weight = 1.0)
+        s.update(100.0, timestampNanos = 1_000_000_000L, weight = -1.0)
+        s.update(200.0, timestampNanos = 2_000_000_000L, weight = 1.0)
+        assertEquals(200.0, s.read(2_000_000_000L).totalValue, DELTA)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/rate/RateStatTest.kt
@@ -111,3 +111,33 @@ class RateStatTest {
         assertEquals(10.0, r1.read(T1).totalValue, DELTA)
     }
 }
+
+class RateMergeWindowTest {
+
+    @Test
+    fun `merging a shard that observed only zeros keeps its window`() {
+        val shardA = RateStat()
+        for (t in 0..8) shardA.update(0.0, timestampNanos = t * 1_000_000_000L)
+        val shardB = RateStat()
+        shardB.update(100.0, timestampNanos = 9_000_000_000L)
+
+        val merged = RateStat()
+        merged.merge(shardA.read(10_000_000_000L))
+        merged.merge(shardB.read(10_000_000_000L))
+
+        val single = RateStat()
+        for (t in 0..8) single.update(0.0, timestampNanos = t * 1_000_000_000L)
+        single.update(100.0, timestampNanos = 9_000_000_000L)
+
+        assertEquals(single.read(10_000_000_000L).rate, merged.read(10_000_000_000L).rate, DELTA)
+    }
+
+    @Test
+    fun `merging an untouched shard does not stretch the window`() {
+        val empty = RateStat()
+        val merged = RateStat()
+        merged.update(100.0, timestampNanos = 9_000_000_000L)
+        merged.merge(empty.read(10_000_000_000L))
+        assertEquals(9_000_000_000L, merged.read(10_000_000_000L).startTimestampNanos)
+    }
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DecayingSumRotationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/DecayingSumRotationTest.kt
@@ -1,0 +1,26 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import com.eignex.kumulant.stat.decay.DecayingSumStat
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.microseconds
+
+class DecayingSumRotationTest {
+
+    @Test
+    fun `a concurrent stream across many epoch rotations stays finite`() {
+        // A 1us half-life puts the rotation threshold at 50us, so a stream stepping 1us per update
+        // crosses it constantly. Writers race the rotation from both sides: one adding against a
+        // landmark another is replacing, and one arriving so far behind the landmark that its
+        // exponent underflows while the read's matching exponent overflows.
+        val stat = DecayingSumStat(halfLife = 1.microseconds, concurrency = Concurrency.Relaxed)
+        val threads = 4
+        val perThread = 20_000
+        runConcurrently(threads, perThread) { t, i ->
+            stat.update(1.0, timestampNanos = i.toLong() * 1000L + t)
+        }
+        val sum = stat.read((perThread.toLong() - 1) * 1000L + threads).sum
+        assertTrue(sum.isFinite() && sum > 0.0, "sum=$sum")
+    }
+}


### PR DESCRIPTION
## What changed

- DecayingSumStat snaps its landmark back to the observation while the accumulator is empty, and read no longer multiplies a zero accumulator by an infinite decay factor.
- Epoch rotation drains the retired accumulator instead of snapshotting it, so an add that lands after the swap is still carried.
- CounterRateStat registers a counter reset for any decrease, including a restart to exactly 0.0.
- CounterRateStat drops non-positive weights rather than admitting a negative one it cannot invert.
- RateStat and CounterRateStat decide whether to adopt an incoming window from whether the shard observed anything, not from whether its total is zero.
- SojournStat keeps its entry landmark when a stamp arrives behind it.
- CrossingStat.merge validates the level and carries the last observed side.

## Why

The decay landmark starts at process uptime and never moved, so a replay stream numbered from its own epoch made update underflow to zero and read overflow to infinity, and the stat reported NaN. It propagated to the mean and the rate. The rotation lost updates outright, which the design rules forbid.

A counter restarting at exactly 0.0 is the most common Prometheus-style restart, and it was the one case the reset branch missed: the window stayed anchored at the old start and every pre-reset increment was kept. A negative weight silently destroyed a counter increment for good. Merging a shard that observed only zero-valued events dropped its window, so the merged denominator was shorter than the observations it divided and the rate came out ten times too high. SojournStat could report more dwell than the stream spans.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. The decay landmark and rotation tests were both confirmed to fail before the fix. The landmark case needs about 107 seconds of prior process uptime to underflow, so the test reaches the same offset with a negative timestamp instead of waiting.