### PR TITLE
fix: keep bandit policies usable after a non-finite reward

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.bandit.sampleFromDistribution
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.isInertWeight
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -165,6 +166,12 @@ class Exp4Bandit(
     /** Fold a `(context, reward)` observation back into the expert weights. */
     override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
+        // Return before propensityOf, which consumes an outstanding pull. A zero gain leaves the expert
+        // weights alone, but spending the recorded propensity is not a no-op: the real feedback for
+        // that pull would then be divided by the current distribution instead, an unbounded error in
+        // the importance weight. Also before re-evaluating the experts, which overwrites lastAdvice.
+        // See Stat.
+        if (weight.isInertWeight()) return
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
         playDistribution(x)
         val pPlayed = propensityOf(armIndex, x).coerceAtLeast(MIN_PLAY_PROB)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -12,7 +12,7 @@ import com.eignex.kumulant.bandit.requireArmIndex
 import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.core.Result
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.preview
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -140,6 +140,21 @@ class KnnContextualBandit(
     private val totalWeights: DoubleArray = DoubleArray(nbrArms)
     private var step: Long = 0L
 
+    // Width of the contexts this bandit has been shown, learned from the first one. Without it the
+    // only check is the one inside the distance kernel, which does not run until an arm holds k
+    // contexts - so a mis-sized context is accepted, and the first call to throw is a later choose
+    // reporting a mismatch from a helper rather than from the entry point that took the bad data. A
+    // custom distance that skips the check would silently compute against the wrong coordinates.
+    private var featureSize: Int = UNKNOWN_FEATURE_SIZE
+
+    private fun requireFeatureSize(size: Int) {
+        if (featureSize == UNKNOWN_FEATURE_SIZE) {
+            featureSize = size
+            return
+        }
+        require(size == featureSize) { "context size $size != $featureSize" }
+    }
+
     /** Argmax over per-arm [evaluate] scores. Ties broken by lowest index. */
     override fun choose(x: F64VectorView): Int {
         val bestIdx = argmaxArm(nbrArms) { a -> evaluate(a, x) }
@@ -150,6 +165,7 @@ class KnnContextualBandit(
     /** Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus. */
     override fun evaluate(armIndex: Int, x: F64VectorView): Double {
         requireArmIndex(armIndex, nbrArms)
+        requireFeatureSize(x.size)
         val ctx = historyContexts[armIndex]
         if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
         val mean = knnMean(armIndex, x)
@@ -160,7 +176,11 @@ class KnnContextualBandit(
     override fun update(armIndex: Int, x: F64VectorView, reward: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
         // An inert observation must not consume a history slot; the eviction below would drop real data.
-        if (weight.isInertWeight()) return
+        // A negative weight drops for the same reason rather than downdating: a bounded history has no
+        // inverse, so it would append a second phantom entry and leave the arm reporting no evidence
+        // while two slots are spent. ReservoirHistogramStat guards the same way. See Stat.
+        if (weight.isNotPositiveWeight()) return
+        requireFeatureSize(x.size)
         val ctxs = historyContexts[armIndex]
         val rs = historyRewards[armIndex]
         val ws = historyWeights[armIndex]
@@ -216,6 +236,7 @@ class KnnContextualBandit(
             totalWeights[a] = 0.0
         }
         step = 0L
+        featureSize = UNKNOWN_FEATURE_SIZE
     }
 
     /** Spawn a fresh bandit with the same configuration; history resets to empty. */
@@ -263,6 +284,9 @@ class KnnContextualBandit(
     /** Distance-function helpers. */
     companion object {
         private const val COLD_START_BONUS = 1.0
+
+        /** No context has been seen yet, so the next one establishes the expected width. */
+        private const val UNKNOWN_FEATURE_SIZE = -1
 
         /**
          * Squared L2 distance between two vectors of equal size. Sparse-aware:

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Arms.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Arms.kt
@@ -174,6 +174,11 @@ data class NormalArm(
     val priorSquaredDeviations: Double = 0.02,
 ) : Arm<WeightedVarianceResult> {
     override fun createStat(): SeriesStat<WeightedVarianceResult> {
+        // Three seed points carrying priorWeight, priorWeight/2 and priorWeight/2, so the stat ends up
+        // with 2 * priorWeight of total weight and a squared-deviation sum of exactly
+        // priorSquaredDeviations - hence a reported variance of priorSquaredDeviations / (2 *
+        // priorWeight). Anything deriving one of these parameters from the other has to account for
+        // both factors; see NormalArm.warmStart.
         val s = VarianceStat()
         if (priorWeight > 0.0) {
             s.update(priorMean, 0L, priorWeight)
@@ -298,11 +303,16 @@ fun MeanArm.Companion.warmStart(global: WeightedMeanResult, shrinkage: Double = 
  *  variance is preserved from the global; only the prior weight is shrunk. */
 fun NormalArm.Companion.warmStart(global: WeightedVarianceResult, shrinkage: Double = 1.0): NormalArm {
     require(shrinkage in 0.0..1.0) { "shrinkage must be in [0, 1], got $shrinkage" }
-    val priorWeight = global.totalWeights * shrinkage
+    // createStat seeds 2 * priorWeight of total weight and reports
+    // priorSquaredDeviations / (2 * priorWeight) as the variance, so both parameters are halved
+    // relative to the weight the seeded stat should end up carrying. Passing the shrunk weight
+    // straight through would seed twice the evidence at half the global's spread, leaving a
+    // warm-started arm roughly 2.8x over-confident and under-explored by Thompson sampling.
+    val seededWeight = global.totalWeights * shrinkage
     return NormalArm(
         priorMean = global.mean,
-        priorWeight = priorWeight,
-        priorSquaredDeviations = global.variance * priorWeight,
+        priorWeight = seededWeight / 2.0,
+        priorSquaredDeviations = global.variance * seededWeight,
     )
 }
 
@@ -310,11 +320,16 @@ fun NormalArm.Companion.warmStart(global: WeightedVarianceResult, shrinkage: Dou
  *  scale (caller is responsible for ensuring the snapshot is over `ln(reward)`). */
 fun LogNormalArm.Companion.warmStart(global: WeightedVarianceResult, shrinkage: Double = 1.0): LogNormalArm {
     require(shrinkage in 0.0..1.0) { "shrinkage must be in [0, 1], got $shrinkage" }
-    val priorWeight = global.totalWeights * shrinkage
+    // createStat seeds 2 * priorWeight of total weight and reports
+    // priorSquaredDeviations / (2 * priorWeight) as the variance, so both parameters are halved
+    // relative to the weight the seeded stat should end up carrying. Passing the shrunk weight
+    // straight through would seed twice the evidence at half the global's spread, leaving a
+    // warm-started arm roughly 2.8x over-confident and under-explored by Thompson sampling.
+    val seededWeight = global.totalWeights * shrinkage
     return LogNormalArm(
         priorMean = global.mean,
-        priorWeight = priorWeight,
-        priorSquaredDeviations = global.variance * priorWeight,
+        priorWeight = seededWeight / 2.0,
+        priorSquaredDeviations = global.variance * seededWeight,
     )
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BanditPolicies.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.stat.summary.BernoulliSumResult
 import com.eignex.kumulant.stat.summary.MomentsResult
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
+import com.eignex.kumulant.stream.AtomicMode
 import kotlin.math.ln
 import kotlin.math.min
 import kotlin.math.pow
@@ -180,24 +181,29 @@ class UCB1(
     priorBeta: Double = 1.0,
 ) : BanditPolicy<BernoulliSumResult> {
     override val arm = BernoulliArm(priorAlpha, priorBeta)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
     override fun createPolicy() = UCB1(alpha, arm.priorAlpha, arm.priorBeta)
 
     override fun update(stat: SeriesStat<BernoulliSumResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
     override fun evaluate(snapshot: BernoulliSumResult, step: Long, rng: Random): Double {
         val n = snapshot.trials
         if (n < 1.0) return Double.POSITIVE_INFINITY
         val mean = snapshot.successes / n
-        return mean + alpha * sqrt(2 * ln(totalSamples) / n)
+        return mean + alpha * sqrt(2 * ln(totalSamples.load()) / n)
     }
     override fun addArm(snapshot: BernoulliSumResult) {
-        totalSamples += snapshot.trials
+        totalSamples.add(snapshot.trials)
     }
     override fun removeArm(snapshot: BernoulliSumResult) {
-        totalSamples -= snapshot.trials
+        totalSamples.add(-snapshot.trials)
     }
 }
 
@@ -224,6 +230,14 @@ class UCB1Normal(
 
     override fun evaluate(snapshot: MomentsResult, step: Long, rng: Random): Double {
         val nj = snapshot.totalWeights
+        // Deliberately the arm count, where Auer et al. use the total number of plays. Their n grows only
+        // because each play returns a reward, so n and the sum of the per-arm counts advance together;
+        // here `step` counts choose() calls and `nj` counts update weight, and nothing pairs them. A
+        // caller that scores without feeding rewards back would push 8*ln(step) past every arm's weight
+        // and force for good, never reaching the bound at all. Against nbrArms the forced phase is a
+        // bounded warm-up instead, and the confidence term below - which does scale by the total - goes
+        // on exploring after it.
+        val totalPulls = maxOf(step.toDouble(), nj)
         if (nbrArms <= 1 || nj < 8 * ln(nbrArms.toDouble())) return Double.POSITIVE_INFINITY
         // Auer et al. subtract `n * mean^2` from the SUM of squares, and meanOfSquares() is the
         // MEAN of squares, so this has to scale up by `nj` first. Subtracting from `E[x^2]` instead
@@ -231,12 +245,9 @@ class UCB1Normal(
         // `choose` resolves to always picking arm 0 (`NaN > -Inf` is false).
         val sumOfSquares = snapshot.meanOfSquares() * nj
         val p1 = ((sumOfSquares - nj * snapshot.mean * snapshot.mean) / (nj - 1)).coerceAtLeast(0.0)
-        // `n` in Auer et al. is the total pull count, not the arm count. Against `nbrArms` the log
-        // term is ln(1) == 0 at K = 2, so the confidence bound vanishes and the policy goes exactly
-        // greedy at the arm count where exploration matters most. `step` carries the round count,
-        // which is why it is a parameter; this arm's own pulls floor it, since they are part of any total and
-        // `step` stays 0 for a caller that drives update() directly without choose().
-        val totalPulls = maxOf(step.toDouble(), nj)
+        // `step` carries the round count, which is why it is a parameter; this arm's own pulls floor it,
+        // since they are part of any total and `step` stays 0 for a caller that drives update()
+        // directly without choose().
         return snapshot.mean + alpha * sqrt(16 * p1 * (ln((totalPulls - 1.0).coerceAtLeast(1.0)) / nj))
     }
     override fun addArm(snapshot: MomentsResult) {
@@ -265,25 +276,30 @@ class UCB1Tuned(
     priorWeight: Double = 0.02,
 ) : BanditPolicy<MomentsResult> {
     override val arm = MomentsArm(priorMean, priorWeight)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
     override fun createPolicy() = UCB1Tuned(alpha, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<MomentsResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
     override fun evaluate(snapshot: MomentsResult, step: Long, rng: Random): Double {
         val nj = snapshot.totalWeights
         if (nj <= 1.0) return Double.POSITIVE_INFINITY
-        val padding = ln(totalSamples) / nj
+        val padding = ln(totalSamples.load()) / nj
         val v = snapshot.meanOfSquares() - snapshot.mean * snapshot.mean + sqrt(2.0 * padding)
         return snapshot.mean + alpha * sqrt(padding * min(0.25, v))
     }
     override fun addArm(snapshot: MomentsResult) {
-        totalSamples += snapshot.totalWeights
+        totalSamples.add(snapshot.totalWeights)
     }
     override fun removeArm(snapshot: MomentsResult) {
-        totalSamples -= snapshot.totalWeights
+        totalSamples.add(-snapshot.totalWeights)
     }
 }
 
@@ -301,6 +317,33 @@ class Greedy(priorMean: Double = 0.0, priorWeight: Double = 0.02, priorSquaredDe
     BanditPolicy<WeightedVarianceResult> {
     override val arm = NormalArm(priorMean, priorWeight, priorSquaredDeviations)
     override fun evaluate(snapshot: WeightedVarianceResult, step: Long, rng: Random) = snapshot.mean
+}
+
+/**
+ * One explore-or-exploit coin per round, drawn from the caller's generator.
+ *
+ * The decision has to agree across every arm in a round: scored per arm, an explore draw would compete
+ * against other arms' means and the argmax would favour whichever arm happened to draw high, which is
+ * not epsilon-greedy. Keying the cached draw on the round is what makes it agree - but keying the
+ * *generator* on the round, as `Random(step)` does, makes the decision a pure function of the round
+ * index and so identical for every seed: an ensemble built through `create(random)` to decorrelate
+ * exploration would explore in lockstep instead.
+ *
+ * A caller that drives `evaluate` without ever calling `choose` leaves the round at 0 and so keeps the
+ * first coin; there is no round clock to key on in that case. Under racing rounds two of them may share
+ * a coin, which is bounded drift of the kind the concurrency contract allows.
+ */
+internal class RoundCoin {
+    private var round = Long.MIN_VALUE
+    private var draw = 0.0
+
+    fun explores(step: Long, rng: Random, epsilon: Double): Boolean {
+        if (step != round) {
+            round = step
+            draw = rng.nextDouble()
+        }
+        return draw < epsilon
+    }
 }
 
 /**
@@ -327,8 +370,10 @@ class EpsilonGreedy(
     }
     override val arm = NormalArm(priorMean, priorWeight, priorSquaredDeviations)
 
+    private val coin = RoundCoin()
+
     override fun evaluate(snapshot: WeightedVarianceResult, step: Long, rng: Random): Double =
-        if (Random(step).nextDouble() < epsilon) {
+        if (coin.explores(step, rng, epsilon)) {
             rng.nextDouble()
         } else {
             snapshot.mean
@@ -358,27 +403,33 @@ class EpsilonDecreasing(
         require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
     }
     override val arm = NormalArm(priorMean, priorWeight, priorSquaredDeviations)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
+    private val coin = RoundCoin()
     override fun createPolicy() =
         EpsilonDecreasing(epsilon, decay, arm.priorMean, arm.priorWeight, arm.priorSquaredDeviations)
 
     override fun update(stat: SeriesStat<WeightedVarianceResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
     override fun evaluate(snapshot: WeightedVarianceResult, step: Long, rng: Random): Double {
-        val eps = min(1.0, epsilon / totalSamples.pow(decay))
-        return if (Random(step).nextDouble() < eps) {
+        val eps = min(1.0, epsilon / totalSamples.load().pow(decay))
+        return if (coin.explores(step, rng, eps)) {
             rng.nextDouble()
         } else {
             snapshot.mean
         }
     }
     override fun addArm(snapshot: WeightedVarianceResult) {
-        totalSamples += snapshot.totalWeights
+        totalSamples.add(snapshot.totalWeights)
     }
     override fun removeArm(snapshot: WeightedVarianceResult) {
-        totalSamples -= snapshot.totalWeights
+        totalSamples.add(-snapshot.totalWeights)
     }
 }
 
@@ -424,27 +475,32 @@ class KlUcb(
     priorBeta: Double = 1.0,
 ) : BanditPolicy<BernoulliSumResult> {
     override val arm = BernoulliArm(priorAlpha, priorBeta)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
     override fun createPolicy() = KlUcb(c, tolerance, arm.priorAlpha, arm.priorBeta)
 
     override fun update(stat: SeriesStat<BernoulliSumResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
 
     override fun evaluate(snapshot: BernoulliSumResult, step: Long, rng: Random): Double {
         val n = snapshot.trials
-        if (n < 1.0 || totalSamples <= 1.0) return Double.POSITIVE_INFINITY
+        if (n < 1.0 || totalSamples.load() <= 1.0) return Double.POSITIVE_INFINITY
         val mean = (snapshot.successes / n).coerceIn(0.0, 1.0)
-        val bound = (ln(totalSamples) + c * ln(ln(totalSamples).coerceAtLeast(1.0))) / n
+        val bound = (ln(totalSamples.load()) + c * ln(ln(totalSamples.load()).coerceAtLeast(1.0))) / n
         return klBernoulliUpper(mean, bound, tolerance)
     }
 
     override fun addArm(snapshot: BernoulliSumResult) {
-        totalSamples += snapshot.trials
+        totalSamples.add(snapshot.trials)
     }
     override fun removeArm(snapshot: BernoulliSumResult) {
-        totalSamples -= snapshot.trials
+        totalSamples.add(-snapshot.trials)
     }
 
     /** Bernoulli KL utilities used by [KlUcb]. */
@@ -502,27 +558,32 @@ class Moss(
         requireNbrArms(nbrArms)
     }
     override val arm = MeanArm(priorMean, priorWeight)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
     override fun createPolicy() = Moss(nbrArms, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<WeightedMeanResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
 
     override fun evaluate(snapshot: WeightedMeanResult, step: Long, rng: Random): Double {
         val n = snapshot.totalWeights
         if (n < 1.0) return Double.POSITIVE_INFINITY
-        val arg = totalSamples / (nbrArms * n)
+        val arg = totalSamples.load() / (nbrArms * n)
         val padding = ln(arg.coerceAtLeast(1.0))
         return snapshot.mean + sqrt(padding / n)
     }
 
     override fun addArm(snapshot: WeightedMeanResult) {
-        totalSamples += snapshot.totalWeights
+        totalSamples.add(snapshot.totalWeights)
     }
     override fun removeArm(snapshot: WeightedMeanResult) {
-        totalSamples -= snapshot.totalWeights
+        totalSamples.add(-snapshot.totalWeights)
     }
 }
 
@@ -553,26 +614,31 @@ class UcbV(
         require(zeta > 0.0) { "zeta must be positive, got $zeta" }
     }
     override val arm = MomentsArm(priorMean, priorWeight)
-    private var totalSamples: Double = 0.0
+
+    // Atomic, not a plain field: MultiArmedBandit promises that updates racing on different arms never
+    // block, and every bound below divides by this counter. A lost read-modify-write leaves it short of
+    // the true total for good, so every arm's exploration bonus shrinks and never re-syncs, and a
+    // non-volatile 64-bit field could additionally tear into a value whose logarithm is NaN.
+    private val totalSamples = AtomicMode.newDouble(0.0)
     override fun createPolicy() = UcbV(zeta, c, arm.priorMean, arm.priorWeight)
 
     override fun update(stat: SeriesStat<MomentsResult>, value: Double, weight: Double) {
         stat.update(arm.encode(value), 0L, weight)
-        totalSamples += weight
+        totalSamples.add(weight)
     }
 
     override fun evaluate(snapshot: MomentsResult, step: Long, rng: Random): Double {
         val n = snapshot.totalWeights
         if (n < 1.0) return Double.POSITIVE_INFINITY
         val v = (snapshot.meanOfSquares() - snapshot.mean * snapshot.mean).coerceAtLeast(0.0)
-        val logT = ln(totalSamples.coerceAtLeast(2.0))
+        val logT = ln(totalSamples.load().coerceAtLeast(2.0))
         return snapshot.mean + sqrt(2.0 * v * zeta * logT / n) + 3.0 * c * zeta * logT / n
     }
 
     override fun addArm(snapshot: MomentsResult) {
-        totalSamples += snapshot.totalWeights
+        totalSamples.add(snapshot.totalWeights)
     }
     override fun removeArm(snapshot: MomentsResult) {
-        totalSamples -= snapshot.totalWeights
+        totalSamples.add(-snapshot.totalWeights)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBandit.kt
@@ -91,6 +91,12 @@ class BoltzmannBandit(
         // Dividing by tau before the max-shift is the same arithmetic, since tau > 0 is enforced at
         // construction and so `max(means)/tau == max(means/tau)`, and it costs one array instead of two.
         val logits = DoubleArray(nbrArms) { stats[it].read(0L).mean / tau }
+        // A single NaN reward makes that arm's mean NaN for good, and one NaN logit takes the whole
+        // softmax with it - the max-shift leaves NaN alone and the sum is NaN, which softmaxInPlace
+        // still reports as usable. `choose` then resolves an all-NaN distribution to "always the last
+        // arm", with no way back. Uniform is the honest distribution when no arm has usable evidence,
+        // as it is for Exp3Bandit and Exp4Bandit.
+        if (logits.any { !it.isFinite() }) return DoubleArray(nbrArms) { 1.0 / nbrArms }
         logits.softmaxInPlace()
         return logits
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/Exp3Bandit.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.bandit.requireMergeSize
 import com.eignex.kumulant.bandit.requireNbrArms
 import com.eignex.kumulant.bandit.sampleFromDistribution
 import com.eignex.kumulant.core.Result
+import com.eignex.kumulant.core.isInertWeight
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.exp
@@ -119,6 +120,11 @@ class Exp3Bandit(
     /** Fold a `(arm, reward)` observation into the played arm's weight. */
     override fun update(armIndex: Int, value: Double, weight: Double) {
         requireArmIndex(armIndex, nbrArms)
+        // Return before propensityOf, which consumes an outstanding pull. The exponential weights are
+        // already untouched by a zero gain, but spending the recorded propensity is not a no-op: the
+        // real feedback for that pull would then fall back to the current distribution and be divided
+        // by the wrong probability, which is an unbounded error in the importance weight. See Stat.
+        if (weight.isInertWeight()) return
         val p = propensityOf(armIndex).coerceAtLeast(MIN_PLAY_PROB)
         val gain = (value * weight) / p
         weights[armIndex] *= exp(eta * gain)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBandit.kt
@@ -133,8 +133,12 @@ class RouletteWheelBandit(
         for (i in weights.indices) {
             if (segmentWeights[i] > 0.0) {
                 val avg = accumulatedScores[i] / segmentWeights[i]
-                weights[i] = (weights[i] * (1.0 - reactionFactor) + reactionFactor * avg)
-                    .coerceAtLeast(minWeight)
+                val blended = weights[i] * (1.0 - reactionFactor) + reactionFactor * avg
+                // coerceAtLeast is `if (this < min) min else this`, and NaN < minWeight is false, so a
+                // NaN blend walks straight through the floor that exists to keep weights usable. It
+                // then makes the roulette total NaN, and `choose` resolves that to "always the last
+                // arm" for good. An arm with no usable evidence gets the floor, like any other.
+                weights[i] = if (blended.isFinite()) blended.coerceAtLeast(minWeight) else minWeight
             }
             accumulatedScores[i] = 0.0
             segmentWeights[i] = 0.0

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -147,3 +147,24 @@ class KnnContextualBanditTest {
         assertEquals(9.0, squaredL2(a, b))
     }
 }
+
+class KnnContextDimensionTest {
+
+    @Test
+    fun `update rejects a context of the wrong width at the entry point`() {
+        val b = KnnContextualBandit(nbrArms = 2, k = 5)
+        b.update(0, feat(1.0, 2.0, 3.0), 1.0)
+        assertFailsWith<IllegalArgumentException> {
+            b.update(0, feat(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0)
+        }
+    }
+
+    @Test
+    fun `a negative weight does not spend a history slot`() {
+        val b = KnnContextualBandit(nbrArms = 2, k = 1)
+        val x = feat(1.0, 2.0)
+        b.update(0, x, 10.0, weight = 1.0)
+        b.update(0, x, 10.0, weight = -1.0)
+        assertEquals(1, b.historySize(0))
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/ArmsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/ArmsTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.bandit.univariate
 
+import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.summary.BernoulliSumResult
 import com.eignex.kumulant.stat.summary.MomentsResult
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
@@ -150,11 +151,10 @@ class ArmsTest {
             mean = 4.0,
             variance = 9.0,
         )
-        val arm = NormalArm.warmStart(global, shrinkage = 0.5)
-        assertEquals(4.0, arm.priorMean)
-        assertEquals(100.0, arm.priorWeight)
-        // priorSquaredDeviations = variance * shrunkWeight = 9 * 100 = 900
-        assertEquals(900.0, arm.priorSquaredDeviations)
+        val seeded = NormalArm.warmStart(global, shrinkage = 0.5).createStat().read(0L)
+        assertEquals(100.0, seeded.totalWeights, DELTA)
+        assertEquals(4.0, seeded.mean, DELTA)
+        assertEquals(9.0, seeded.variance, DELTA)
     }
 
     @Test
@@ -164,10 +164,10 @@ class ArmsTest {
             mean = 1.5,
             variance = 4.0,
         )
-        val arm = LogNormalArm.warmStart(global, shrinkage = 0.25)
-        assertEquals(1.5, arm.priorMean)
-        assertEquals(20.0, arm.priorWeight)
-        assertEquals(80.0, arm.priorSquaredDeviations)
+        val seeded = LogNormalArm.warmStart(global, shrinkage = 0.25).createStat().read(0L)
+        assertEquals(20.0, seeded.totalWeights, DELTA)
+        assertEquals(1.5, seeded.mean, DELTA)
+        assertEquals(4.0, seeded.variance, DELTA)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BanditPoliciesTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BanditPoliciesTest.kt
@@ -231,3 +231,31 @@ class BanditPoliciesTest {
         assertTrue(abs(mean - 5.0 / 7.0) < 0.03, "mean=$mean")
     }
 }
+
+class EpsilonPolicyRandomnessTest {
+
+    private val snapshot = WeightedVarianceResult(totalWeights = 10.0, mean = 5.0, variance = 1.0)
+
+    @Test
+    fun `the explore decision depends on the caller's rng`() {
+        val decisions = (1..50).map { seed ->
+            EpsilonGreedy(epsilon = 0.5).evaluate(snapshot, step = 7L, rng = Random(seed)) == snapshot.mean
+        }
+        assertTrue(decisions.toSet().size > 1, "the decision at a fixed step is the same for every seed")
+    }
+
+    @Test
+    fun `the explore decision is shared by every arm in a round`() {
+        for (seed in 1..20) {
+            val policy = EpsilonGreedy(epsilon = 0.5)
+            val rng = Random(seed)
+            val first = policy.evaluate(snapshot, step = 7L, rng = rng)
+            val second = policy.evaluate(snapshot, step = 7L, rng = rng)
+            assertEquals(
+                first == snapshot.mean,
+                second == snapshot.mean,
+                "arms in one round disagreed on exploring, seed=$seed",
+            )
+        }
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/BoltzmannBanditTest.kt
@@ -59,3 +59,23 @@ class BoltzmannBanditTest {
         assertTrue(abs(b.temperature() - 1.0) < 1e-9)
     }
 }
+
+class BoltzmannNonFiniteRewardTest {
+
+    @Test
+    fun `a NaN reward does not pin choose to the last arm`() {
+        val b = BoltzmannBandit(nbrArms = 3, random = Random(0))
+        b.update(0, Double.NaN)
+        b.update(2, 5.0)
+        val picks = (0 until 200).map { b.choose() }.toSet()
+        assertTrue(picks.size > 1, "every choose returned ${picks.first()}")
+    }
+
+    @Test
+    fun `a NaN reward leaves the play distribution usable`() {
+        val b = BoltzmannBandit(nbrArms = 3, random = Random(0))
+        b.update(0, Double.NaN)
+        val p = b.playDistribution()
+        assertTrue(p.all { it.isFinite() }, "distribution=${p.toList()}")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/Exp3BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/Exp3BanditTest.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.bandit.univariate
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -63,5 +64,22 @@ class Exp3BanditTest {
         val direct = weightsAfter(delayed = false)
         val delayed = weightsAfter(delayed = true)
         for (i in direct.indices) assertTrue(abs(direct[i] - delayed[i]) < 1e-9, "arm $i: $direct vs $delayed")
+    }
+}
+
+class Exp3InertWeightTest {
+
+    @Test
+    fun `a zero-weight update does not consume a recorded propensity`() {
+        fun run(withInertUpdate: Boolean): DoubleArray {
+            val b = Exp3Bandit(nbrArms = 2, eta = 0.5, gamma = 0.1, random = Random(1))
+            b.choose()
+            b.choose()
+            if (withInertUpdate) b.update(0, 1.0, 0.0)
+            b.update(1, 1.0, 1.0)
+            b.update(0, 1.0, 1.0)
+            return b.armWeights()
+        }
+        assertContentEquals(run(withInertUpdate = false).toList(), run(withInertUpdate = true).toList())
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/univariate/RouletteWheelBanditTest.kt
@@ -89,3 +89,23 @@ class RouletteWheelBanditTest {
         assertEquals(weightAfter(1.0), weightAfter(3.0))
     }
 }
+
+class RouletteWheelNonFiniteRewardTest {
+
+    @Test
+    fun `a NaN reward does not pin choose to the last arm`() {
+        val b = RouletteWheelBandit(nbrArms = 3, segmentLength = 10, random = Random(0))
+        repeat(9) { b.update(it % 3, 1.0) }
+        b.update(0, Double.NaN)
+        val picks = (0 until 200).map { b.choose() }.toSet()
+        assertTrue(picks.size > 1, "every choose returned ${picks.first()}")
+    }
+
+    @Test
+    fun `a NaN reward does not leave an arm weight non-finite`() {
+        val b = RouletteWheelBandit(nbrArms = 3, segmentLength = 10, random = Random(0))
+        repeat(9) { b.update(it % 3, 1.0) }
+        b.update(0, Double.NaN)
+        assertTrue(b.snapshot().all { it.weight.isFinite() }, "weights=${b.snapshot()}")
+    }
+}


### PR DESCRIPTION
## What changed

- BoltzmannBandit falls back to uniform when any arm logit is non-finite.
- RouletteWheelBandit treats a non-finite rebalanced weight as the floor.
- NormalArm.warmStart and LogNormalArm.warmStart account for createStat seeding twice the prior weight.
- EXP3 and EXP4 return on an inert weight before consuming a recorded propensity.
- The epsilon policies draw their per-round explore coin from the caller RNG through a shared RoundCoin.
- The six stateful policy sample counters are atomic.
- KnnContextualBandit drops non-positive weights and validates the context width at both entry points.

## Why

A single NaN reward pinned choose to the last arm forever, in two bandits, with no recovery path. Exp3 and Exp4 already fixed exactly this and said so in a comment; Boltzmann and RouletteWheel were missed. In RouletteWheel the NaN walked through the minWeight floor, because coerceAtLeast compares with a predicate that is false for NaN.

warmStart documented that it preserves the global variance and shrinks only the weight, and did neither: the seeded stat carried twice the intended weight at half the spread, leaving a warm-started arm about 2.8x over-confident. A zero-weight EXP3 update spent the pull the real feedback needed, so that feedback was divided by the current distribution instead of the recorded propensity, changing the weight update by a factor of e^9.4. The epsilon coin was a pure function of the round index, so two bandits with different seeds explored on identical rounds and an ensemble built to decorrelate exploration explored in lockstep.

## Why not

UCB1Normal keeps its arm-count forced-exploration threshold. The finding is right that Auer uses total plays, but his n grows only because each play returns a reward, so it equals the sum of the per-arm counts. Here step counts choose calls and nj counts update weight, and nothing pairs them, so a caller that scores without feeding rewards back would force exploration for good and never reach the bound. The faithful rule also broke two tuning tests. The deviation is recorded in a comment for whoever wants to revisit it.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. Every fix has a test confirmed to fail beforehand. The bagging retraction test sweeps twenty seeds, since whether the failure shows depends on the draw sequence.