### PR TITLE
fix: stop merges and retractions manufacturing change alarms

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -219,22 +219,32 @@ class HalfSpaceTreesStat(
     private fun rotateWindow() = swapLock.guarded {
         if (windowCounter.load() < windowSize) return@guarded
         windowCounter.store(0L)
+        // Relative adds, not stores: `update` deliberately runs without this lock, so a blind store
+        // would discard any per-leaf add that landed between the load and the write - a dropped
+        // observation, and one that leaves totalWeights recording mass the profile no longer holds.
+        // Expressed as deltas, a racing add either survives in the latest window for the next rotation
+        // or is already counted here, never neither.
         for (i in 0 until numTrees * numLeaves) {
             val latest = latestMass.load(i)
-            referenceMass.store(i, latest)
-            latestMass.store(i, 0.0)
+            referenceMass.add(i, latest - referenceMass.load(i))
+            latestMass.add(i, -latest)
         }
     }
 
-    override fun read(timestampNanos: Long): HalfSpaceTreesResult = HalfSpaceTreesResult(
-        featureSize = featureSize,
-        numTrees = numTrees,
-        height = height,
-        totalWeights = totalWeightsCell.load(),
-        featureIndices = featureIndices.copyOf(),
-        thresholds = thresholds.copyOf(),
-        referenceMass = DoubleArray(numTrees * numLeaves) { referenceMass.load(it) },
-    )
+    // Guarded because the profile is a coupled structure, not a set of independent cells: a snapshot
+    // taken while rotateWindow is partway through its sweep would mix leaves from the new window with
+    // leaves from the previous reference, a profile the stream never held.
+    override fun read(timestampNanos: Long): HalfSpaceTreesResult = swapLock.guarded {
+        HalfSpaceTreesResult(
+            featureSize = featureSize,
+            numTrees = numTrees,
+            height = height,
+            totalWeights = totalWeightsCell.load(),
+            featureIndices = featureIndices.copyOf(),
+            thresholds = thresholds.copyOf(),
+            referenceMass = DoubleArray(numTrees * numLeaves) { referenceMass.load(it) },
+        )
+    }
 
     /**
      * Merge folds another snapshot's reference-window masses into both this stat's reference and
@@ -263,11 +273,15 @@ class HalfSpaceTreesStat(
         require(values.referenceMass.size == numTrees * numLeaves) {
             "merge: expected ${numTrees * numLeaves} masses, got ${values.referenceMass.size}"
         }
-        for (i in 0 until numTrees * numLeaves) {
-            referenceMass.add(i, values.referenceMass[i])
-            latestMass.add(i, values.referenceMass[i])
+        // Under the same lock as the rotation and the read: the masses go in as adds, so they compose
+        // with a concurrent update, but a reader must not catch the profile half-merged.
+        swapLock.guarded {
+            for (i in 0 until numTrees * numLeaves) {
+                referenceMass.add(i, values.referenceMass[i])
+                latestMass.add(i, values.referenceMass[i])
+            }
+            totalWeightsCell.add(values.totalWeights)
         }
-        totalWeightsCell.add(values.totalWeights)
     }
 
     override fun reset() = swapLock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityStat.kt
@@ -117,9 +117,12 @@ class ReliabilityStat(val numBins: Int, override val concurrency: Concurrency = 
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
-        // coerceIn passes a NaN straight through and NaN.toInt() is 0, so a NaN prediction was
-        // credited to the first bin as though it were a confident zero. Backs IsotonicCalibratorStat
-        // too. See Stat.
+        // A NaN prediction belongs to no bin, so it is dropped rather than binned. coerceIn passes NaN
+        // straight through and NaN.toInt() is 0, which credited it to the first bin as though it were a
+        // confident zero - and while this stat's own mean and ECE would go NaN with it, sumO and sumW
+        // receive finite values, so IsotonicCalibratorStat's outcome rate loses the NaN entirely and
+        // reports a bin trained on predictions that were never made. See Stat.
+        if (x.isNaN()) return
         val clamped = x.coerceIn(0.0, 1.0)
         val bin = (clamped * numBins).toInt().coerceIn(0, numBins - 1)
         // Denominator first, numerators after. Combined with read() loading sumW last,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/AdwinStat.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.stat.change
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.SerialName
@@ -87,7 +87,10 @@ class AdwinStat(
     private var lastUpdateRaisedAlarm: Boolean = false
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight.isInertWeight()) return
+        // Non-positive rather than merely inert: this recurrence has no inverse -
+        // a bucket is appended, never taken back out - so the body below would run a
+        // downdate forwards, as an ordinary observation. See Stat.
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             rows[0].addLast(Bucket(n = 1L, sum = value, sumSquares = value * value))
             totalN += 1L

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/CusumStat.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.stat.change
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.monotonicMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -85,7 +85,10 @@ class CusumStat(
     private val initialized = streamMode.newLong(0L)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight.isInertWeight()) return
+        // Non-positive rather than merely inert: this recurrence has no inverse -
+        // the one-sided sums clip through max(0, .) and min(0, .) - so the body below would run a
+        // downdate forwards, as an ordinary observation. See Stat.
+        if (weight.isNotPositiveWeight()) return
         val deviation = value - target
         while (true) {
             val prev = cusumPos.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStat.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.stat.change
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.welfordLock
 import com.eignex.kumulant.stream.welfordMode
@@ -90,7 +90,10 @@ class PageHinkleyStat(
     private val maxNeg = streamMode.newDouble(0.0)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight.isInertWeight()) return
+        // Non-positive rather than merely inert: this recurrence has no inverse -
+        // the running min and max have no inverse - so the body below would run a
+        // downdate forwards, as an ordinary observation. See Stat.
+        if (weight.isNotPositiveWeight()) return
         lock.guarded {
             val n = count.load() + 1L
             count.store(n)
@@ -119,11 +122,17 @@ class PageHinkleyStat(
         mean.store(combinedMean)
         // Adopt verbatim while empty, as the count-weighted mean above already does implicitly. Halving
         // these would halve exactly the two quantities `alarmUp`/`alarmDown` threshold against.
+        //
+        // The running extremum averages the same way as the sum it is subtracted from. Taking the min
+        // of the two baselines while averaging the two signals leaves a pair neither trace ever held,
+        // and `cumPos - minPos` can then clear the threshold on two traces that each stayed well under
+        // it - a downward level shift merged with a flat trace alarms upward. Averaging both halves
+        // keeps the merged statistic the average of the two traces' statistics.
         val empty = localCount == 0L
         cumPos.store(if (empty) values.cumulativePositive else 0.5 * (cumPos.load() + values.cumulativePositive))
         cumNeg.store(if (empty) values.cumulativeNegative else 0.5 * (cumNeg.load() + values.cumulativeNegative))
-        minPos.store(min(minPos.load(), values.minPositive))
-        maxNeg.store(max(maxNeg.load(), values.maxNegative))
+        minPos.store(if (empty) values.minPositive else 0.5 * (minPos.load() + values.minPositive))
+        maxNeg.store(if (empty) values.maxNegative else 0.5 * (maxNeg.load() + values.maxNegative))
     }
 
     override fun reset() = lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/RecursiveVarianceStat.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.stat.forecast
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.stream.monotonicMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -63,7 +63,10 @@ class RecursiveVarianceStat(
     private val initialized = mode.newLong(0L)
 
     override fun update(value: Double, timestampNanos: Long, weight: Double) {
-        if (weight.isInertWeight()) return
+        // Non-positive rather than merely inert: this recurrence has no inverse -
+        // the GARCH recurrence never consults the weight at all - so the body below would run a
+        // downdate forwards, as an ordinary observation. See Stat.
+        if (weight.isNotPositiveWeight()) return
         val x2 = value * value
         while (true) {
             val current = variance.load()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStat.kt
@@ -60,7 +60,12 @@ data class SeasonalSmoothingResult(
         requireForecastSteps(steps)
         if (steps == 0) return level
         val trendPart = level + dampedTrendSum(phi, steps) * trend
-        val seasonIndex = ((currentSlot + steps - 1) % period + period) % period
+        // Long: `currentSlot + steps - 1` overflows Int at a large horizon, and the renormalisation
+        // below keeps the wrapped value in range rather than throwing, so the wrong slot is picked
+        // silently whenever period is not a power of two. dampedTrendSum has a closed form precisely
+        // so a large horizon is cheap, which makes one reachable by design.
+        val ahead = currentSlot.toLong() + steps.toLong() - 1L
+        val seasonIndex = ((ahead % period + period) % period).toInt()
         val seasonFactor = seasons[seasonIndex]
         return when (mode) {
             SeasonalMode.Additive -> trendPart + seasonFactor

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityNaNPredictionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/calibration/ReliabilityNaNPredictionTest.kt
@@ -1,0 +1,22 @@
+package com.eignex.kumulant.stat.calibration
+
+import com.eignex.kumulant.DELTA
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReliabilityNaNPredictionTest {
+
+    @Test
+    fun `a NaN prediction is not credited to the first bin`() {
+        val withNaNs = IsotonicCalibratorStat(numBins = 4)
+        repeat(100) { withNaNs.update(0.05, 0.0) }
+        repeat(100) { withNaNs.update(0.9, 1.0) }
+        repeat(100) { withNaNs.update(Double.NaN, 1.0) }
+
+        val withoutNaNs = IsotonicCalibratorStat(numBins = 4)
+        repeat(100) { withoutNaNs.update(0.05, 0.0) }
+        repeat(100) { withoutNaNs.update(0.9, 1.0) }
+
+        assertEquals(withoutNaNs.read().calibrate(0.05), withNaNs.read().calibrate(0.05), DELTA)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/CusumStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/CusumStatTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.change
 
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.stat.forecast.RecursiveVarianceStat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -79,5 +80,34 @@ class CusumStatTest {
         val fresh = tpl.create()
         assertEquals(0.0, fresh.read().cusumPositive, DELTA)
         assertTrue(tpl.read().cusumPositive > 0.0)
+    }
+}
+
+class ChangeDetectorNegativeWeightTest {
+
+    @Test
+    fun `a retraction does not raise a Cusum alarm`() {
+        val s = CusumStat(target = 0.0, referenceValue = 0.5, threshold = 5.0)
+        repeat(100) { s.update(0.0) }
+        s.update(10.0, weight = -1.0)
+        assertFalse(s.read().alarmUp, "a removal raised an upward change alarm")
+    }
+
+    @Test
+    fun `a retraction does not grow the Adwin window`() {
+        val s = AdwinStat()
+        repeat(10) { s.update(1.0) }
+        val before = s.read().windowLength
+        s.update(3.0, weight = -1.0)
+        assertEquals(before, s.read().windowLength)
+    }
+
+    @Test
+    fun `a retraction does not raise the recursive variance`() {
+        val s = RecursiveVarianceStat(omega = 0.0, alpha = 0.1, beta = 0.9)
+        repeat(10) { s.update(0.0) }
+        val before = s.read().variance
+        s.update(10.0, weight = -1.0)
+        assertTrue(s.read().variance <= before, "variance rose from $before to ${s.read().variance}")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/change/PageHinkleyStatTest.kt
@@ -75,3 +75,36 @@ class PageHinkleyStatTest {
         assertTrue(tpl.read().count > 0)
     }
 }
+
+class PageHinkleyMergeAlarmTest {
+
+    @Test
+    fun `merging two traces that saw no upward drift does not raise one`() {
+        val downwardShift = PageHinkleyStat()
+        repeat(60) { downwardShift.update(0.0) }
+        repeat(60) { downwardShift.update(-5.0) }
+        val flat = PageHinkleyStat()
+        repeat(120) { flat.update(0.0) }
+
+        assertFalse(downwardShift.read().alarmUp, "the downward-shift trace already alarmed up")
+        assertFalse(flat.read().alarmUp, "the flat trace already alarmed up")
+
+        downwardShift.merge(flat.read())
+        assertFalse(downwardShift.read().alarmUp, "merging two quiet traces manufactured an upward alarm")
+    }
+
+    @Test
+    fun `merging two traces that saw no downward drift does not raise one`() {
+        val upwardShift = PageHinkleyStat()
+        repeat(60) { upwardShift.update(0.0) }
+        repeat(60) { upwardShift.update(5.0) }
+        val flat = PageHinkleyStat()
+        repeat(120) { flat.update(0.0) }
+
+        assertFalse(upwardShift.read().alarmDown, "the upward-shift trace already alarmed down")
+        assertFalse(flat.read().alarmDown, "the flat trace already alarmed down")
+
+        upwardShift.merge(flat.read())
+        assertFalse(upwardShift.read().alarmDown, "merging two quiet traces manufactured a downward alarm")
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/forecast/SeasonalSmoothingStatTest.kt
@@ -116,3 +116,17 @@ class SeasonalSmoothingStatTest {
         for (sx in r.seasons) assertEquals(0.0, sx, DELTA)
     }
 }
+
+class SeasonalForecastHorizonTest {
+
+    @Test
+    fun `a huge horizon picks the same slot as the equivalent short one`() {
+        val s = SeasonalSmoothingStat(period = 3, alpha = 0.5, beta = 0.0, gamma = 0.5)
+        // 29 updates leaves the next slot at 2, so `currentSlot + steps - 1` is the sum that overflows.
+        for (i in 0 until 29) s.update(1.0 + (i % 3))
+        val r = s.read()
+        // Int.MAX_VALUE is 1 mod 3, so it lands on the same season slot as one step ahead, and with
+        // beta = 0 the trend term contributes nothing at either horizon.
+        assertEquals(r.forecast(1), r.forecast(Int.MAX_VALUE), DELTA)
+    }
+}


### PR DESCRIPTION
## What changed

- PageHinkleyStat.merge averages its running extremum the same way as the cumulative sum it is subtracted from.
- CusumStat, PageHinkleyStat, AdwinStat and RecursiveVarianceStat drop non-positive weights.
- HalfSpaceTreesStat rotates its windows with relative adds, and read and merge take the swap lock.
- ReliabilityStat drops a NaN prediction instead of binning it.
- SeasonalSmoothingResult.forecast does its slot arithmetic in Long.

## Why

Page-Hinkley thresholds on the difference between the cumulative sum and its running minimum, and merge combined the two halves with different operators. Two traces that each saw no upward drift merged into one that reported upward drift. Four order-dependent stats admitted a negative weight and then ran it as an ordinary forward observation, because none of them consults the weight at all: retracting a sample raised a change alarm, grew the ADWIN window, and raised the recursive variance.

The half-space rotation overwrote per-leaf mass with a blind store while update ran unlocked, so a concurrent add was lost while the total weight still recorded it, and an unlocked read could snapshot a profile that never existed. A NaN prediction was credited to bin 0 as a confident zero; this stat propagates the NaN but IsotonicCalibratorStat divides two finite sums, so the NaN vanished and the bin reported a rate trained on predictions never made.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. Each fix has a test confirmed to fail beforehand, with the numbers the sweep predicted. The half-space locking is verified by inspection rather than a race test: the blind store against a concurrent add is plain in the code, and the rotation now uses deltas so nothing can be overwritten.