### PR TITLE
fix: scale tree splits to the criterion and keep posteriors exploring

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -3289,6 +3289,33 @@ public final class com/eignex/kumulant/schema/spec/BrierScore : com/eignex/kumul
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/eignex/kumulant/schema/spec/ClassCounts : com/eignex/kumulant/schema/spec/SeriesStatSpec {
+	public static final field Companion Lcom/eignex/kumulant/schema/spec/ClassCounts$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/eignex/kumulant/schema/spec/ClassCounts;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/schema/spec/ClassCounts;IILjava/lang/Object;)Lcom/eignex/kumulant/schema/spec/ClassCounts;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumClasses ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/eignex/kumulant/schema/spec/ClassCounts$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/eignex/kumulant/schema/spec/ClassCounts$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/eignex/kumulant/schema/spec/ClassCounts;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/eignex/kumulant/schema/spec/ClassCounts;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/eignex/kumulant/schema/spec/ClassCounts$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/eignex/kumulant/schema/spec/ConfusionMatrix : com/eignex/kumulant/schema/spec/PairedStatSpec {
 	public static final field Companion Lcom/eignex/kumulant/schema/spec/ConfusionMatrix$Companion;
 	public fun <init> (I)V

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -3049,6 +3049,32 @@ final class com.eignex.kumulant.schema.spec/BloomFilter : com.eignex.kumulant.sc
     }
 }
 
+final class com.eignex.kumulant.schema.spec/ClassCounts : com.eignex.kumulant.schema.spec/SeriesStatSpec<com.eignex.kumulant.stat.regression.tree/ClassCountsResult> { // com.eignex.kumulant.schema.spec/ClassCounts|null[0]
+    constructor <init>(kotlin/Int) // com.eignex.kumulant.schema.spec/ClassCounts.<init>|<init>(kotlin.Int){}[0]
+
+    final val numClasses // com.eignex.kumulant.schema.spec/ClassCounts.numClasses|{}numClasses[0]
+        final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.schema.spec/ClassCounts.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
+
+    final fun component1(): kotlin/Int // com.eignex.kumulant.schema.spec/ClassCounts.component1|component1(){}[0]
+    final fun copy(kotlin/Int = ...): com.eignex.kumulant.schema.spec/ClassCounts // com.eignex.kumulant.schema.spec/ClassCounts.copy|copy(kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.schema.spec/ClassCounts.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.eignex.kumulant.schema.spec/ClassCounts.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.eignex.kumulant.schema.spec/ClassCounts.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.schema.spec/ClassCounts> { // com.eignex.kumulant.schema.spec/ClassCounts.$serializer|null[0]
+        final val descriptor // com.eignex.kumulant.schema.spec/ClassCounts.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.eignex.kumulant.schema.spec/ClassCounts.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.eignex.kumulant.schema.spec/ClassCounts.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.eignex.kumulant.schema.spec/ClassCounts // com.eignex.kumulant.schema.spec/ClassCounts.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.eignex.kumulant.schema.spec/ClassCounts) // com.eignex.kumulant.schema.spec/ClassCounts.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.eignex.kumulant.schema.spec.ClassCounts){}[0]
+    }
+
+    final object Companion { // com.eignex.kumulant.schema.spec/ClassCounts.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.schema.spec/ClassCounts> // com.eignex.kumulant.schema.spec/ClassCounts.Companion.serializer|serializer(){}[0]
+    }
+}
+
 final class com.eignex.kumulant.schema.spec/ConfusionMatrix : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.score/ConfusionMatrixResult> { // com.eignex.kumulant.schema.spec/ConfusionMatrix|null[0]
     constructor <init>(kotlin/Int) // com.eignex.kumulant.schema.spec/ConfusionMatrix.<init>|<init>(kotlin.Int){}[0]
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -99,6 +99,7 @@ import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
 import com.eignex.kumulant.stat.regression.glm.UnivariateRegressionStat
+import com.eignex.kumulant.stat.regression.tree.ClassCountsStat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeClassifierStat
 import com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat
 import com.eignex.kumulant.stat.regression.tree.RandomForestClassifierStat
@@ -179,6 +180,8 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
         Moments -> MomentsStat(concurrency)
 
         Summary -> SummaryStat(concurrency)
+
+        is ClassCounts -> ClassCountsStat(numClasses, concurrency)
 
         GaussianScorer -> GaussianScorerStat(concurrency)
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Stats.kt
@@ -37,6 +37,7 @@ import com.eignex.kumulant.stat.regression.glm.Link
 import com.eignex.kumulant.stat.regression.glm.Penalty
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult
 import com.eignex.kumulant.stat.regression.glm.UnivariateRegressionResult
+import com.eignex.kumulant.stat.regression.tree.ClassCountsResult
 import com.eignex.kumulant.stat.regression.tree.ClassificationTreeConfig
 import com.eignex.kumulant.stat.regression.tree.ForestClassificationResult
 import com.eignex.kumulant.stat.regression.tree.ForestRegressionResult
@@ -191,6 +192,14 @@ data object Variance : SeriesStatSpec<WeightedVarianceResult>
 @Serializable
 @SerialName("Moments")
 data object Moments : SeriesStatSpec<MomentsResult>
+
+/** Spec for `ClassCountsStat`: weighted count per class over a discrete label stream. */
+@Serializable
+@SerialName("ClassCounts")
+data class ClassCounts(
+    /** Number of classes; each observed value must be exactly an integer in `[0, numClasses)`. */
+    val numClasses: Int,
+) : SeriesStatSpec<ClassCountsResult>
 
 /** Spec for `GaussianScorerStat`: running mean / variance with `|x - mean| / stdDev` z-score. */
 @Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -173,14 +173,18 @@ class BayesianRegressionStat(
             // condition: treating an exact 1.0 as success downdates the covariance below without its
             // factor, and the two never agree again.
             var norm = covarianceL.choleskyDowndateInPlace(z)
-            if (norm >= 1.0) {
+            // Negated, so a NaN norm bails into the repair too. choleskyDowndateInPlace was hardened to
+            // return a NaN rather than write one through the factor, and `norm >= 1.0` is false for NaN -
+            // which would fall straight through to the covariance downdate below and desynchronise it
+            // from its factor permanently, the exact failure the comment above describes.
+            if (!(norm < 1.0)) {
                 for (i in 0 until featureSize) covariance[i, i] = covariance[i, i] + COVARIANCE_RIDGE
                 val Lnew = covariance.cholesky(CholeskyPolicy.Regularize()).l
                 for (i in 0 until featureSize) {
                     for (j in 0..i) covarianceL[i, j] = Lnew[i, j]
                 }
                 norm = covarianceL.choleskyDowndateInPlace(z)
-                while (norm >= 1.0) {
+                while (!(norm < 1.0)) {
                     scale(z, 1.0 / (norm + DOWNDATE_SHRINK))
                     norm = covarianceL.choleskyDowndateInPlace(z)
                 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Link.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/Link.kt
@@ -41,6 +41,12 @@ sealed interface Link {
     data object Identity : Link {
         override fun invMean(eta: Double) = eta
         override fun curvature(eta: Double) = 1.0
+
+        // Squared error, which is twice the Gaussian negative log-likelihood: `sse` is accumulated from
+        // this and `mse`/`rSquared` are defined against squared error, so halving it to match `curvature`
+        // - the second derivative of the halved form - would change what those report. The two therefore
+        // differ by a factor of two on this link, which matters only to a consumer comparing `sse` across
+        // links or pairing `loss` with `curvature` in a line search.
         override fun loss(eta: Double, y: Double): Double {
             val r = eta - y
             return r * r

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -10,6 +10,7 @@ import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.CounterRandom
+import kotlin.concurrent.Volatile
 
 /**
  * Online VFDT decision-tree classifier; the classification counterpart of
@@ -67,6 +68,11 @@ class DecisionTreeClassifierStat(
             concurrency,
         )
     }
+
+    // Volatile like TreeGrowth.root, and for the same reason: this reference is read on the update
+    // path and rewritten by reset, so without it a concurrent updater can go on writing into the
+    // pre-reset tree indefinitely, never observing the replacement.
+    @Volatile
     private var tree: ClassificationTree = newTree()
 
     private fun newTree(): ClassificationTree = ClassificationTree(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -10,6 +10,7 @@ import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.CounterRandom
 import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
+import kotlin.concurrent.Volatile
 
 /**
  * Online VFDT decision-tree regressor; a piecewise-constant predictor over the feature
@@ -71,6 +72,11 @@ class DecisionTreeRegressionStat(
     // Resolved per instance, not captured in the constructor default: create() has to be able
     // to rebind the default arm to the replica's concurrency.
     private val armFactory: () -> SeriesStat<WeightedVarianceResult> = leafArmFactory ?: { VarianceStat(concurrency) }
+
+    // Volatile like TreeGrowth.root, and for the same reason: this reference is read on the update
+    // path and rewritten by reset, so without it a concurrent updater can go on writing into the
+    // pre-reset tree indefinitely, never observing the replacement.
+    @Volatile
     private var tree: RegressionTree<F64VectorView> = newTree()
 
     private fun newTree(): RegressionTree<F64VectorView> = RegressionTree(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig.kt
@@ -72,10 +72,18 @@ interface HoeffdingTreeConfig {
  * `hoeffdingBound` takes `-ln(delta * deltaDecay^depth)`: at `delta >= 1` the bound collapses to zero
  * or NaN, and every `shouldSplit` comparison against NaN is false, so the tree stops growing with no
  * error to show for it.
+ *
+ * `mtry` is checked only for negativity. Zero is deliberate and pinned by `defaultMtry`: a tree built with
+ * no split candidates reports zero rather than clamping to one and drawing from an empty pool, so growth
+ * is off because there is nothing to split on. A negative value has no such meaning and would throw from
+ * `List.take` inside `pickCandidates` at leaf birth, naming neither `mtry` nor the tree.
  */
 internal fun HoeffdingTreeConfig.requireValidBoundParameters() {
     require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
     require(deltaDecay > 0.0 && deltaDecay <= 1.0) { "deltaDecay must be in (0, 1], got $deltaDecay" }
+    // Null means "use the modality default", which is always positive; only an explicit value can be bad.
+    val requestedMtry = mtry
+    require(requestedMtry == null || requestedMtry >= 0) { "mtry cannot be negative, got $requestedMtry" }
 }
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.asClassLabel
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
@@ -15,6 +16,7 @@ import com.eignex.kumulant.math.argMaxOf
 import com.eignex.kumulant.math.nextPoissonOne
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.concurrent.Volatile
 
 /**
  * Online random-forest classifier; the classification counterpart of
@@ -77,6 +79,11 @@ class RandomForestClassifierStat(
     // Drawn from on the update path, once per tree, with no lock over it - so it has to be a generator
     // that concurrent updates can share. See CounterRandom.
     private val baggingRng = CounterRandom(seedRng.childSeed(), concurrency)
+
+    // Volatile like TreeGrowth.root, and for the same reason: this reference is read on the update
+    // path and rewritten by reset, so without it a concurrent updater can go on writing into the
+    // pre-reset tree indefinitely, never observing the replacement.
+    @Volatile
     private var trees: Array<ClassificationTree> = Array(nbrTrees) { newTree() }
 
     private fun newTree(): ClassificationTree = ClassificationTree(
@@ -90,11 +97,14 @@ class RandomForestClassifierStat(
 
     override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // isInertWeight rather than isNotPositiveWeight: a class count subtracts exactly, so a negative
-        // weight is a real downdate here, exactly as it is for the regression forest. Returning before
-        // the bagging draw also matters - an inert call that consumed one Poisson draw per tree would
-        // desynchronise every later one.
-        if (weight.isInertWeight()) return
+        // A negative weight is a real downdate only when bagging is off: a class count and a Welford
+        // accumulator both subtract exactly. Under bagging each arrival draws its own Poisson
+        // multiplier, so a retraction is scaled by a different k than the insertion it undoes - leaving
+        // a leaf with negative mass, or tripping the weight guard inside it - and keying the multiplier
+        // off the observation instead would hand repeated identical observations the same k and bias the
+        // resampling. Either way the guard returns before the first draw, since consuming one would
+        // desynchronise every later bagging draw and change the forest's predictions.
+        if (if (bagging) weight.isNotPositiveWeight() else weight.isInertWeight()) return
         val c = y.asClassLabel(numClasses)
         if (c < 0) return
         if (!bagging) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -6,6 +6,7 @@ import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.isInertWeight
+import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
 import com.eignex.kumulant.math.CounterRandom
@@ -14,6 +15,7 @@ import com.eignex.kumulant.stat.summary.VarianceStat
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.concurrent.Volatile
 
 /**
  * Online random-forest regressor; a population of [RegressionTree]s sharing the candidate-split
@@ -74,6 +76,11 @@ class RandomForestRegressionStat(
     // Drawn from on the update path, once per tree, with no lock over it - so it has to be a generator
     // that concurrent updates can share. See CounterRandom.
     private val baggingRng = CounterRandom(seedRng.childSeed(), concurrency)
+
+    // Volatile like TreeGrowth.root, and for the same reason: this reference is read on the update
+    // path and rewritten by reset, so without it a concurrent updater can go on writing into the
+    // pre-reset tree indefinitely, never observing the replacement.
+    @Volatile
     private var trees: Array<RegressionTree<F64VectorView>> = Array(nbrTrees) { newTree() }
 
     private fun newTree(): RegressionTree<F64VectorView> = RegressionTree(
@@ -86,9 +93,14 @@ class RandomForestRegressionStat(
 
     override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
         x.requireFeatureSize(featureSize)
-        // Return before drawing from baggingRng: an inert call that consumed one draw per tree would
+        // A negative weight is a real downdate only when bagging is off: a class count and a Welford
+        // accumulator both subtract exactly. Under bagging each arrival draws its own Poisson
+        // multiplier, so a retraction is scaled by a different k than the insertion it undoes - leaving
+        // a leaf with negative mass, or tripping the weight guard inside it - and keying the multiplier
+        // off the observation instead would hand repeated identical observations the same k and bias the
+        // resampling. Either way the guard returns before the first draw, since consuming one would
         // desynchronise every later bagging draw and change the forest's predictions.
-        if (weight.isInertWeight()) return
+        if (if (bagging) weight.isNotPositiveWeight() else weight.isInertWeight()) return
         if (!bagging) {
             for (t in trees) t.update(x, y, weight)
             return

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -143,11 +143,19 @@ internal fun shouldSplit(ranked: SplitInfo, totalWeight: Double, depth: Int, con
 }
 
 /**
- * Parent impurity minus the weight-averaged impurity of the two children.
+ * The fraction of the parent's impurity that splitting removes.
  *
  * Every split criterion kumulant ships is this expression over a different impurity measure:
  * [VarianceReduction] over `variance`, [GiniReduction] over `gini`, [InformationGain] over `entropy`. The
  * `w <= 0.0` guard is what keeps an empty split scoring zero rather than NaN.
+ *
+ * Reported as a fraction rather than an absolute reduction because [hoeffdingBound] assumes a criterion
+ * whose range is 1. Absolute variance reduction is in units of the variance of `y` and so unbounded: on a
+ * stream with a spread of 100 two candidates split on pure noise differ by far more than any bound, so the
+ * test passes trivially and the tree splits on noise, while on a stream inside `[0, 1]` the differences
+ * never reach the bound and every split comes from the tie-break instead - the tree splits on a schedule
+ * rather than on evidence. Entropy in nats has range `ln(K)` and misses in the other direction. Dividing
+ * by the parent impurity puts all three in `[0, 1]`, which is the range the bound is derived for.
  */
 internal inline fun <R : HasObservationCount> impurityReduction(
     total: R,
@@ -159,6 +167,9 @@ internal inline fun <R : HasObservationCount> impurityReduction(
     val wNeg = neg.totalWeights
     val w = wPos + wNeg
     if (w <= 0.0) return 0.0
+    val parent = impurity(total)
+    // An already-pure parent has nothing to remove, so no candidate improves on not splitting.
+    if (parent <= 0.0) return 0.0
     val weighted = (wPos / w) * impurity(pos) + (wNeg / w) * impurity(neg)
-    return impurity(total) - weighted
+    return (parent - weighted) / parent
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
@@ -30,10 +30,39 @@ data object MeanTreePosterior : TreePosterior {
 }
 
 /**
+ * Merged-leaf weight deflated by the number of trees that contributed it.
+ *
+ * [ForestRegressionResult.findLeafMerged] folds the leaf every tree routes `x` to into one accumulator,
+ * but under bagging those are N correlated views of a single sample rather than N samples, so the merged
+ * weight overstates the evidence by roughly the tree count. Dividing it back out keeps the posterior's
+ * standard error at the honest `sqrt(variance / observations)` instead of shrinking it by
+ * `sqrt(nbrTrees)` and under-exploring by the same factor.
+ */
+private fun effectiveWeight(leaf: WeightedVarianceResult, snapshot: ForestRegressionResult): Double =
+    leaf.totalWeights / snapshot.trees.size
+
+/**
+ * Leaf variance blended with [priorVariance] on a [priorWeight] pseudo-count.
+ *
+ * Swapping in the prior only for a completely empty leaf leaves a hole one observation wide: a leaf
+ * holding exactly one sample reports `totalWeights = 1` with a variance of exactly `0`, so a Thompson
+ * draw collapses to a point and a UCB bound loses its bonus - on the leaves that need exploration most.
+ * Driving a contextual bandit, an arm whose single observation was unlucky is then never picked again,
+ * so the leaf never gets a second observation and the state is absorbing. Blending also removes the
+ * discontinuity at `totalWeights == 0`, where the two branches disagreed.
+ */
+private fun blendedVariance(leaf: WeightedVarianceResult, priorWeight: Double, priorVariance: Double): Double {
+    val n = leaf.totalWeights + priorWeight
+    if (n <= 0.0) return priorVariance
+    return (priorWeight * priorVariance + leaf.totalWeights * leaf.variance) / n
+}
+
+/**
  * Thompson sampling over the leaf's Normal-Gamma posterior. Given the leaf's pseudo-
  * count `n`, sample mean `m`, and sample variance `v`, draws are `mu ~ N(m, exploration *
- * v / max(n, 1))`; the posterior on the leaf mean assuming a Normal-Gamma conjugate
- * with weak prior. `exploration = 0.0` collapses to the leaf mean.
+ * v / max(n, 1))`; the posterior on the leaf mean assuming a Normal-Gamma conjugate. The variance is
+ * blended with [priorVariance] on a [priorWeight] pseudo-count, so a leaf holding one observation - whose
+ * sample variance is exactly zero - still has spread. `exploration = 0.0` collapses to the leaf mean.
  */
 data class ThompsonTreePosterior(
     /** Pseudo-count added to the leaf's totalWeights to avoid divide-by-zero on empty leaves. */
@@ -45,8 +74,7 @@ data class ThompsonTreePosterior(
         val leaf = snapshot.findLeaf(x)
         if (exploration <= 0.0) return leaf.mean
         val n = leaf.totalWeights + priorWeight
-        val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance
-        val sd = sqrt(exploration * v / n)
+        val sd = sqrt(exploration * blendedVariance(leaf, priorWeight, priorVariance) / n)
         return rng.nextNormal(leaf.mean, sd)
     }
 }
@@ -65,8 +93,7 @@ data class UcbTreePosterior(
     override fun evaluate(snapshot: TreeRegressionResult, x: F64VectorView, rng: Random, exploration: Double): Double {
         val leaf = snapshot.findLeaf(x)
         val n = leaf.totalWeights + priorWeight
-        val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance
-        return leaf.mean + exploration * sqrt(v / n)
+        return leaf.mean + exploration * sqrt(blendedVariance(leaf, priorWeight, priorVariance) / n)
     }
 }
 
@@ -100,9 +127,8 @@ data class ThompsonForestPosterior(
     ): Double {
         val leaf: WeightedVarianceResult = snapshot.findLeafMerged(x)
         if (exploration <= 0.0) return leaf.mean
-        val n = leaf.totalWeights + priorWeight
-        val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance
-        return rng.nextNormal(leaf.mean, sqrt(exploration * v / n))
+        val n = effectiveWeight(leaf, snapshot) + priorWeight
+        return rng.nextNormal(leaf.mean, sqrt(exploration * blendedVariance(leaf, priorWeight, priorVariance) / n))
     }
 }
 
@@ -120,8 +146,7 @@ data class UcbForestPosterior(
         exploration: Double,
     ): Double {
         val leaf = snapshot.findLeafMerged(x)
-        val n = leaf.totalWeights + priorWeight
-        val v = if (leaf.totalWeights > 0.0) leaf.variance else priorVariance
-        return leaf.mean + exploration * sqrt(v / n)
+        val n = effectiveWeight(leaf, snapshot) + priorWeight
+        return leaf.mean + exploration * sqrt(blendedVariance(leaf, priorWeight, priorVariance) / n)
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCountsResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ClassCountsResultTest.kt
@@ -1,6 +1,9 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.schema.runtime.StatGroup
+import com.eignex.kumulant.schema.runtime.StatSchema
+import com.eignex.kumulant.schema.spec.ClassCounts
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -50,5 +53,20 @@ class ClassCountsResultTest {
         val a = ClassCountsResult(2, doubleArrayOf(6.0, -5.0))
         val b = ClassCountsResult(2, doubleArrayOf(4.0, 2.0))
         assertEquals(a, subtractCC(mergeCC(a, b), b))
+    }
+}
+
+class ClassCountsSpecTest {
+
+    @Test
+    fun `a schema-declared class histogram materializes and reads back`() {
+        val schema = object : StatSchema() {
+            val labels by series(ClassCounts(numClasses = 3))
+        }
+        val group = StatGroup(schema)
+        group.update(0.0)
+        group.update(2.0)
+        group.update(2.0)
+        assertEquals(listOf(1.0, 0.0, 2.0), group.read()[schema.labels].counts.toList())
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DefaultMtryTest.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.regression.tree
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class DefaultMtryTest {
 
@@ -65,5 +66,21 @@ class DefaultMtryTest {
                 nbrTrees = 2,
             ).config.mtry,
         )
+    }
+}
+
+class MtryValidationTest {
+
+    @Test
+    fun `a negative mtry is rejected at construction`() {
+        for (bad in listOf(-1, -7)) {
+            assertFailsWith<IllegalArgumentException>("mtry=$bad was accepted") {
+                DecisionTreeRegressionStat(
+                    featureSize = 2,
+                    splitCandidates = emptyList(),
+                    config = RegressionTreeConfig(mtry = bad),
+                )
+            }
+        }
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
@@ -70,3 +70,42 @@ class RandomForestClassifierStatTest {
         assertEquals(2, r.numClasses)
     }
 }
+
+class ForestBaggingDowndateTest {
+
+    @Test
+    fun `a retraction under bagging does not leave a negative class probability`() {
+        // Swept over seeds: whether the retraction's Poisson multiplier exceeds the insertion's is a
+        // property of the draw sequence, so a single seed can miss it.
+        for (seed in 1..20) {
+            val f = RandomForestClassifierStat(
+                featureSize = 1,
+                numClasses = 2,
+                nbrTrees = 1,
+                bagging = true,
+                randomSeed = seed,
+                splitCandidates = emptyList(),
+            )
+            val x = F64DenseVector.of(doubleArrayOf(1.0))
+            f.update(x, 0.0, weight = 1.0)
+            f.update(x, 0.0, weight = -1.0)
+            f.update(x, 1.0, weight = 5.0)
+            val p = f.read().probabilities(x)
+            assertTrue(p.all { it >= 0.0 }, "seed=$seed probabilities=${p.toList()}")
+        }
+    }
+
+    @Test
+    fun `a retraction under bagging does not throw out of the regression forest`() {
+        val f = RandomForestRegressionStat(
+            featureSize = 1,
+            nbrTrees = 1,
+            bagging = true,
+            randomSeed = 1,
+            splitCandidates = emptyList(),
+        )
+        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        f.update(x, 2.0, weight = 1.0)
+        f.update(x, 2.0, weight = -1.0)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternalsTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.kumulant.DELTA
+import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.random.Random
@@ -265,5 +266,25 @@ class TreeInternalsTest {
         assertFailsWith<IllegalArgumentException> { RegressionTreeConfig(deltaDecay = 1.5) }
         assertFailsWith<IllegalArgumentException> { ClassificationTreeConfig(delta = 1.0) }
         assertFailsWith<IllegalArgumentException> { ClassificationTreeConfig(deltaDecay = 1.5) }
+    }
+}
+
+class ImpurityReductionScaleTest {
+
+    @Test
+    fun `variance reduction does not depend on the scale of y`() {
+        val small = WeightedVarianceResult(totalWeights = 100.0, mean = 0.5, variance = 0.08)
+        val smallPos = WeightedVarianceResult(totalWeights = 50.0, mean = 0.2, variance = 0.01)
+        val smallNeg = WeightedVarianceResult(totalWeights = 50.0, mean = 0.8, variance = 0.01)
+
+        fun scaled(r: WeightedVarianceResult, k: Double) =
+            WeightedVarianceResult(r.totalWeights, r.mean * k, r.variance * k * k)
+
+        val k = 100.0
+        assertEquals(
+            impurityReduction(small, smallPos, smallNeg) { it.variance },
+            impurityReduction(scaled(small, k), scaled(smallPos, k), scaled(smallNeg, k)) { it.variance },
+            DELTA,
+        )
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriorsTest.kt
@@ -150,3 +150,31 @@ class TreePosteriorsTest {
         return sqrt(s / (xs.size - 1))
     }
 }
+
+class SingleObservationLeafPosteriorTest {
+
+    private fun oneObservationTree(y: Double): DecisionTreeRegressionStat {
+        val t = DecisionTreeRegressionStat(featureSize = 1, splitCandidates = emptyList())
+        t.update(feat(1.0), y)
+        return t
+    }
+
+    @Test
+    fun `Thompson still spreads on a leaf holding one observation`() {
+        val snapshot = oneObservationTree(0.0).read()
+        val x = feat(1.0)
+        val rng = Random(1)
+        val draws = (0 until 200).map {
+            ThompsonTreePosterior().evaluate(snapshot, x, rng, exploration = 1.0)
+        }
+        assertTrue(draws.toSet().size > 1, "every draw was ${draws.first()}")
+    }
+
+    @Test
+    fun `UCB still gives a bonus on a leaf holding one observation`() {
+        val snapshot = oneObservationTree(0.0).read()
+        val x = feat(1.0)
+        val score = UcbTreePosterior().evaluate(snapshot, x, Random(1), exploration = 1.0)
+        assertTrue(score > snapshot.findLeaf(x).mean, "score=$score had no confidence bonus")
+    }
+}


### PR DESCRIPTION
## What changed

- impurityReduction reports the fraction of parent impurity removed, so the Hoeffding bound applies to a criterion whose range really is 1.
- Both forests refuse a negative weight while bagging is on.
- Tree and forest posteriors blend priorVariance in on a pseudo-count.
- The forest posteriors deflate the merged leaf weight by the tree count.
- The Bayesian downdate repair branch triggers on a NaN norm.
- ClassCountsStat has a spec, so it can be declared in a schema.
- mtry rejects a negative value; the tree references on the update path are volatile.

## Why

The bound is derived for a criterion of range 1, but variance reduction is in units of the variance of y. On a stream with a spread of 100 two candidates split on pure noise differ by far more than any bound, so the tree split on noise; on a stream inside [0,1] the differences never reached the bound and every split came from the tie-break, so the tree split on a schedule rather than on evidence. Normalising puts variance, gini and entropy reduction all in [0,1].

Both forests advertise negative weights as real downdates, but bagging draws a fresh Poisson multiplier per arrival, so a retraction was scaled differently from the insertion it undid: the classifier reported a negative class probability and the regression forest threw. Keying the multiplier off the observation instead would hand repeated identical observations the same k and bias the resampling, so downdates and bagging are now mutually exclusive.

priorVariance applied only to a completely empty leaf, but a leaf holding one observation has a variance of exactly zero, so Thompson collapsed to a point and UCB lost its bonus on the leaves that need exploration most. Driving a contextual bandit that is absorbing: the arm is never picked again, so the leaf never gets a second observation.

## Why not

Identity.loss stays at r^2. It is twice the Gaussian negative log-likelihood while curvature is the second derivative of the halved form, but sse, mse and rSquared are all defined against squared error and a test pins it, so halving it would change what those report. The factor of two is documented in place.

mtry = 0 is deliberate, not a silent failure: a tree with no split candidates reports zero rather than clamping to one and drawing from an empty pool, and defaultMtry has a test pinning it. Only the negative case is rejected.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. The scale-dependence test showed 0.07 against 700.0 before the fix. Normalising broke no existing test, which was the main risk. The posterior collapse and the forest retraction were both confirmed to fail beforehand.