### PR TITLE
fix: fail schema materialization and merges at the point of the mistake

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -1995,6 +1995,10 @@ public final class com/eignex/kumulant/core/PairedStat$DefaultImpls {
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/PairedStat;DDJDILjava/lang/Object;)V
 }
 
+public abstract interface class com/eignex/kumulant/core/RefusesMerge {
+	public abstract fun getMergeRefusal ()Ljava/lang/String;
+}
+
 public abstract interface class com/eignex/kumulant/core/RegressionStat : com/eignex/kumulant/core/Stat {
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
@@ -2761,7 +2765,8 @@ public final class com/eignex/kumulant/schema/ops/OperationsKt {
 	public static final fun transformPair (Lcom/eignex/kumulant/schema/spec/PairedStatSpec;Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/spec/PairedStatSpec;
 	public static final fun transformVector (Lcom/eignex/kumulant/schema/spec/VectorStatSpec;Lcom/eignex/kumulant/schema/expr/VectorExpr;)Lcom/eignex/kumulant/schema/spec/VectorStatSpec;
 	public static final fun transformX (Lcom/eignex/kumulant/schema/spec/PairedStatSpec;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/spec/PairedStatSpec;
-	public static final fun transformX (Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;Lcom/eignex/kumulant/schema/expr/VectorExpr;)Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;
+	public static final fun transformX (Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;Lcom/eignex/kumulant/schema/expr/VectorExpr;Ljava/lang/Integer;)Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;
+	public static synthetic fun transformX$default (Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;Lcom/eignex/kumulant/schema/expr/VectorExpr;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;
 	public static final fun transformY (Lcom/eignex/kumulant/schema/spec/PairedStatSpec;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/spec/PairedStatSpec;
 	public static final fun transformY (Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/spec/RegressionStatSpec;
 	public static final fun vectorized (Lcom/eignex/kumulant/schema/spec/SeriesStatSpec;IZ)Lcom/eignex/kumulant/schema/spec/VectorStatSpec;
@@ -3000,6 +3005,24 @@ public final class com/eignex/kumulant/schema/runtime/PairedStatGroup : com/eign
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun update (DDD)V
 	public fun update (DDJD)V
+}
+
+public final class com/eignex/kumulant/schema/runtime/RegressionStatGroup : com/eignex/kumulant/schema/runtime/AbstractStatGroup, com/eignex/kumulant/core/RegressionStat {
+	public fun <init> (Lcom/eignex/kumulant/schema/runtime/StatSchema;Lcom/eignex/kumulant/core/Concurrency;)V
+	public synthetic fun <init> (Lcom/eignex/kumulant/schema/runtime/StatSchema;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lcom/eignex/kumulant/core/Concurrency;)V
+	public synthetic fun <init> (Ljava/util/List;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/eignex/kumulant/schema/runtime/BoundStat;Lcom/eignex/kumulant/core/Concurrency;)V
+	public synthetic fun <init> ([Lcom/eignex/kumulant/schema/runtime/BoundStat;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;)V
+	public synthetic fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
+	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
+	public fun getFeatureSize ()I
+	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update ([DDD)V
+	public fun update ([DDJD)V
 }
 
 public final class com/eignex/kumulant/schema/runtime/StatFactoryKt {
@@ -5101,7 +5124,7 @@ public final class com/eignex/kumulant/stat/anomaly/QuantileFilterResult$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/eignex/kumulant/stat/anomaly/QuantileFilterStat : com/eignex/kumulant/core/SeriesStat {
+public final class com/eignex/kumulant/stat/anomaly/QuantileFilterStat : com/eignex/kumulant/core/RefusesMerge, com/eignex/kumulant/core/SeriesStat {
 	public fun <init> ()V
 	public fun <init> (DDLcom/eignex/kumulant/core/Concurrency;)V
 	public synthetic fun <init> (DDLcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5109,6 +5132,7 @@ public final class com/eignex/kumulant/stat/anomaly/QuantileFilterStat : com/eig
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/anomaly/QuantileFilterStat;
 	public fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
+	public fun getMergeRefusal ()Ljava/lang/String;
 	public final fun getProbability ()D
 	public final fun getRelativeError ()D
 	public synthetic fun merge (Lcom/eignex/kumulant/core/Result;)V
@@ -5155,7 +5179,7 @@ public final class com/eignex/kumulant/stat/calibration/IsotonicCalibratorResult
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat : com/eignex/kumulant/core/PairedStat {
+public final class com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat : com/eignex/kumulant/core/PairedStat, com/eignex/kumulant/core/RefusesMerge {
 	public fun <init> ()V
 	public fun <init> (ILcom/eignex/kumulant/core/Concurrency;)V
 	public synthetic fun <init> (ILcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5163,6 +5187,7 @@ public final class com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat :
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/calibration/IsotonicCalibratorStat;
 	public fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
+	public fun getMergeRefusal ()Ljava/lang/String;
 	public final fun getNumBins ()I
 	public synthetic fun merge (Lcom/eignex/kumulant/core/Result;)V
 	public fun merge (Lcom/eignex/kumulant/stat/calibration/IsotonicCalibratorResult;)Ljava/lang/Void;

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -300,6 +300,11 @@ abstract interface com.eignex.kumulant.core/HasSlope : com.eignex.kumulant.core/
     open fun predict(kotlin/Double): kotlin/Double // com.eignex.kumulant.core/HasSlope.predict|predict(kotlin.Double){}[0]
 }
 
+abstract interface com.eignex.kumulant.core/RefusesMerge { // com.eignex.kumulant.core/RefusesMerge|null[0]
+    abstract val mergeRefusal // com.eignex.kumulant.core/RefusesMerge.mergeRefusal|{}mergeRefusal[0]
+        abstract fun <get-mergeRefusal>(): kotlin/String // com.eignex.kumulant.core/RefusesMerge.mergeRefusal.<get-mergeRefusal>|<get-mergeRefusal>(){}[0]
+}
+
 abstract interface com.eignex.kumulant.core/Result // com.eignex.kumulant.core/Result|null[0]
 
 abstract interface com.eignex.kumulant.math/LongHasher { // com.eignex.kumulant.math/LongHasher|null[0]
@@ -2848,6 +2853,19 @@ final class com.eignex.kumulant.schema.runtime/PairedStatGroup : com.eignex.kumu
     final fun update(kotlin/Double, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/PairedStatGroup.update|update(kotlin.Double;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
+final class com.eignex.kumulant.schema.runtime/RegressionStatGroup : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.schema/GroupResult>, com.eignex.kumulant.schema.runtime/AbstractStatGroup<com.eignex.kumulant.core/RegressionStat<*>> { // com.eignex.kumulant.schema.runtime/RegressionStatGroup|null[0]
+    constructor <init>(com.eignex.kumulant.schema.runtime/StatSchema, com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.<init>|<init>(com.eignex.kumulant.schema.runtime.StatSchema;com.eignex.kumulant.core.Concurrency){}[0]
+    constructor <init>(kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/RegressionStat<*>, *>>, com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.<init>|<init>(kotlin.collections.List<com.eignex.kumulant.schema.runtime.BoundStat<*,out|com.eignex.kumulant.core.RegressionStat<*>,*>>;com.eignex.kumulant.core.Concurrency?){}[0]
+    constructor <init>(kotlin/Array<out com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/RegressionStat<*>, *>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.<init>|<init>(kotlin.Array<out|com.eignex.kumulant.schema.runtime.BoundStat<*,out|com.eignex.kumulant.core.RegressionStat<*>,*>>...;com.eignex.kumulant.core.Concurrency?){}[0]
+    constructor <init>(kotlin/Array<out kotlin/Pair<com.eignex.kumulant.schema/StatKey<*>, com.eignex.kumulant.core/RegressionStat<*>>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.<init>|<init>(kotlin.Array<out|kotlin.Pair<com.eignex.kumulant.schema.StatKey<*>,com.eignex.kumulant.core.RegressionStat<*>>>...;com.eignex.kumulant.core.Concurrency?){}[0]
+
+    final val featureSize // com.eignex.kumulant.schema.runtime/RegressionStatGroup.featureSize|{}featureSize[0]
+        final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.schema.runtime/RegressionStatGroup.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
+
+    final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/RegressionStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
+    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+}
+
 final class com.eignex.kumulant.schema.runtime/StatGroup : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.schema/GroupResult>, com.eignex.kumulant.schema.runtime/AbstractStatGroup<com.eignex.kumulant.core/SeriesStat<*>> { // com.eignex.kumulant.schema.runtime/StatGroup|null[0]
     constructor <init>(com.eignex.kumulant.schema.runtime/StatSchema, com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.schema.runtime/StatGroup.<init>|<init>(com.eignex.kumulant.schema.runtime.StatSchema;com.eignex.kumulant.core.Concurrency){}[0]
     constructor <init>(kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/SeriesStat<*>, *>>, com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/StatGroup.<init>|<init>(kotlin.collections.List<com.eignex.kumulant.schema.runtime.BoundStat<*,out|com.eignex.kumulant.core.SeriesStat<*>,*>>;com.eignex.kumulant.core.Concurrency?){}[0]
@@ -4725,11 +4743,13 @@ final class com.eignex.kumulant.stat.anomaly/QuantileFilterResult : com.eignex.k
     }
 }
 
-final class com.eignex.kumulant.stat.anomaly/QuantileFilterStat : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.anomaly/QuantileFilterResult> { // com.eignex.kumulant.stat.anomaly/QuantileFilterStat|null[0]
+final class com.eignex.kumulant.stat.anomaly/QuantileFilterStat : com.eignex.kumulant.core/RefusesMerge, com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.anomaly/QuantileFilterResult> { // com.eignex.kumulant.stat.anomaly/QuantileFilterStat|null[0]
     constructor <init>(kotlin/Double = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.<init>|<init>(kotlin.Double;kotlin.Double;com.eignex.kumulant.core.Concurrency){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
+    final val mergeRefusal // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.mergeRefusal|{}mergeRefusal[0]
+        final fun <get-mergeRefusal>(): kotlin/String // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.mergeRefusal.<get-mergeRefusal>|<get-mergeRefusal>(){}[0]
     final val probability // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.probability|{}probability[0]
         final fun <get-probability>(): kotlin/Double // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.probability.<get-probability>|<get-probability>(){}[0]
     final val relativeError // com.eignex.kumulant.stat.anomaly/QuantileFilterStat.relativeError|{}relativeError[0]
@@ -4778,11 +4798,13 @@ final class com.eignex.kumulant.stat.calibration/IsotonicCalibratorResult : com.
     }
 }
 
-final class com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.calibration/IsotonicCalibratorResult> { // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat|null[0]
+final class com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.calibration/IsotonicCalibratorResult>, com.eignex.kumulant.core/RefusesMerge { // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat|null[0]
     constructor <init>(kotlin/Int = ..., com.eignex.kumulant.core/Concurrency = ...) // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.<init>|<init>(kotlin.Int;com.eignex.kumulant.core.Concurrency){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
+    final val mergeRefusal // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.mergeRefusal|{}mergeRefusal[0]
+        final fun <get-mergeRefusal>(): kotlin/String // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.mergeRefusal.<get-mergeRefusal>|<get-mergeRefusal>(){}[0]
     final val numBins // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.numBins|{}numBins[0]
         final fun <get-numBins>(): kotlin/Int // com.eignex.kumulant.stat.calibration/IsotonicCalibratorStat.numBins.<get-numBins>|<get-numBins>(){}[0]
 
@@ -9362,7 +9384,7 @@ final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/sample(kotlin/Double, kotlin/Long): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/sample|sample@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(kotlin.Double;kotlin.Long){0§<com.eignex.kumulant.core.Result>}[0]
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/standardScaleFeatures(): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/standardScaleFeatures|standardScaleFeatures@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(){0§<com.eignex.kumulant.core.Result>}[0]
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/throttle(kotlin/Int): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/throttle|throttle@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(kotlin.Int){0§<com.eignex.kumulant.core.Result>}[0]
-final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/transformX(com.eignex.kumulant.schema.expr/VectorExpr): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/transformX|transformX@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(com.eignex.kumulant.schema.expr.VectorExpr){0§<com.eignex.kumulant.core.Result>}[0]
+final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/transformX(com.eignex.kumulant.schema.expr/VectorExpr, kotlin/Int? = ...): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/transformX|transformX@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(com.eignex.kumulant.schema.expr.VectorExpr;kotlin.Int?){0§<com.eignex.kumulant.core.Result>}[0]
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/transformY(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/transformY|transformY@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(com.eignex.kumulant.schema.expr.ScalarExpr){0§<com.eignex.kumulant.core.Result>}[0]
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/weightBy(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/weightBy|weightBy@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(com.eignex.kumulant.schema.expr.ScalarExpr){0§<com.eignex.kumulant.core.Result>}[0]
 final fun <#A: com.eignex.kumulant.core/Result> (com.eignex.kumulant.schema.spec/RegressionStatSpec<#A>).com.eignex.kumulant.schema.ops/withWeight(kotlin/Double): com.eignex.kumulant.schema.spec/RegressionStatSpec<#A> // com.eignex.kumulant.schema.ops/withWeight|withWeight@com.eignex.kumulant.schema.spec.RegressionStatSpec<0:0>(kotlin.Double){0§<com.eignex.kumulant.core.Result>}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -347,3 +347,17 @@ interface VectorStat<R : Result> : Stat<R> {
 
     override fun create(concurrency: Concurrency?): VectorStat<R>
 }
+
+/**
+ * A stat whose [Stat.merge] always throws, declared so a container can find out before it starts.
+ *
+ * A group merges its children in declaration order with no way to undo one, so a child that throws
+ * partway leaves the group permanently inconsistent: the entries before it carry both shards and the
+ * entries after it carry one. Declaring the refusal lets the group check every child first and throw
+ * without touching any of them, and lets the message name the offending key instead of surfacing from
+ * whichever stat happened to be reached.
+ */
+interface RefusesMerge {
+    /** Why this stat cannot merge, and what to merge instead. */
+    val mergeRefusal: String
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Band.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.operation
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasCenterScale
+import com.eignex.kumulant.core.RefusesMerge
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.schema.BandResult
 import kotlin.time.Duration
@@ -18,6 +19,7 @@ internal fun <R> SeriesStat<R>.band(k: Double): SeriesStat<BandResult>
 
 internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private val k: Double) :
     WindowsInside<BandResult, SeriesStat<BandResult>>,
+    RefusesMerge,
     SeriesStat<BandResult> where R : HasCenterScale {
 
     override val concurrency: Concurrency get() = delegate.concurrency
@@ -32,8 +34,9 @@ internal class BandSeriesStat<R>(private val delegate: SeriesStat<R>, private va
         return BandResult(center = c, scale = s, k = k, lower = c - k * s, upper = c + k * s)
     }
 
-    override fun merge(values: BandResult): Unit =
-        error("band wrapper cannot merge BandResult; merge the inner stat directly")
+    override val mergeRefusal: String = "band wrapper cannot merge BandResult; merge the inner stat directly"
+
+    override fun merge(values: BandResult): Unit = error(mergeRefusal)
 
     /**
      * Band *around* a windowed inner stat rather than a window around a band.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -26,10 +26,16 @@ internal fun <R : Result> RegressionStat<R>.transformY(
     transform: (F64VectorView, Double) -> Double,
 ): RegressionStat<R> = TransformYRegressionStat(this, transform)
 
-/** Rewrite x before update via [transform]; y and weight pass through unchanged. */
+/**
+ * Rewrite x before update via [transform]; y and weight pass through unchanged.
+ *
+ * [inputFeatureSize] is the width callers must supply, which differs from the inner regressor's whenever
+ * the transform changes the length. Null keeps the inner width.
+ */
 internal fun <R : Result> RegressionStat<R>.transformX(
+    inputFeatureSize: Int? = null,
     transform: (F64VectorView, Double) -> DoubleArray,
-): RegressionStat<R> = TransformXRegressionStat(this, transform)
+): RegressionStat<R> = TransformXRegressionStat(this, inputFeatureSize, transform)
 
 /**
  * Replace every update's weight with the constant [weight].
@@ -96,15 +102,23 @@ internal class TransformYRegressionStat<R : Result>(
 
 internal class TransformXRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
+    private val inputFeatureSize: Int?,
     private val transform: (F64VectorView, Double) -> DoubleArray,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
-    override val featureSize: Int = delegate.featureSize
+    // The width expected in `x`, which is what RegressionStat.featureSize means - not the inner
+    // regressor's. A transform that changes the length made the wrapper advertise the post-transform
+    // width, so a caller sizing its input from this sent the wrong number of coordinates and the extras
+    // were silently dropped, while RegressionListStats rejected the honest pairing as a mismatch.
+    override val featureSize: Int = inputFeatureSize ?: delegate.featureSize
+
     override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
+        x.requireFeatureSize(featureSize)
         delegate.update(F64DenseVector.of(transform(x, y)), y, timestampNanos, weight)
     }
+
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
-        TransformXRegressionStat(delegate.create(concurrency), transform)
+        TransformXRegressionStat(delegate.create(concurrency), inputFeatureSize, transform)
 }
 
 internal class WithWeightRegressionStat<R : Result>(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/ops/Operations.kt
@@ -333,9 +333,15 @@ fun <R : Result> RegressionStatSpec<R>.filterFinite(): RegressionStatSpec<R> = f
 fun <R : Result> RegressionStatSpec<R>.transformY(expr: ScalarExpr): RegressionStatSpec<R> =
     TransformYRegression(this, expr) as RegressionStatSpec<R>
 
-/** Wrap this regression spec so x is remapped by [expr] before the inner stat sees it. */
-fun <R : Result> RegressionStatSpec<R>.transformX(expr: VectorExpr): RegressionStatSpec<R> =
-    TransformXRegression(this, expr) as RegressionStatSpec<R>
+/**
+ * Wrap this regression spec so x is remapped by [expr] before the inner stat sees it.
+ *
+ * Pass [featureSize] whenever [expr] changes the vector's length: it is the width callers must supply,
+ * and the wrapper reports it as its own `featureSize`. Left null the inner regressor's width is reported,
+ * which is only right when the transform preserves length.
+ */
+fun <R : Result> RegressionStatSpec<R>.transformX(expr: VectorExpr, featureSize: Int? = null): RegressionStatSpec<R> =
+    TransformXRegression(this, expr, featureSize) as RegressionStatSpec<R>
 
 /** Wrap this regression spec so every update uses [weight] regardless of caller input. */
 fun <R : Result> RegressionStatSpec<R>.withWeight(weight: Double): RegressionStatSpec<R> =

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatFactory.kt
@@ -344,11 +344,18 @@ fun <R : Result> SeriesStatSpec<R>.materialize(concurrency: Concurrency = Concur
                 .minMaxScaler(targetLow, targetHigh, concurrency)
 
         is BandSeries -> {
-            // The runtime check happens at the first read; the cast is safe iff the inner stat's
-            // Result implements HasCenterScale, which is part of BandSeries's documented contract.
-            val centerScaleInner = requireSeries(inner, "BandSeries").materialize(concurrency)
-                as SeriesStat<HasCenterScale>
-            centerScaleInner.band(k)
+            val innerStat = requireSeries(inner, "BandSeries").materialize(concurrency)
+            // Checked here rather than left to the cast. The HasCenterScale bound is enforced on the live
+            // operator but erased on the spec path, so `Sum.band(2.0)` compiles, materializes and accepts
+            // updates, and only the first read throws a bare ClassCastException - naming neither the
+            // operator nor the schema key, and taking a whole group's read down with it. Every stat
+            // returns a well-formed result before its first update, so the probe costs one read.
+            val probe = innerStat.read(0L)
+            require(probe is HasCenterScale) {
+                "BandSeries requires an inner stat whose result has a center and scale, got $inner"
+            }
+            @Suppress("UNCHECKED_CAST")
+            (innerStat as SeriesStat<HasCenterScale>).band(k)
         }
     }
     return out as SeriesStat<R>
@@ -660,7 +667,7 @@ fun <R : Result> RegressionStatSpec<R>.materialize(concurrency: Concurrency = Co
 
         is TransformXRegression -> {
             val m = requireRegression(inner, "TransformXRegression").materialize(concurrency) as RegressionStat<Result>
-            m.transformX { v, y -> expr.eval(0.0, y, v.toDoubleArray()) }
+            m.transformX(featureSize) { v, y -> expr.eval(0.0, y, v.toDoubleArray()) }
         }
 
         is WithWeightRegression ->

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -4,6 +4,8 @@ import com.eignex.koblas.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.RefusesMerge
+import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.Stat
 import com.eignex.kumulant.core.VectorStat
@@ -52,6 +54,16 @@ sealed class AbstractStatGroup<S : Stat<*>>(
         GroupResult(stats.associate { (key, stat) -> key.name to stat.read(timestampNanos) })
 
     final override fun merge(values: GroupResult) {
+        // Checked across every entry before any of them is touched. Merging in declaration order with no
+        // way to undo one means a child that refuses partway leaves the group permanently inconsistent -
+        // the entries ahead of it carrying both shards and the ones behind it carrying one - and a caller
+        // that catches the exception around a shard roll-up has no way to tell. Throwing first also names
+        // the key, instead of surfacing from whichever stat happened to be reached.
+        for ((key, stat) in stats) {
+            val refusal = (stat as? RefusesMerge)?.mergeRefusal ?: continue
+            if (values.results[key.name] == null) continue
+            throw UnsupportedOperationException("cannot merge group entry '${key.name}': $refusal")
+        }
         for ((key, stat) in stats) mergeEntry(values, key, stat)
     }
 
@@ -144,6 +156,54 @@ class VectorStatGroup(stats: List<BoundStat<*, out VectorStat<*>, *>>, concurren
         val effectiveConcurrency = concurrency ?: this.concurrencyOverride
         val newStats = stats.map { (key, stat) -> toSpec(key, stat.create(effectiveConcurrency)) }
         return VectorStatGroup(stats = newStats, concurrency = effectiveConcurrency)
+    }
+}
+
+/**
+ * [StatGroup] variant over regression inputs, so a schema's `regression` entries have a home.
+ *
+ * Without it the declarator was reachable but unusable: every other group filters the schema by modality
+ * with `mapNotNull`, so a regression entry was silently skipped and the failure surfaced only as a missing
+ * key at read time.
+ *
+ * Every entry must expect the same feature width, since one update fans out to all of them.
+ */
+class RegressionStatGroup(stats: List<BoundStat<*, out RegressionStat<*>, *>>, concurrency: Concurrency? = null) :
+    AbstractStatGroup<RegressionStat<*>>(stats, concurrency),
+    RegressionStat<GroupResult> {
+
+    constructor(
+        vararg stats: BoundStat<*, out RegressionStat<*>, *>,
+        concurrency: Concurrency? = null,
+    ) : this(stats = stats.asList(), concurrency = concurrency)
+
+    constructor(
+        vararg stats: Pair<StatKey<*>, RegressionStat<*>>,
+        concurrency: Concurrency? = null,
+    ) : this(stats = stats.map { toSpec(it.first, it.second) }, concurrency = concurrency)
+
+    constructor(schema: StatSchema, concurrency: Concurrency = Concurrency.None) :
+        this(stats = regressionSpecs(schema, concurrency), concurrency = concurrency)
+
+    override val featureSize: Int = stats.firstOrNull()?.let { (_, stat) -> stat.featureSize }
+        ?: error("RegressionStatGroup requires at least one entry")
+
+    init {
+        for ((key, stat) in stats) {
+            require(stat.featureSize == featureSize) {
+                "RegressionStatGroup entry '${key.name}' has featureSize=${stat.featureSize}, expected $featureSize"
+            }
+        }
+    }
+
+    override fun update(x: F64VectorView, y: Double, timestampNanos: Long, weight: Double) {
+        for ((_, stat) in stats) stat.update(x, y, timestampNanos, weight)
+    }
+
+    override fun create(concurrency: Concurrency?): RegressionStat<GroupResult> {
+        val effectiveConcurrency = concurrency ?: this.concurrencyOverride
+        val newStats = stats.map { (key, stat) -> toSpec(key, stat.create(effectiveConcurrency)) }
+        return RegressionStatGroup(stats = newStats, concurrency = effectiveConcurrency)
     }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatSchema.kt
@@ -57,9 +57,37 @@ abstract class StatSchema : Schema<StatSpec>() {
 
     protected fun <R : Result> regression(config: RegressionStatSpec<R>) = register(config) { StatKey<R>(it) }
 
-    /** Nest a sub-schema as a [GroupStatSpec]; materialization recurses at the parent's group construction. */
+    /**
+     * Nest a sub-schema as a [GroupStatSpec]; materialization recurses at the parent's group construction.
+     *
+     * Series-only, and checked here rather than at materialization. [GroupStatSpec] is itself a
+     * [SeriesStatSpec], so a nested schema holding another modality has no consistent home: the series
+     * view of the parent rejects the child at materialize time, while the discrete or vector view skips
+     * the whole subtree - reporting no error and no entries, and leaving the nested results unreachable
+     * by any means. A mixed schema is legal at the root, where each modality's view picks its own
+     * entries, so failing at the declaration is what tells the two cases apart.
+     */
     protected fun <T : StatSchema> group(nestedSchema: T) =
-        register(GroupStatSpec(nestedSchema.statSchemaDef().stats)) { GroupStatKey(it, nestedSchema) }
+        register(seriesOnlyGroupSpec(nestedSchema)) { GroupStatKey(it, nestedSchema) }
+}
+
+/**
+ * [GroupStatSpec] over a nested schema, rejecting any entry that is not series.
+ *
+ * [GroupStatSpec] is itself a [SeriesStatSpec], so a nested schema holding another modality has no
+ * consistent home: the series view of the parent rejects the child at materialize time, while the
+ * discrete or vector view skips the whole subtree - reporting no error and no entries, and leaving the
+ * nested results unreachable by any means. A mixed schema is legal at the root, where each modality's
+ * view picks out its own entries, so failing at the declaration is what tells the two cases apart.
+ */
+private fun seriesOnlyGroupSpec(nestedSchema: StatSchema): GroupStatSpec {
+    val nested = nestedSchema.statSchemaDef().stats
+    for ((name, config) in nested) {
+        require(config is SeriesStatSpec<*>) {
+            "nested group entry '$name' is ${config::class.simpleName}; a nested schema must be series-only"
+        }
+    }
+    return GroupStatSpec(nested)
 }
 
 /** Series-modality specs from a schema, materialized at [concurrency]. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/spec/Operations.kt
@@ -785,6 +785,14 @@ internal data class TransformXRegression(
     val inner: StatSpec,
     /** Expression producing the new vector; sees `Y` and `V`. */
     val expr: VectorExpr,
+    /**
+     * Width expected in `x` on each update, before the transform.
+     *
+     * Carried separately because the transform may change the length, so the inner regressor's width is
+     * not what a caller must supply - the same reason [FoldRegression] carries one. Null keeps the
+     * inner width, which is right whenever the transform preserves length.
+     */
+    val featureSize: Int? = null,
 ) : RegressionStatSpec<Result>
 
 /** Wire spec for `RegressionStat.withWeight(weight)`: replaces every update's weight. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/QuantileFilterStat.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.stat.anomaly
 
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
+import com.eignex.kumulant.core.RefusesMerge
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.quantile.DDSketchStat
 import kotlinx.serialization.SerialName
@@ -53,7 +54,11 @@ class QuantileFilterStat(
     /** Relative-error guarantee passed to the underlying DDSketch. */
     val relativeError: Double = 0.01,
     override val concurrency: Concurrency = Concurrency.None,
-) : SeriesStat<QuantileFilterResult> {
+) : SeriesStat<QuantileFilterResult>,
+    RefusesMerge {
+
+    override val mergeRefusal: String =
+        "QuantileFilterStat does not support merge; merge a DDSketch directly"
 
     init {
         require(probability > 0.0 && probability < 1.0) {
@@ -83,8 +88,7 @@ class QuantileFilterStat(
      * not typically sharded across streams; if you need a distributed
      * quantile, merge a [DDSketchStat] directly and project here.
      */
-    override fun merge(values: QuantileFilterResult): Nothing =
-        throw UnsupportedOperationException("QuantileFilterStat does not support merge; merge a DDSketch directly")
+    override fun merge(values: QuantileFilterResult): Nothing = throw UnsupportedOperationException(mergeRefusal)
 
     override fun reset() = inner.reset()
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/IsotonicCalibratorStat.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.calibration
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
+import com.eignex.kumulant.core.RefusesMerge
 import com.eignex.kumulant.core.requirePositiveBins
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -96,7 +97,8 @@ class IsotonicCalibratorStat(
     /** Number of equal-width bins over `[0, 1]`. */
     val numBins: Int = 16,
     override val concurrency: Concurrency = Concurrency.None,
-) : PairedStat<IsotonicCalibratorResult> {
+) : PairedStat<IsotonicCalibratorResult>,
+    RefusesMerge {
 
     init {
         requirePositiveBins(numBins)
@@ -166,9 +168,10 @@ class IsotonicCalibratorStat(
         return out
     }
 
-    override fun merge(values: IsotonicCalibratorResult): Nothing = throw UnsupportedOperationException(
-        "IsotonicCalibratorStat does not support merge; merge the underlying ReliabilityStat directly",
-    )
+    override val mergeRefusal: String =
+        "IsotonicCalibratorStat does not support merge; merge the underlying ReliabilityStat directly"
+
+    override fun merge(values: IsotonicCalibratorResult): Nothing = throw UnsupportedOperationException(mergeRefusal)
 
     override fun reset() = inner.reset()
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -9,6 +9,7 @@ import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.ResultList
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.VectorStat
+import com.eignex.kumulant.feat
 import com.eignex.kumulant.operation.VectorizedStat
 import com.eignex.kumulant.operation.withValue
 import com.eignex.kumulant.operation.withWeight
@@ -930,5 +931,104 @@ class DiscreteListStatsTest {
         target.merge(source.read())
         val merged = assertIs<HyperLogLogResult>(target.read().results[0])
         assertTrue(merged.estimate > 100.0, "estimate=${merged.estimate}")
+    }
+}
+
+class GroupMergeAtomicityTest {
+
+    private object MergeHostile : StatSchema() {
+        val hits by series(Sum)
+        val p99 by series(QuantileFilter())
+        val total by series(Count)
+    }
+
+    @Test
+    fun `a refused merge leaves every entry untouched`() {
+        val local = StatGroup(MergeHostile)
+        val remote = StatGroup(MergeHostile)
+        repeat(3) { local.update(1.0) }
+        repeat(5) { remote.update(1.0) }
+
+        val hitsBefore = local.read()[MergeHostile.hits].sum
+        val totalBefore = local.read()[MergeHostile.total].sum
+
+        assertFailsWith<UnsupportedOperationException> { local.merge(remote.read()) }
+
+        assertEquals(hitsBefore, local.read()[MergeHostile.hits].sum, DELTA)
+        assertEquals(totalBefore, local.read()[MergeHostile.total].sum, DELTA)
+    }
+
+    @Test
+    fun `a group with no refusing entry still merges`() {
+        val mergeable = object : StatSchema() {
+            val hits by series(Sum)
+            val total by series(Count)
+        }
+        val local = StatGroup(mergeable)
+        val remote = StatGroup(mergeable)
+        repeat(3) { local.update(1.0) }
+        repeat(5) { remote.update(1.0) }
+        local.merge(remote.read())
+        assertEquals(8.0, local.read()[mergeable.hits].sum, DELTA)
+        assertEquals(8.0, local.read()[mergeable.total].sum, DELTA)
+    }
+}
+
+class BandAndTransformSpecGuardTest {
+
+    @Test
+    fun `band rejects an inner stat with no center and scale at materialize time`() {
+        val schema = object : StatSchema() {
+            val bad by series(Sum.band(2.0))
+        }
+        assertFailsWith<IllegalArgumentException> { StatGroup(schema) }
+    }
+
+    @Test
+    fun `band still accepts an inner stat that has a center and scale`() {
+        val schema = object : StatSchema() {
+            val ok by series(Variance.band(2.0))
+        }
+        val group = StatGroup(schema)
+        group.update(1.0)
+        group.update(3.0)
+        assertTrue(group.read()[schema.ok].upper >= group.read()[schema.ok].lower)
+    }
+
+    @Test
+    fun `transformX reports the width callers must supply`() {
+        val expanded = StochasticRegression(featureSize = 3)
+            .transformX(vectorOf(V(0), V(1), V(0) * V(1)), featureSize = 2)
+        val stat = expanded.materialize()
+        assertEquals(2, stat.featureSize)
+    }
+}
+
+class SchemaModalityReachabilityTest {
+
+    private object MixedInner : StatSchema() {
+        val hits by series(Sum)
+        val users by discrete(HyperLogLog())
+    }
+
+    @Test
+    fun `a nested schema holding a non-series entry is rejected at declaration`() {
+        assertFailsWith<IllegalArgumentException> {
+            val nested = object : StatSchema() {
+                val inner by group(MixedInner)
+            }
+            nested.statSchemaDef()
+        }
+    }
+
+    @Test
+    fun `a schema-declared regression entry has a group to materialize into`() {
+        val schema = object : StatSchema() {
+            val model by regression(StochasticRegression(featureSize = 2))
+        }
+        val group = RegressionStatGroup(schema)
+        group.update(feat(1.0, 2.0), 3.0)
+        assertEquals(2, group.featureSize)
+        assertTrue(group.read()[schema.model].totalWeights > 0.0)
     }
 }


### PR DESCRIPTION
## What changed

- A new RefusesMerge marker lets a group check every child before it mutates any of them, and name the offending key.
- BandSeries validates its inner spec at materialize time by probing the result once.
- TransformXRegression carries the pre-transform feature width and enforces it at update time.
- A public RegressionStatGroup, so schema-declared regression entries have somewhere to materialize.
- A nested group rejects a non-series entry at declaration.

## Why

A group merged its children in declaration order with no way to undo one, and three schema-declarable stats throw unconditionally from merge. A caller catching the exception around a shard roll-up was left with the entries ahead of the failure counting both shards and the ones behind it counting one, with nothing to indicate it. Entry order decided the damage.

The HasCenterScale bound on band is enforced on the live operator but erased on the spec path, so Sum.band(2.0) compiled, materialized, accepted updates, and only the first read threw a ClassCastException naming neither the operator nor the key, taking a whole group read down with it. transformX advertised the inner post-transform width where the contract is the width callers must supply, so a caller sizing its input from it sent the wrong number of coordinates and the extras were dropped silently. A regression entry in a schema was skipped by every public group, so it failed as a missing key at read time.

## Why not

Rejecting an unmergeable group at construction would forbid a group that is only ever read, which is legitimate. Making merge all-or-nothing keeps that working.

Nested groups stay series-only rather than gaining per-modality counterparts, which would mean four parallel spec types and recursion in each helper. The defect was that a mixed nested schema failed inconsistently: the series view threw at materialize while the discrete view silently produced no entries and left the subtree unreachable. It now fails at the declaration, and a root-level mixed schema still works.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target, with the ABI regenerated for the new group and marker. The half-merge, the band cast and the regression group were all confirmed against the pre-fix behaviour.