### PR TITLE
fix: stop a striped store exposing a half-cleared table

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SerialMode.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stream/SerialMode.kt
@@ -49,6 +49,10 @@ internal class SerialDouble(var ref: Double) : StreamDouble {
     }
 
     override fun add(delta: Double) {
+        // Same short-circuit AtomicMode takes, so a cell holding -0.0 keeps its sign at every level
+        // rather than flipping to +0.0 here and staying -0.0 under Relaxed and Strict. Nothing else in
+        // the primitive differs by mode, and the reported sign of a zero should not either.
+        if (delta == 0.0) return
         ref += delta
     }
 
@@ -97,6 +101,8 @@ internal class SerialDoubleArray(val ref: DoubleArray) : StreamDoubleArray {
         ref[index] = value
     }
     override fun add(index: Int, delta: Double) {
+        // See SerialDouble.add.
+        if (delta == 0.0) return
         ref[index] += delta
     }
     override fun compareAndSet(index: Int, expectedValue: Double, newValue: Double): Boolean {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamModeZeroAddTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/StreamModeZeroAddTest.kt
@@ -1,0 +1,38 @@
+package com.eignex.kumulant.stream
+
+import com.eignex.kumulant.core.Concurrency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StreamModeZeroAddTest {
+
+    // HighWrite is excluded on purpose: a striped adder sums from a +0.0 base, so it cannot represent a
+    // negative zero at all and loses the sign when the cell is seeded, before any add. See AdderMode.
+    private val levelsThatCanSignZero = Concurrency.entries.filter { it != Concurrency.HighWrite }
+
+    @Test
+    fun `adding zero leaves the sign of a negative zero alone at every level`() {
+        for (level in levelsThatCanSignZero) {
+            val cell = level.additiveMode().newDouble(-0.0)
+            cell.add(0.0)
+            assertEquals(
+                (-0.0).toRawBits(),
+                cell.load().toRawBits(),
+                "level=$level flipped the sign of a reported zero",
+            )
+        }
+    }
+
+    @Test
+    fun `adding zero to an array cell leaves the sign alone at every level`() {
+        for (level in levelsThatCanSignZero) {
+            val cells = level.additiveMode().newDoubleArray(1) { -0.0 }
+            cells.add(0, 0.0)
+            assertEquals(
+                (-0.0).toRawBits(),
+                cells.load(0).toRawBits(),
+                "level=$level flipped the sign of a reported zero",
+            )
+        }
+    }
+}

--- a/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/AdderMode.kt
+++ b/kumulant/src/jvmMain/kotlin/com/eignex/kumulant/stream/AdderMode.kt
@@ -31,7 +31,13 @@ internal object AdderMode : StreamMode {
         AtomicMode.newDoubleArray(size, init)
 }
 
-/** [StreamDouble] backed by a striped `java.util.concurrent.atomic.DoubleAdder`. */
+/**
+ * [StreamDouble] backed by a striped `java.util.concurrent.atomic.DoubleAdder`.
+ *
+ * `sum` accumulates from a `+0.0` base, so this cell cannot represent a negative zero: seeding it with
+ * `-0.0` reports `+0.0`. Only the sign of a reported zero is affected, and it is inherent to a striped
+ * counter rather than something the operations below can preserve.
+ */
 @JvmInline
 internal value class DoubleAdder(val ref: JDoubleAdder) : StreamDouble {
 
@@ -43,15 +49,29 @@ internal value class DoubleAdder(val ref: JDoubleAdder) : StreamDouble {
 
     override fun load(): Double = ref.sum()
 
+    // One relative add rather than reset-then-add. `reset` zeroes the base and then each cell in turn
+    // while `sum` walks the same table, so a concurrent reader can pick up a partial residue that was
+    // never the total at any instant - and DoubleAdder.reset is documented as effective only with no
+    // concurrent updates, while StreamDouble.store promises an overwrite. Expressed as a delta, every
+    // observation stays a real total and a racing add is folded in rather than discarded. Two racing
+    // stores still leave one of them plus drift, which is what a striped counter can offer.
     override fun store(value: Double) {
-        ref.reset()
-        ref.add(value)
+        ref.add(value - ref.sum())
     }
 
     override fun add(delta: Double) {
+        // Same short-circuit AtomicMode takes, so a cell holding -0.0 keeps its sign under every level
+        // rather than flipping to +0.0 here and staying -0.0 under Relaxed and Strict.
+        if (delta == 0.0) return
         ref.add(delta)
     }
 
+    // Add then sum, which is deliberately not linearizable: a striped counter has no atomic
+    // read-modify-write, and the returned total may already include a concurrent writer's delta. Safe
+    // for "add and report roughly where we are", but NOT for the `addAndGet(1) == 1` first-writer
+    // election used elsewhere in the library - two threads racing it can both observe 2, so neither
+    // wins and the baseline is never seeded. Every election site sits on monotonicMode or
+    // firstWriterMode, both of which resolve to AtomicMode, where the operation is a single atomic.
     override fun addAndGet(delta: Double): Double {
         ref.add(delta)
         return ref.sum()
@@ -69,15 +89,29 @@ internal value class LongAdder(val ref: JLongAdder) : StreamLong {
 
     override fun load(): Long = ref.sum()
 
+    // One relative add rather than reset-then-add. `reset` zeroes the base and then each cell in turn
+    // while `sum` walks the same table, so a concurrent reader can pick up a partial residue that was
+    // never the total at any instant - and DoubleAdder.reset is documented as effective only with no
+    // concurrent updates, while StreamDouble.store promises an overwrite. Expressed as a delta, every
+    // observation stays a real total and a racing add is folded in rather than discarded. Two racing
+    // stores still leave one of them plus drift, which is what a striped counter can offer.
     override fun store(value: Long) {
-        ref.reset()
-        ref.add(value)
+        ref.add(value - ref.sum())
     }
 
     override fun add(delta: Long) {
+        // Same short-circuit AtomicMode takes, so a cell holding -0L keeps its sign under every level
+        // rather than flipping to +0L here and staying -0L under Relaxed and Strict.
+        if (delta == 0L) return
         ref.add(delta)
     }
 
+    // Add then sum, which is deliberately not linearizable: a striped counter has no atomic
+    // read-modify-write, and the returned total may already include a concurrent writer's delta. Safe
+    // for "add and report roughly where we are", but NOT for the `addAndGet(1) == 1` first-writer
+    // election used elsewhere in the library - two threads racing it can both observe 2, so neither
+    // wins and the baseline is never seeded. Every election site sits on monotonicMode or
+    // firstWriterMode, both of which resolve to AtomicMode, where the operation is a single atomic.
     override fun addAndGet(delta: Long): Long {
         ref.add(delta)
         return ref.sum()


### PR DESCRIPTION
## What changed

- The JVM striped adders write through a single relative add instead of reset-then-add.
- SerialMode short-circuits a zero delta on both the scalar and array cell, matching AtomicMode.
- addAndGet on the adders is documented as not linearizable.

## Why

reset zeroes the base and then each cell in turn while sum walks the same table, so a concurrent reader could pick up a partial residue that was never the total at any instant. DoubleAdder.reset is documented as effective only with no concurrent updates, while StreamDouble.store promises an overwrite. Expressed as a delta, every observation stays a real total and a racing add is folded in rather than discarded. Two racing stores still leave one of them plus drift, which is what a striped counter can offer.

A cell holding a negative zero kept its sign under Relaxed and Strict but flipped to positive under None, so the reported sign of a zero depended on the concurrency level in a primitive that is otherwise uniform.

## Why not

addAndGet keeps its add-then-sum behaviour. Making it throw, matching the sibling compareAndSet, broke two existing tests that pin it as working, so it is a deliberate convenience rather than an oversight. It is now documented as unsafe for the first-writer election, and every election site resolves to AtomicMode where the operation is a single atomic.

HighWrite cannot preserve a negative zero at all: DoubleAdder sums from a positive-zero base, so the sign is lost when the cell is seeded, before any add. That is documented on the class and excluded in the test with the reason.

## Testing

./gradlew check lintDocs --rerun-tasks passes on every target. The signed-zero test was confirmed to fail under None beforehand.