### PR TITLE
chore: bump kbuild to 1.3.2

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
@@ -7,7 +7,7 @@ import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.UCB1
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
 import com.eignex.kumulant.stat.regression.glm.PointPosterior

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
@@ -6,7 +6,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.random.Random
 
 /** Single observation passed to a stat under test. */

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -27,17 +27,17 @@ public final class com/eignex/kumulant/bandit/BanditFactoryKt {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualBandit : com/eignex/kumulant/bandit/Bandit {
-	public abstract fun choose (Lcom/eignex/koblas/F64VectorView;)I
-	public abstract fun update (ILcom/eignex/koblas/F64VectorView;DD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
+	public abstract fun choose (Lcom/eignex/koblas/core/F64VectorView;)I
+	public abstract fun update (ILcom/eignex/koblas/core/F64VectorView;DD)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/core/F64VectorView;DDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/bandit/ContextualBandit$DefaultImpls {
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/core/F64VectorView;DDILjava/lang/Object;)V
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualScorable {
-	public abstract fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
+	public abstract fun evaluate (ILcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/bandit/PerArmBandit : com/eignex/kumulant/bandit/Snapshotable {
@@ -61,14 +61,14 @@ public abstract interface class com/eignex/kumulant/bandit/Snapshotable {
 public final class com/eignex/kumulant/bandit/TrackedContextualBandit : com/eignex/kumulant/bandit/ContextualBandit {
 	public fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
+	public fun choose (Lcom/eignex/koblas/core/F64VectorView;)I
 	public final fun chooseResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun getContextFeatureSize ()I
 	public final fun getInner ()Lcom/eignex/kumulant/bandit/ContextualBandit;
 	public fun getNbrArms ()I
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun reset ()V
-	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/core/F64VectorView;DD)V
 	public final fun updateArmRewardResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateJointResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateMarginalResult ()Lcom/eignex/kumulant/core/Result;
@@ -114,7 +114,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion;
 	public fun <init> (ILjava/util/List;DDLkotlin/random/Random;)V
 	public synthetic fun <init> (ILjava/util/List;DDLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
+	public fun choose (Lcom/eignex/koblas/core/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit;
 	public final fun expertWeights ()[D
@@ -125,11 +125,11 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun merge (Lcom/eignex/kumulant/bandit/contextual/Exp4State;)V
 	public synthetic fun merge (Ljava/lang/Object;)V
-	public final fun playDistribution (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun playDistribution (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public fun reset ()V
 	public fun snapshot ()Lcom/eignex/kumulant/bandit/contextual/Exp4State;
 	public synthetic fun snapshot ()Ljava/lang/Object;
-	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/core/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
@@ -138,7 +138,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/contextual/Exp4Expert {
-	public abstract fun advise (Lcom/eignex/koblas/F64VectorView;I)[D
+	public abstract fun advise (Lcom/eignex/koblas/core/F64VectorView;I)[D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4State : com/eignex/kumulant/core/Result {
@@ -208,10 +208,10 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun armResult (I)Lcom/eignex/kumulant/bandit/contextual/KnnArmResult;
 	public synthetic fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armWeight (I)D
-	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
+	public fun choose (Lcom/eignex/koblas/core/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
+	public fun evaluate (ILcom/eignex/koblas/core/F64VectorView;)D
 	public final fun getColdStartScore ()D
 	public final fun getDistance ()Lkotlin/jvm/functions/Function2;
 	public final fun getExploration ()D
@@ -225,11 +225,11 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/core/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit$Companion {
-	public final fun squaredL2 (Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64VectorView;)D
+	public final fun squaredL2 (Lcom/eignex/koblas/core/F64VectorView;Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -391,10 +391,10 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public synthetic fun <init> (ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/stat/regression/RegressionPosterior;DLcom/eignex/kumulant/core/RegressionStat;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armStat (I)Lcom/eignex/kumulant/core/RegressionStat;
-	public fun choose (Lcom/eignex/koblas/F64VectorView;)I
+	public fun choose (Lcom/eignex/koblas/core/F64VectorView;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/F64VectorView;)D
+	public fun evaluate (ILcom/eignex/koblas/core/F64VectorView;)D
 	public final fun getExploration ()D
 	public fun getNbrArms ()I
 	public final fun getPosterior ()Lcom/eignex/kumulant/stat/regression/RegressionPosterior;
@@ -407,7 +407,7 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/F64VectorView;DD)V
+	public fun update (ILcom/eignex/koblas/core/F64VectorView;DD)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/RegressionContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -1840,13 +1840,13 @@ public abstract interface class com/eignex/kumulant/core/HasCenterScale : com/ei
 public abstract interface class com/eignex/kumulant/core/HasLinearModel : com/eignex/kumulant/core/Result {
 	public abstract fun getBias ()D
 	public fun getFeatureSize ()I
-	public abstract fun getWeights ()Lcom/eignex/koblas/F64VectorView;
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/core/HasLinearModel$DefaultImpls {
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasLinearModel;)I
-	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/F64VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/core/HasMinMax : com/eignex/kumulant/core/Result {
@@ -1939,16 +1939,16 @@ public abstract interface class com/eignex/kumulant/core/HasSlope : com/eignex/k
 	public fun getFeatureSize ()I
 	public abstract fun getIntercept ()D
 	public abstract fun getSlope ()D
-	public fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
 	public fun predict (D)D
 }
 
 public final class com/eignex/kumulant/core/HasSlope$DefaultImpls {
 	public static fun getBias (Lcom/eignex/kumulant/core/HasSlope;)D
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasSlope;)I
-	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/F64VectorView;
+	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/core/F64VectorView;
 	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;D)D
-	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/F64VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/core/IndexedResult : com/eignex/kumulant/core/Result {
@@ -2003,22 +2003,22 @@ public abstract interface class com/eignex/kumulant/core/RegressionStat : com/ei
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public abstract fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public abstract fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DJDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorView;DJDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/RegressionStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DD)V
+	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorView;DD)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDD)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DDILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/F64VectorView;DJDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorView;DDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorView;DJDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDILjava/lang/Object;)V
 }
@@ -2090,22 +2090,22 @@ public final class com/eignex/kumulant/core/Stat$DefaultImpls {
 public abstract interface class com/eignex/kumulant/core/VectorStat : com/eignex/kumulant/core/Stat {
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
-	public abstract fun update (Lcom/eignex/koblas/F64VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;D)V
+	public abstract fun update (Lcom/eignex/koblas/core/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorView;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorView;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/VectorStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;D)V
+	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorView;D)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DD)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/F64VectorView;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorView;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorView;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
@@ -3019,8 +3019,8 @@ public final class com/eignex/kumulant/schema/runtime/RegressionStatGroup : com/
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -3119,8 +3119,8 @@ public final class com/eignex/kumulant/schema/runtime/VectorStatGroup : com/eign
 	public synthetic fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;D)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -5048,7 +5048,7 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult : com/e
 	public fun getTotalWeights ()D
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun score (Lcom/eignex/koblas/F64VectorView;)D
+	public final fun score (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -5085,8 +5085,8 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat : com/eig
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;D)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;JD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;D)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -6822,30 +6822,30 @@ public final class com/eignex/kumulant/stat/regression/CovarianceStat : com/eign
 }
 
 public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesResult : com/eignex/kumulant/core/HasObservationCount {
-	public fun <init> (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DD)V
+	public fun <init> (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/F64DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/F64DenseMatrix;
-	public final fun component5 ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun component5 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component6 ()D
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public final fun copy (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getClassWeights ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun getClassWeights ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun getFeatureSize ()I
-	public final fun getMeans ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getMeans ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public final fun getNumClasses ()I
 	public fun getTotalWeights ()D
 	public final fun getVarianceFloor ()D
-	public final fun getVariances ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getVariances ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logPosterior (Lcom/eignex/koblas/F64VectorView;I)D
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
+	public final fun logPosterior (Lcom/eignex/koblas/core/F64VectorView;I)D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)I
 	public final fun prior (I)D
-	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6875,8 +6875,8 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat : 
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -6893,12 +6893,12 @@ public final class com/eignex/kumulant/stat/regression/Optimizer$DefaultImpls {
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/RegressionPosterior {
-	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
+	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RegressionPosterior$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;DILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RmspropOptimizer : com/eignex/kumulant/stat/regression/Optimizer {
@@ -6926,29 +6926,29 @@ public final class com/eignex/kumulant/stat/regression/SgdOptimizer : com/eignex
 
 public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult$Companion;
-	public fun <init> (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJD)V
+	public fun <init> (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/F64DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component5 ()D
 	public final fun component6 ()J
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public final fun copy (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBiases ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun getBiases ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun getCrossEntropy ()D
 	public final fun getFeatureSize ()I
 	public final fun getNumClasses ()I
 	public final fun getStep ()J
 	public fun getTotalWeights ()D
-	public final fun getWeights ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getWeights ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logit (Lcom/eignex/koblas/F64VectorView;I)D
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun logit (Lcom/eignex/koblas/core/F64VectorView;I)D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6986,16 +6986,16 @@ public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionStat : c
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat : com/eignex/kumulant/core/RegressionStat {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat$Companion;
-	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64MatrixView;)V
-	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/F64VectorView;Lcom/eignex/koblas/F64MatrixView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/core/F64VectorView;Lcom/eignex/koblas/core/F64MatrixView;)V
+	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/core/F64VectorView;Lcom/eignex/koblas/core/F64MatrixView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
@@ -7008,8 +7008,8 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7021,24 +7021,24 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 
 public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/F64DenseMatrix;
-	public final fun component7 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun component6 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun component7 ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public final fun component8 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component9 ()D
-	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/koblas/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
-	public final fun getCovariance ()Lcom/eignex/koblas/F64DenseMatrix;
-	public final fun getCovarianceL ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getCovariance ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getCovarianceL ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
@@ -7053,12 +7053,12 @@ public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionR
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7079,25 +7079,25 @@ public final class com/eignex/kumulant/stat/regression/glm/CovarianceRegressionR
 
 public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun component6 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component7 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component8 ()D
-	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDDJLcom/eignex/koblas/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
-	public final fun getPrecision ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun getPrecision ()Lcom/eignex/koblas/core/F64DenseVector;
 	public fun getRSquared ()D
 	public fun getRmse ()D
 	public fun getSampleStdDev ()D
@@ -7109,12 +7109,12 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionRes
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7150,8 +7150,8 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7159,19 +7159,19 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 public final class com/eignex/kumulant/stat/regression/glm/FactorisedGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/FactorisedGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression {
-	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;)V
-	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;)V
+	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createInstance ()Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
 	public final fun getBiasPriorVariance ()D
 	public final fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
@@ -7195,22 +7195,22 @@ public final class com/eignex/kumulant/stat/regression/glm/LearningRatesKt {
 public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/LinUcb;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearPosterior : com/eignex/kumulant/stat/regression/RegressionPosterior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion;
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/F64VectorView;
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/core/F64VectorView;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion {
@@ -7218,8 +7218,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Compa
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$DefaultImpls {
-	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/F64VectorView;
+	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/core/F64VectorView;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult : com/eignex/kumulant/core/HasLinearModel, com/eignex/kumulant/core/HasRegression, com/eignex/kumulant/core/Result {
@@ -7228,9 +7228,9 @@ public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRe
 	public abstract fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public abstract fun getStep ()J
 	public abstract fun getTotalWeights ()D
-	public abstract fun getWeights ()Lcom/eignex/koblas/F64VectorView;
-	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
+	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult$Companion {
@@ -7249,8 +7249,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResul
 	public static fun getStdDev (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun getVariance (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun isEmpty (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)Z
-	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;)D
-	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;)D
+	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;)D
+	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;)D
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/Link {
@@ -7300,12 +7300,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Link$Logit : com/eign
 public final class com/eignex/kumulant/stat/regression/glm/MultivariateGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/MultivariateGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/CovarianceRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
@@ -7383,28 +7383,28 @@ public final class com/eignex/kumulant/stat/regression/glm/Penalty$None : com/ei
 public final class com/eignex/kumulant/stat/regression/glm/PointPosterior : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/PointPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/F64VectorView;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorView;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior$Companion;
-	public fun <init> (Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;I)V
-	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
-	public final fun component2 ()Lcom/eignex/koblas/F64DenseMatrix;
+	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;I)V
+	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun component2 ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public final fun component3 ()I
-	public final fun copy (Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/F64DenseVector;Lcom/eignex/koblas/F64DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCovariance ()Lcom/eignex/koblas/F64DenseMatrix;
+	public final fun getCovariance ()Lcom/eignex/koblas/core/F64DenseMatrix;
 	public final fun getInstanceCount ()I
-	public final fun getMean ()Lcom/eignex/koblas/F64DenseVector;
+	public final fun getMean ()Lcom/eignex/koblas/core/F64DenseVector;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7426,17 +7426,17 @@ public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior$Compa
 
 public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
-	public synthetic fun <init> (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
+	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component6 ()D
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public fun getFeatureSize ()I
@@ -7454,12 +7454,12 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionR
 	public fun getTotalWeights ()D
 	public final fun getUpdaterState ()Ljava/util/List;
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/F64VectorView;)D
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7499,8 +7499,8 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionS
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7538,13 +7538,13 @@ public final class com/eignex/kumulant/stat/regression/glm/UnivariateRegressionR
 	public final fun getSxy ()D
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/F64VectorView;
+	public fun getWeights ()Lcom/eignex/koblas/core/F64VectorView;
 	public final fun getX ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public final fun getY ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public fun predict (D)D
-	public fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7646,12 +7646,12 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationAuditL
 }
 
 public abstract class com/eignex/kumulant/stat/regression/tree/ClassificationLeafNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public abstract fun getArm ()Lcom/eignex/kumulant/core/SeriesStat;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric {
@@ -7666,7 +7666,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitM
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
 	public fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getCarryover ()Lcom/eignex/kumulant/core/SeriesStat;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
@@ -7684,19 +7684,19 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTermin
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTree {
 	public fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;I)V
 	public synthetic fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getNodeCount ()I
 	public final fun merge (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;)V
 	public final fun mergeSnapshot (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)V
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)I
 	public final fun prettyPrint (Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun prettyPrint$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public final fun reset ()V
 	public final fun rootNode ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun rootSnapshot ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
-	public final fun update (Lcom/eignex/koblas/F64VectorView;ID)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/F64VectorView;IDILjava/lang/Object;)V
+	public final fun update (Lcom/eignex/koblas/core/F64VectorView;ID)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/core/F64VectorView;IDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
@@ -7763,8 +7763,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7785,8 +7785,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/RegressionTree;
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7797,7 +7797,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ExprSplit : com/eign
 	public final fun component1 ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public final fun copy (Lcom/eignex/kumulant/schema/expr/BoolExpr;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;Lcom/eignex/kumulant/schema/expr/BoolExpr;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
-	public fun direction (Lcom/eignex/koblas/F64VectorView;)Z
+	public fun direction (Lcom/eignex/koblas/core/F64VectorView;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpr ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -7832,8 +7832,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestClassification
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7862,11 +7862,11 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestRegressionResu
 	public final fun copy (Ljava/util/List;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Ljava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeafMerged (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeafMerged (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7918,8 +7918,8 @@ public final class com/eignex/kumulant/stat/regression/tree/InformationGain : co
 public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior : com/eignex/kumulant/stat/regression/tree/ForestPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7927,8 +7927,8 @@ public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior 
 public final class com/eignex/kumulant/stat/regression/tree/MeanTreePosterior : com/eignex/kumulant/stat/regression/tree/TreePosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7952,8 +7952,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestClassificationResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -7976,8 +7976,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/F64VectorView;DD)V
-	public fun update (Lcom/eignex/koblas/F64VectorView;DJD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DD)V
+	public fun update (Lcom/eignex/koblas/core/F64VectorView;DJD)V
 	public fun update ([DDD)V
 	public fun update ([DDJD)V
 }
@@ -8134,8 +8134,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonForestPoster
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8151,8 +8151,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonTreePosterio
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8166,7 +8166,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ThresholdSplit : com
 	public final fun component2 ()D
 	public final fun copy (ID)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;IDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
-	public fun direction (Lcom/eignex/koblas/F64VectorView;)Z
+	public fun direction (Lcom/eignex/koblas/core/F64VectorView;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatureIndex ()I
@@ -8197,7 +8197,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8220,7 +8220,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 }
 
@@ -8235,13 +8235,13 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationRe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNumClasses ()I
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)I
-	public final fun probabilities (Lcom/eignex/koblas/F64VectorView;)[D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)I
+	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorView;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8270,7 +8270,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationSp
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8301,7 +8301,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult : com
 	public final fun copy (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8324,7 +8324,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult$Compa
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 }
 
@@ -8342,12 +8342,12 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeRegressionResult
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getRootMean ()D
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/F64VectorView;)D
+	public final fun predict (Lcom/eignex/koblas/core/F64VectorView;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8381,7 +8381,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeSplitResult : co
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorView;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8414,8 +8414,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbForestPosterior :
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8431,8 +8431,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbTreePosterior : c
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/F64VectorView;Lkotlin/random/Random;D)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorView;Lkotlin/random/Random;D)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -91,7 +91,7 @@ final enum class com.eignex.kumulant.stat.sketch/AdmissionPolicy : kotlin/Enum<c
 }
 
 abstract fun interface com.eignex.kumulant.bandit.contextual/Exp4Expert { // com.eignex.kumulant.bandit.contextual/Exp4Expert|null[0]
-    abstract fun advise(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
+    abstract fun advise(com.eignex.koblas.core/F64VectorView, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.core.F64VectorView;kotlin.Int){}[0]
 }
 
 abstract fun interface com.eignex.kumulant.math/Hasher64 { // com.eignex.kumulant.math/Hasher64|null[0]
@@ -131,8 +131,8 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
         abstract fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/RegressionStat.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.core/RegressionStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
@@ -155,14 +155,14 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.core/VectorStat : com.eignex.kumulant.core/Stat<#A> { // com.eignex.kumulant.core/VectorStat|null[0]
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<#A> // com.eignex.kumulant.core/VectorStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas/F64VectorView, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas.core/F64VectorView, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Long;kotlin.Double){}[0]
 }
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.stat.regression/RegressionPosterior { // com.eignex.kumulant.stat.regression/RegressionPosterior|null[0]
-    abstract fun evaluate(#A, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    abstract fun evaluate(#A, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
 }
 
 abstract interface <#A: in kotlin/Any?> com.eignex.kumulant.stat.regression.tree/Split { // com.eignex.kumulant.stat.regression.tree/Split|null[0]
@@ -185,12 +185,12 @@ abstract interface com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.ba
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualBandit : com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.bandit/ContextualBandit|null[0]
-    abstract fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
-    abstract fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    abstract fun choose(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorView){}[0]
+    abstract fun update(kotlin/Int, com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualScorable { // com.eignex.kumulant.bandit/ContextualScorable|null[0]
-    abstract fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
+    abstract fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorView){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/Scorable { // com.eignex.kumulant.bandit/Scorable|null[0]
@@ -214,11 +214,11 @@ abstract interface com.eignex.kumulant.core/HasLinearModel : com.eignex.kumulant
     abstract val bias // com.eignex.kumulant.core/HasLinearModel.bias|{}bias[0]
         abstract fun <get-bias>(): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.bias.<get-bias>|<get-bias>(){}[0]
     abstract val weights // com.eignex.kumulant.core/HasLinearModel.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
     open val featureSize // com.eignex.kumulant.core/HasLinearModel.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasLinearModel.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
-    open fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    open fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
 }
 
 abstract interface com.eignex.kumulant.core/HasMinMax : com.eignex.kumulant.core/Result { // com.eignex.kumulant.core/HasMinMax|null[0]
@@ -295,7 +295,7 @@ abstract interface com.eignex.kumulant.core/HasSlope : com.eignex.kumulant.core/
     open val featureSize // com.eignex.kumulant.core/HasSlope.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasSlope.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     open val weights // com.eignex.kumulant.core/HasSlope.weights|{}weights[0]
-        open fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
+        open fun <get-weights>(): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
 
     open fun predict(kotlin/Double): kotlin/Double // com.eignex.kumulant.core/HasSlope.predict|predict(kotlin.Double){}[0]
 }
@@ -403,8 +403,8 @@ sealed interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.schem
 }
 
 sealed interface <#A: com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> com.eignex.kumulant.stat.regression.glm/LinearPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<#A> { // com.eignex.kumulant.stat.regression.glm/LinearPosterior|null[0]
-    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
-    open fun evaluate(#A, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
+    open fun evaluate(#A, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion|null[0]
         final fun <#A2: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A2>): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearPosterior<#A2>> // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
@@ -625,10 +625,10 @@ sealed interface com.eignex.kumulant.stat.regression.glm/LinearRegressionResult 
     abstract val totalWeights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights|{}totalWeights[0]
         abstract fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     abstract val weights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    open fun linearPredictor(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.F64VectorView){}[0]
-    open fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    open fun linearPredictor(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.core.F64VectorView){}[0]
+    open fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion.serializer|serializer(){}[0]
@@ -748,7 +748,7 @@ sealed interface com.eignex.kumulant.stat.regression.glm/Penalty { // com.eignex
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationNode { // com.eignex.kumulant.stat.regression.tree/ClassificationNode|null[0]
-    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric { // com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric|null[0]
@@ -762,7 +762,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMet
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ForestPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestPosterior|null[0]
 
-sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/F64VectorView> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
+sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas.core/F64VectorView> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/SerializableSplit> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(){}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -782,7 +782,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeClassificationNode
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion.serializer|serializer(){}[0]
@@ -794,7 +794,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeNodeResult { // co
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    abstract fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion.serializer|serializer(){}[0]
@@ -837,10 +837,10 @@ final class <#A: com.eignex.kumulant.bandit/ContextualBandit> com.eignex.kumulan
     final val random // com.eignex.kumulant.bandit/TrackedContextualBandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit/TrackedContextualBandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
+    final fun choose(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorView){}[0]
     final fun chooseResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.chooseResult|chooseResult(){}[0]
     final fun reset() // com.eignex.kumulant.bandit/TrackedContextualBandit.reset|reset(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
     final fun updateArmRewardResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateArmRewardResult|updateArmRewardResult(){}[0]
     final fun updateJointResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateJointResult|updateJointResult(){}[0]
     final fun updateMarginalResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateMarginalResult|updateMarginalResult(){}[0]
@@ -893,16 +893,16 @@ final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.con
 
     final fun armResult(kotlin/Int): #A // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armResult|armResult(kotlin.Int){}[0]
     final fun armStat(kotlin/Int): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armStat|armStat(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
+    final fun choose(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/RegressionContextualBandit<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorView){}[0]
     final fun globalSnapshot(): #A? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalSnapshot|globalSnapshot(){}[0]
     final fun globalStat(): com.eignex.kumulant.core/RegressionStat<#A>? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalStat|globalStat(){}[0]
     final fun merge(kotlin.collections/List<#A>) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.merge|merge(kotlin.collections.List<1:0>){}[0]
     final fun mergeGlobal(#A) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.mergeGlobal|mergeGlobal(1:0){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 }
 
 final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.univariate/MultiArmedBandit : com.eignex.kumulant.bandit/PerArmBandit<#A>, com.eignex.kumulant.bandit/Scorable, com.eignex.kumulant.bandit/UnivariateBandit { // com.eignex.kumulant.bandit.univariate/MultiArmedBandit|null[0]
@@ -1196,14 +1196,14 @@ final class com.eignex.kumulant.bandit.contextual/Exp4Bandit : com.eignex.kumula
     final val random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
+    final fun choose(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.core.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/Exp4Bandit // com.eignex.kumulant.bandit.contextual/Exp4Bandit.create|create(kotlin.random.Random){}[0]
     final fun expertWeights(): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.expertWeights|expertWeights(){}[0]
     final fun merge(com.eignex.kumulant.bandit.contextual/Exp4State) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.merge|merge(com.eignex.kumulant.bandit.contextual.Exp4State){}[0]
-    final fun playDistribution(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.F64VectorView){}[0]
+    final fun playDistribution(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.core.F64VectorView){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/Exp4Bandit.reset|reset(){}[0]
     final fun snapshot(): com.eignex.kumulant.bandit.contextual/Exp4State // com.eignex.kumulant.bandit.contextual/Exp4Bandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion|null[0]
         final fun defaultEta(kotlin/Int, kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion.defaultEta|defaultEta(kotlin.Int;kotlin.Int){}[0]
@@ -1275,12 +1275,12 @@ final class com.eignex.kumulant.bandit.contextual/KnnArmResult : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eignex.kumulant.bandit/ContextualBandit, com.eignex.kumulant.bandit/ContextualScorable, com.eignex.kumulant.bandit/PerArmBandit<com.eignex.kumulant.bandit.contextual/KnnArmResult> { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.F64VectorView,com.eignex.koblas.F64VectorView,kotlin.Double>;kotlin.random.Random){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas.core/F64VectorView, com.eignex.koblas.core/F64VectorView, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.core.F64VectorView,com.eignex.koblas.core.F64VectorView,kotlin.Double>;kotlin.random.Random){}[0]
 
     final val coldStartScore // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore|{}coldStartScore[0]
         final fun <get-coldStartScore>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore.<get-coldStartScore>|<get-coldStartScore>(){}[0]
     final val distance // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance|{}distance[0]
-        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
+        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas.core/F64VectorView, com.eignex.koblas.core/F64VectorView, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
     final val exploration // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration|{}exploration[0]
         final fun <get-exploration>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration.<get-exploration>|<get-exploration>(){}[0]
     final val k // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.k|{}k[0]
@@ -1293,17 +1293,17 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.random.<get-random>|<get-random>(){}[0]
 
     final fun armWeight(kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.armWeight|armWeight(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.F64VectorView){}[0]
+    final fun choose(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorView){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.F64VectorView){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorView){}[0]
     final fun historySize(kotlin/Int): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.historySize|historySize(kotlin.Int){}[0]
     final fun merge(kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult>) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.merge|merge(kotlin.collections.List<com.eignex.kumulant.bandit.contextual.KnnArmResult>){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Double){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion|null[0]
-        final fun squaredL2(com.eignex.koblas/F64VectorView, com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.F64VectorView;com.eignex.koblas.F64VectorView){}[0]
+        final fun squaredL2(com.eignex.koblas.core/F64VectorView, com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.core.F64VectorView;com.eignex.koblas.core.F64VectorView){}[0]
     }
 }
 
@@ -2863,7 +2863,7 @@ final class com.eignex.kumulant.schema.runtime/RegressionStatGroup : com.eignex.
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.schema.runtime/RegressionStatGroup.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/RegressionStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.schema.runtime/StatGroup : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.schema/GroupResult>, com.eignex.kumulant.schema.runtime/AbstractStatGroup<com.eignex.kumulant.core/SeriesStat<*>> { // com.eignex.kumulant.schema.runtime/StatGroup|null[0]
@@ -2911,7 +2911,7 @@ final class com.eignex.kumulant.schema.runtime/VectorStatGroup : com.eignex.kumu
     constructor <init>(kotlin/Array<out kotlin/Pair<com.eignex.kumulant.schema/StatKey<*>, com.eignex.kumulant.core/VectorStat<*>>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/VectorStatGroup.<init>|<init>(kotlin.Array<out|kotlin.Pair<com.eignex.kumulant.schema.StatKey<*>,com.eignex.kumulant.core.VectorStat<*>>>...;com.eignex.kumulant.core.Concurrency?){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/VectorStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
@@ -4668,7 +4668,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult : com.eignex.k
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/IntArray = ..., kotlin/DoubleArray = ..., kotlin/DoubleArray = ...): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.IntArray;kotlin.DoubleArray;kotlin.DoubleArray){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.hashCode|hashCode(){}[0]
-    final fun score(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.F64VectorView){}[0]
+    final fun score(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult> { // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.$serializer|null[0]
@@ -4707,7 +4707,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat : com.eignex.kum
     final fun merge(com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.merge|merge(com.eignex.kumulant.stat.anomaly.HalfSpaceTreesResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.anomaly/QuantileFilterResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.anomaly/QuantileFilterResult|null[0]
@@ -6328,7 +6328,7 @@ final class com.eignex.kumulant.stat.rate/RateStat : com.eignex.kumulant.core/Se
 }
 
 final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult> { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat|null[0]
-    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/F64VectorView? = ..., com.eignex.koblas/F64MatrixView? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.F64VectorView?;com.eignex.koblas.F64MatrixView?){}[0]
+    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas.core/F64VectorView? = ..., com.eignex.koblas.core/F64MatrixView? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.core.F64VectorView?;com.eignex.koblas.core.F64MatrixView?){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
@@ -6343,7 +6343,7 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 
     final object Companion { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion|null[0]
         final fun fitPopulationPrior(kotlin.collections/List<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlin/Function1<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin/Double> = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion.fitPopulationPrior|fitPopulationPrior(kotlin.collections.List<com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult>;kotlin.Function1<com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult,kotlin.Double>){}[0]
@@ -6351,16 +6351,16 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
 }
 
 final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
     final val biasPrecision // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.biasPrecision|{}biasPrecision[0]
         final fun <get-biasPrecision>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.biasPrecision.<get-biasPrecision>|<get-biasPrecision>(){}[0]
     final val covariance // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance|{}covariance[0]
-        final fun <get-covariance>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance.<get-covariance>|<get-covariance>(){}[0]
+        final fun <get-covariance>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covariance.<get-covariance>|<get-covariance>(){}[0]
     final val covarianceL // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL|{}covarianceL[0]
-        final fun <get-covarianceL>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL.<get-covarianceL>|<get-covarianceL>(){}[0]
+        final fun <get-covarianceL>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.covarianceL.<get-covarianceL>|<get-covarianceL>(){}[0]
     final val link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.sse|{}sse[0]
@@ -6370,18 +6370,18 @@ final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component6|component6(){}[0]
-    final fun component7(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component7|component7(){}[0]
+    final fun component6(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component6|component6(){}[0]
+    final fun component7(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component7|component7(){}[0]
     final fun component8(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component8|component8(){}[0]
     final fun component9(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.component9|component9(){}[0]
-    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult.toString|toString(){}[0]
@@ -6403,7 +6403,7 @@ final class com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult :
 }
 
 final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/F64DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas.core/F64DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6412,7 +6412,7 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val precision // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision|{}precision[0]
-        final fun <get-precision>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
+        final fun <get-precision>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse|{}sse[0]
         final fun <get-sse>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse.<get-sse>|<get-sse>(){}[0]
     final val step // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.step|{}step[0]
@@ -6420,17 +6420,17 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
+    final fun component6(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
     final fun component7(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component7|component7(){}[0]
     final fun component8(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component8|component8(){}[0]
-    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/F64DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas.core/F64DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.toString|toString(){}[0]
@@ -6471,11 +6471,11 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression { // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression|null[0]
-    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas/F64DenseVector? = ..., com.eignex.koblas/F64DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.F64DenseVector?;com.eignex.koblas.F64DenseMatrix?){}[0]
+    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas.core/F64DenseVector? = ..., com.eignex.koblas.core/F64DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.core.F64DenseVector?;com.eignex.koblas.core.F64DenseMatrix?){}[0]
 
     final val biasPriorVariance // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance|{}biasPriorVariance[0]
         final fun <get-biasPriorVariance>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance.<get-biasPriorVariance>|<get-biasPriorVariance>(){}[0]
@@ -6497,19 +6497,19 @@ final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegressi
 }
 
 final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eignex.kumulant.stat.regression.glm/PopulationPrior|null[0]
-    constructor <init>(com.eignex.koblas/F64DenseVector, com.eignex.koblas/F64DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.F64DenseVector;com.eignex.koblas.F64DenseMatrix;kotlin.Int){}[0]
+    constructor <init>(com.eignex.koblas.core/F64DenseVector, com.eignex.koblas.core/F64DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.core.F64DenseVector;com.eignex.koblas.core.F64DenseMatrix;kotlin.Int){}[0]
 
     final val covariance // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance|{}covariance[0]
-        final fun <get-covariance>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
+        final fun <get-covariance>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
     final val instanceCount // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount|{}instanceCount[0]
         final fun <get-instanceCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount.<get-instanceCount>|<get-instanceCount>(){}[0]
     final val mean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean|{}mean[0]
-        final fun <get-mean>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
+        final fun <get-mean>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
 
-    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
-    final fun component2(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
+    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
+    final fun component2(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
     final fun component3(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component3|component3(){}[0]
-    final fun copy(com.eignex.koblas/F64DenseVector = ..., com.eignex.koblas/F64DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.F64DenseVector;com.eignex.koblas.F64DenseMatrix;kotlin.Int){}[0]
+    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., com.eignex.koblas.core/F64DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.core.F64DenseVector;com.eignex.koblas.core.F64DenseMatrix;kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PopulationPrior.toString|toString(){}[0]
@@ -6529,7 +6529,7 @@ final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eig
 }
 
 final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/F64VectorView> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.F64VectorView>){}[0]
+    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas.core/F64VectorView> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.core.F64VectorView>){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6542,18 +6542,18 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val updaterState // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState|{}updaterState[0]
-        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
+        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas.core/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component4|component4(){}[0]
     final fun component5(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
-    final fun copy(com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/F64VectorView> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.F64VectorView>){}[0]
+    final fun component7(): kotlin.collections/List<com.eignex.koblas.core/F64VectorView> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
+    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas.core/F64VectorView> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.core.F64VectorView>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.toString|toString(){}[0]
@@ -6602,7 +6602,7 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat : c
     final fun merge(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult : com.eignex.kumulant.core/HasRegression, com.eignex.kumulant.core/HasSlope, com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult|null[0]
@@ -6764,7 +6764,7 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode : c
         final fun <get-pos>(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<get-pos>|<get-pos>(){}[0]
         final fun <set-pos>(com.eignex.kumulant.stat.regression.tree/ClassificationNode) // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<set-pos>|<set-pos>(com.eignex.kumulant.stat.regression.tree.ClassificationNode){}[0]
 
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf : com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode { // com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf|null[0]
@@ -6780,16 +6780,16 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationTree { // com
     final val nodeCount // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount|{}nodeCount[0]
         final fun <get-nodeCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount.<get-nodeCount>|<get-nodeCount>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun merge(com.eignex.kumulant.stat.regression.tree/ClassificationTree) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.merge|merge(com.eignex.kumulant.stat.regression.tree.ClassificationTree){}[0]
     final fun mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.mergeSnapshot|mergeSnapshot(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
     final fun prettyPrint(kotlin/String = ...): kotlin/String // com.eignex.kumulant.stat.regression.tree/ClassificationTree.prettyPrint|prettyPrint(kotlin.String){}[0]
-    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.core.F64VectorView){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/ClassificationTree.reset|reset(){}[0]
     final fun rootNode(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootNode|rootNode(){}[0]
     final fun rootSnapshot(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootSnapshot|rootSnapshot(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.F64VectorView;kotlin.Int;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Int;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
@@ -6866,7 +6866,7 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.reset|reset(){}[0]
     final fun tree(): com.eignex.kumulant.stat.regression.tree/ClassificationTree // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat|null[0]
@@ -6885,8 +6885,8 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.reset|reset(){}[0]
-    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorView> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumulant.stat.regression.tree/SerializableSplit { // com.eignex.kumulant.stat.regression.tree/ExprSplit|null[0]
@@ -6897,7 +6897,7 @@ final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumu
 
     final fun component1(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.stat.regression.tree/ExprSplit.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.schema.expr/BoolExpr = ...): com.eignex.kumulant.stat.regression.tree/ExprSplit // com.eignex.kumulant.stat.regression.tree/ExprSplit.copy|copy(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-    final fun direction(com.eignex.koblas/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.F64VectorView){}[0]
+    final fun direction(com.eignex.koblas.core/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.core.F64VectorView){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ExprSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ExprSplit.toString|toString(){}[0]
@@ -6933,8 +6933,8 @@ final class com.eignex.kumulant.stat.regression.tree/ForestClassificationResult 
     final fun copy(kotlin/Int = ..., kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.copy|copy(kotlin.Int;kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeClassificationResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestClassificationResult> { // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.$serializer|null[0]
@@ -6964,9 +6964,9 @@ final class com.eignex.kumulant.stat.regression.tree/ForestRegressionResult : co
     final fun component1(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.component1|component1(){}[0]
     final fun copy(kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.copy|copy(kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeRegressionResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeafMerged(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeafMerged(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.$serializer|null[0]
@@ -7008,7 +7008,7 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.reset|reset(){}[0]
     final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/ClassificationTree> // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat|null[0]
@@ -7031,8 +7031,8 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.reset|reset(){}[0]
-    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorView>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
@@ -7121,7 +7121,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior : c
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.toString|toString(){}[0]
 }
@@ -7138,7 +7138,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior : com
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.toString|toString(){}[0]
 }
@@ -7154,7 +7154,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThresholdSplit : com.eignex
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component2|component2(){}[0]
     final fun copy(kotlin/Int = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThresholdSplit // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.copy|copy(kotlin.Int;kotlin.Double){}[0]
-    final fun direction(com.eignex.koblas/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.F64VectorView){}[0]
+    final fun direction(com.eignex.koblas.core/F64VectorView): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.core.F64VectorView){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.toString|toString(){}[0]
@@ -7182,7 +7182,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResul
     final fun component1(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.copy|copy(com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.toString|toString(){}[0]
 
@@ -7213,10 +7213,10 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationResult : 
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> { // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.$serializer|null[0]
@@ -7253,7 +7253,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResu
     final fun component4(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.toString|toString(){}[0]
 
@@ -7282,7 +7282,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeLeafResult : com.eignex
     final fun component1(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeLeafResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.copy|copy(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.toString|toString(){}[0]
 
@@ -7313,9 +7313,9 @@ final class com.eignex.kumulant.stat.regression.tree/TreeRegressionResult : com.
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.$serializer|null[0]
@@ -7352,7 +7352,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeSplitResult : com.eigne
     final fun component4(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeSplitResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.toString|toString(){}[0]
 
@@ -7384,7 +7384,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbForestPosterior : com.ei
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbForestPosterior // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.toString|toString(){}[0]
 }
@@ -7401,7 +7401,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbTreePosterior : com.eign
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbTreePosterior // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.toString|toString(){}[0]
 }
@@ -7504,14 +7504,14 @@ final class com.eignex.kumulant.stat.regression/CovarianceStat : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
 
     final val classWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights|{}classWeights[0]
-        final fun <get-classWeights>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
+        final fun <get-classWeights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize|{}featureSize[0]
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     final val means // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means|{}means[0]
-        final fun <get-means>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
+        final fun <get-means>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
     final val numClasses // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses|{}numClasses[0]
         final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
     final val totalWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.totalWeights|{}totalWeights[0]
@@ -7519,22 +7519,22 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.e
     final val varianceFloor // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor|{}varianceFloor[0]
         final fun <get-varianceFloor>(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor.<get-varianceFloor>|<get-varianceFloor>(){}[0]
     final val variances // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances|{}variances[0]
-        final fun <get-variances>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
+        final fun <get-variances>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
-    final fun component5(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
+    final fun component3(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
+    final fun component5(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.hashCode|hashCode(){}[0]
-    final fun logPosterior(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
+    final fun logPosterior(com.eignex.koblas.core/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.core.F64VectorView;kotlin.Int){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
     final fun prior(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.prior|prior(kotlin.Int){}[0]
-    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult> { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.$serializer|null[0]
@@ -7563,7 +7563,7 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat : com.eig
     final fun merge(com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.merge|merge(com.eignex.kumulant.stat.regression.GaussianNaiveBayesResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression/RmspropOptimizer : com.eignex.kumulant.stat.regression/Optimizer { // com.eignex.kumulant.stat.regression/RmspropOptimizer|null[0]
@@ -7599,10 +7599,10 @@ final class com.eignex.kumulant.stat.regression/SgdOptimizer : com.eignex.kumula
 }
 
 final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/F64DenseMatrix, com.eignex.koblas/F64DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 
     final val biases // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases|{}biases[0]
-        final fun <get-biases>(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
+        final fun <get-biases>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
     final val crossEntropy // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy|{}crossEntropy[0]
         final fun <get-crossEntropy>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy.<get-crossEntropy>|<get-crossEntropy>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.featureSize|{}featureSize[0]
@@ -7614,21 +7614,21 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.ei
     final val totalWeights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
+    final fun component3(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Long // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/F64DenseMatrix = ..., com.eignex.koblas/F64DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.F64DenseMatrix;com.eignex.koblas.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.hashCode|hashCode(){}[0]
-    final fun logit(com.eignex.koblas/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.F64VectorView;kotlin.Int){}[0]
-    final fun predict(com.eignex.koblas/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.F64VectorView){}[0]
-    final fun probabilities(com.eignex.koblas/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.F64VectorView){}[0]
+    final fun logit(com.eignex.koblas.core/F64VectorView, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.core.F64VectorView;kotlin.Int){}[0]
+    final fun predict(com.eignex.koblas.core/F64VectorView): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorView){}[0]
+    final fun probabilities(com.eignex.koblas.core/F64VectorView): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorView){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/SoftmaxRegressionResult> { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.$serializer|null[0]
@@ -7669,7 +7669,7 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionStat : com.eign
     final fun merge(com.eignex.kumulant.stat.regression/SoftmaxRegressionResult) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.SoftmaxRegressionResult){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas.core/F64VectorView, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.core.F64VectorView;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.score/AccuracyStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.stat.score/AccuracyStat|null[0]
@@ -8850,7 +8850,7 @@ sealed class com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode : c
     abstract val arm // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm|{}arm[0]
         abstract fun <get-arm>(): com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.regression.tree/ClassCountsResult> // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm.<get-arm>|<get-arm>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.F64VectorView){}[0]
+    final fun findLeaf(com.eignex.koblas.core/F64VectorView): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorView){}[0]
 }
 
 final object com.eignex.kumulant.bandit.univariate/BetaPosterior : com.eignex.kumulant.bandit.univariate/Posterior<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.univariate/BetaPosterior|null[0]
@@ -9182,9 +9182,9 @@ final object com.eignex.kumulant.schema.spec/Variance : com.eignex.kumulant.sche
 
 final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/FactorisedGaussian> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.toString|toString(){}[0]
@@ -9192,9 +9192,9 @@ final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.ei
 
 final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinUcb|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/LinUcb.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/LinUcb.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinUcb> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/LinUcb.toString|toString(){}[0]
@@ -9202,9 +9202,9 @@ final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulan
 
 final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/CovarianceRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/MultivariateGaussian> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.toString|toString(){}[0]
@@ -9212,9 +9212,9 @@ final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.
 
 final object com.eignex.kumulant.stat.regression.glm/PointPosterior : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/PointPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PointPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PointPosterior.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/F64VectorView // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorView // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/PointPosterior> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PointPosterior.toString|toString(){}[0]
@@ -9240,14 +9240,14 @@ final object com.eignex.kumulant.stat.regression.tree/InformationGain : com.eign
 
 final object com.eignex.kumulant.stat.regression.tree/MeanForestPosterior : com.eignex.kumulant.stat.regression.tree/ForestPosterior { // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.toString|toString(){}[0]
 }
 
 final object com.eignex.kumulant.stat.regression.tree/MeanTreePosterior : com.eignex.kumulant.stat.regression.tree/TreePosterior { // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorView, kotlin.random/Random, kotlin/Double): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorView;kotlin.random.Random;kotlin.Double){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.toString|toString(){}[0]
 }
@@ -9328,8 +9328,8 @@ final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.k
 final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.kumulant.stat.score/pitKsDistance(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.score/pitKsDistance|pitKsDistance@com.eignex.kumulant.stat.quantile.SparseHistogramResult(kotlin.Int){}[0]
 final fun (com.eignex.kumulant.stat.quantile/TDigestResult).com.eignex.kumulant.stat.quantile/toSparseHistogram(): com.eignex.kumulant.stat.quantile/SparseHistogramResult // com.eignex.kumulant.stat.quantile/toSparseHistogram|toSparseHistogram@com.eignex.kumulant.stat.quantile.TDigestResult(){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<*>).com.eignex.kumulant.stat.regression.tree/aggregate(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/aggregate|aggregate@com.eignex.kumulant.stat.regression.tree.RegressionNode<*>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/F64VectorView>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.F64VectorView>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/F64VectorView>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.F64VectorView>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas.core/F64VectorView>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.core.F64VectorView>(){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorView>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.core.F64VectorView>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/SplitMetric).com.eignex.kumulant.stat.regression.tree/rank(com.eignex.kumulant.stat.summary/WeightedVarianceResult, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin/Double, kotlin/Double): com.eignex.kumulant.stat.regression.tree/SplitInfo // com.eignex.kumulant.stat.regression.tree/rank|rank@com.eignex.kumulant.stat.regression.tree.SplitMetric(com.eignex.kumulant.stat.summary.WeightedVarianceResult;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.Double;kotlin.Double){}[0]
 final fun (com.eignex.kumulant.stat.sketch/BloomFilterResult).com.eignex.kumulant.stat.sketch/contains(kotlin/Long): kotlin/Boolean // com.eignex.kumulant.stat.sketch/contains|contains@com.eignex.kumulant.stat.sketch.BloomFilterResult(kotlin.Long){}[0]
 final fun (com.eignex.kumulant.stat.sketch/CountMinSketchResult).com.eignex.kumulant.stat.sketch/estimate(kotlin/Long): kotlin/Long // com.eignex.kumulant.stat.sketch/estimate|estimate@com.eignex.kumulant.stat.sketch.CountMinSketchResult(kotlin.Long){}[0]

--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import java.util.concurrent.TimeUnit
 
 plugins {
-    id("com.eignex.kmp") version "1.3.1"
+    id("com.eignex.kmp") version "1.3.2"
     kotlin("plugin.serialization") version "2.4.10"
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64SparseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
@@ -329,6 +329,7 @@ class KnnContextualBandit(
             return s
         }
 
+        @OptIn(com.eignex.koblas.UnsafeKoblasApi::class)
         private fun sparseSquaredL2(a: F64SparseVector, b: F64SparseVector): Double {
             var s = 0.0
             a.forEachStored { i, v ->

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlin.time.Duration

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -287,7 +287,7 @@ interface PairedStat<R : Result> : Stat<R> {
  * Inputs are passed as [F64VectorView] so callers can submit sparse feature
  * vectors without materialising them into dense arrays first. The
  * [DoubleArray] convenience overloads wrap the array in a [F64DenseVector]; the
- * sparse path goes through [com.eignex.koblas.F64SparseVector].
+ * sparse path goes through [com.eignex.koblas.core.F64SparseVector].
  *
  * The K-way classifiers
  * ([SoftmaxRegressionStat][com.eignex.kumulant.stat.regression.SoftmaxRegressionStat],

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.stream.currentTimeNanos
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 
 /**
  * Reject a context vector whose arity does not match the model's.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -3,9 +3,9 @@
 
 package com.eignex.kumulant.math
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.norm2
@@ -39,7 +39,7 @@ internal fun F64DenseMatrix.choleskyDowndateInPlace(x: F64VectorView): Double {
     x.forEachStored { i, v -> s[i] = v }
     trsv(this, s, lower = true)
 
-    val norm = norm2(F64DenseVector.wrap(s))
+    val norm = F64DenseVector.wrap(s).norm2()
     // Negated so a NaN norm bails too: falling through would write NaN across the whole factor
     // and still report success.
     if (!(norm > 0.0 && norm < 1.0)) return norm

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -17,7 +17,7 @@ import com.eignex.kumulant.core.requireFeatureSize
  * entries; incoming vectors must match [dimensions] exactly.
  *
  * When [skipZeros] is `true`, only the stored entries of the input vector are
- * forwarded to their per-dimension stats. For a [com.eignex.koblas.F64SparseVector]
+ * forwarded to their per-dimension stats. For a [com.eignex.koblas.core.F64SparseVector]
  * this turns the per-update cost from `O(dimensions)` into `O(nnz)`, and an
  * unobserved index is treated as "no update" rather than "update with 0.0".
  * Keep the default (`false`) for stats whose semantics distinguish zero from

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.calibration
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -1,13 +1,14 @@
 // math convention: single-letter matrices L, M, etc.
 @file:Suppress("VariableNaming", "FunctionParameterNaming", "PropertyName")
+@file:OptIn(com.eignex.koblas.UnsafeKoblasApi::class)
 
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64MatrixView
-import com.eignex.koblas.F64VectorView
 import com.eignex.koblas.axpy
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64MatrixView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.dense.CholeskyDecomposition
 import com.eignex.koblas.dense.CholeskyPolicy
 import com.eignex.koblas.dense.cholesky
@@ -166,7 +167,7 @@ class BayesianRegressionStat(
             // would reach `ger` and poison the covariance permanently, taking every later prediction
             // with it. Skipping the observation keeps the posterior usable.
             if (!denom.isFinite() || denom == 0.0) return@guarded
-            scale(z, sqrt(wc) / denom)
+            z.scale(sqrt(wc) / denom)
 
             // Downdate the Cholesky factor; repair on instability. The downdate leaves the factor
             // untouched for any norm at or above one, so the repair has to trigger on the same
@@ -185,16 +186,16 @@ class BayesianRegressionStat(
                 }
                 norm = covarianceL.choleskyDowndateInPlace(z)
                 while (!(norm < 1.0)) {
-                    scale(z, 1.0 / (norm + DOWNDATE_SHRINK))
+                    z.scale(1.0 / (norm + DOWNDATE_SHRINK))
                     norm = covarianceL.choleskyDowndateInPlace(z)
                 }
             }
 
             // Sum = Sum - z * zT  (rank-1 downdate of the covariance).
-            ger(-1.0, z, z, covariance)
+            covariance.ger(-1.0, z, z)
 
             // Posterior mean update: w += (weight * residual) * S_new * x.
-            axpy(weights, weight * residual, covariance.matVec(x))
+            weights.axpy(weight * residual, covariance.matVec(x))
 
             biasPrecision += wc
             bias += weight * residual / biasPrecision

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.requirePositiveFeatureSize
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.dot
 import com.eignex.koblas.matVec
 import com.eignex.kumulant.math.nextNormal

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireAtLeastTwoClasses

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicLong

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -34,9 +34,9 @@ internal typealias RegressionShapeSpi<Row> = TreeShape<
  *
  * The engine is **generic over the feature representation**: it only ever inspects a row
  * by calling [Split.direction], so any feature type can drive growth by supplying its own
- * [Split]s (e.g. a dense [com.eignex.koblas.F64VectorView] for the built-in stats, or
+ * [Split]s (e.g. a dense [com.eignex.koblas.core.F64VectorView] for the built-in stats, or
  * a typed/constraint-coupled row from a downstream library). Wire-portable serialization
- * of a snapshot is only meaningful for the [com.eignex.koblas.F64VectorView] case and
+ * of a snapshot is only meaningful for the [com.eignex.koblas.core.F64VectorView] case and
  * lives in `TreeRegressionResult.kt` as `VectorView`-constrained extensions.
  *
  * Internal split nodes hold no live arm; subtree aggregates (`rootSnapshot`, the `value`

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.schema.expr.BoolExpr
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 
 /**
  * A feature vector, for the tests that need one.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BernoulliArm

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.univariate.Exp3ArmResult

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64SparseVector
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
 import com.eignex.kumulant.feat
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.feat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.LinUcb

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,8 +1,10 @@
+@file:OptIn(com.eignex.koblas.UnsafeKoblasApi::class)
+
 package com.eignex.kumulant.math
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64SparseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.dense.cholesky
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.CovarianceStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64SparseVector
+import com.eignex.koblas.core.F64SparseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.CountStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.BoolExpr
 import com.eignex.kumulant.schema.expr.Const

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.X
 import com.eignex.kumulant.schema.expr.isFinite

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.math.PI
 import kotlin.math.ln
 import kotlin.math.sqrt

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.optimizer.Adagrad

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.stat.anomaly.FeatureRange
 import com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat
 import com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
 import kotlin.math.abs

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64SparseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.math.abs
 import kotlin.math.sqrt
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.fitLine
 import kotlin.math.abs
 import kotlin.math.exp

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseMatrix
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.schema.optimizer.Sgd
 import kotlin.math.abs
 import kotlin.random.Random

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.optimizer.Sgd

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
@@ -2,8 +2,8 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.F64DenseVector
-import com.eignex.koblas.F64VectorView
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorView
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stream
 
-import com.eignex.koblas.F64DenseVector
+import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.Stat


### PR DESCRIPTION
## Summary

- update the KBuild convention plugin to 1.3.2
- migrate Kumulant to Koblas core types and updated vector operations
- refresh the Kumulant ABI baselines for Koblas’s package relocation

## Validation

- `./gradlew :kumulant:compileKotlinJvm --rerun-tasks`
- `./gradlew check lintDocs --rerun-tasks` *(running in CI)*