### PR TITLE
perf: delegate sparse regression kernels to koblas

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
@@ -1,0 +1,85 @@
+package com.eignex.kumulant.bench
+
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64VectorLike
+import com.eignex.kumulant.stat.regression.SoftmaxRegressionResult
+import com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.Link
+import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlin.random.Random
+
+/** Read-only prediction kernels over dense and sparse feature vectors. */
+@State(Scope.Benchmark)
+open class PredictionKernelBenchmark {
+    @Param("8", "32", "128", "512")
+    var featureSize: Int = 8
+
+    @Param("1", "10", "100")
+    var densityPercent: Int = 1
+
+    private lateinit var x: F64VectorLike
+    private lateinit var linear: StochasticRegressionResult
+    private lateinit var softmax: SoftmaxRegressionResult
+    private lateinit var posterior: CovarianceRegressionResult
+
+    @Setup
+    fun setup() {
+        val values = DoubleArray(featureSize) { i -> (i % 11 - 5) * 0.125 }
+        val count = maxOf(1, featureSize * densityPercent / 100)
+        x = if (densityPercent == 100) F64DenseVector.of(values) else F64SparseVector.of(
+            featureSize,
+            IntArray(count) { it * featureSize / count },
+            DoubleArray(count) { values[it * featureSize / count] },
+        )
+        val weights = F64DenseVector.of(DoubleArray(featureSize) { i -> (i % 7 - 3) * 0.2 })
+        linear = StochasticRegressionResult(weights, 0.25, 0.0, 0L, Link.Identity)
+        softmax = SoftmaxRegressionResult(
+            featureSize,
+            4,
+            F64DenseMatrix.of(Array(4) { k -> DoubleArray(featureSize) { i -> (k - i % 5) * 0.1 } }),
+            F64DenseVector.of(doubleArrayOf(-0.2, 0.0, 0.1, 0.3)),
+            0.0,
+            0L,
+            0.0,
+        )
+        val identity = F64DenseMatrix.diagonal(featureSize, 1.0)
+        posterior = CovarianceRegressionResult(weights, 0.25, 1.0, 0.0, 0L, identity, identity)
+    }
+
+    @Benchmark
+    fun linearPredict(): Double = linear.predict(x)
+
+    @Benchmark
+    fun softmaxProbabilities(): DoubleArray = softmax.probabilities(x)
+
+    @Benchmark
+    fun softmaxPredict(): Int = softmax.predict(x)
+
+    @Benchmark
+    fun multivariateSample(): F64VectorLike = MultivariateGaussian.sample(posterior, Random(1234), 1.0)
+
+    @Benchmark
+    fun bayesianPrior(): CovarianceRegressionResult = BayesianRegressionStat(
+        featureSize = featureSize,
+        priorMean = F64DenseVector.of(DoubleArray(featureSize) { it * 0.01 }),
+    ).read()
+
+    @Benchmark
+    fun bayesianMerge(): CovarianceRegressionResult {
+        val left = BayesianRegressionStat(featureSize)
+        val right = BayesianRegressionStat(featureSize)
+        left.update(x, 1.0)
+        right.update(x, -0.5)
+        left.merge(right.read())
+        return left.read()
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -2,6 +2,7 @@ package com.eignex.kumulant.core
 
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.dot
 import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlin.time.Duration
@@ -231,9 +232,7 @@ interface HasLinearModel : Result {
      */
     fun predict(x: F64VectorLike): Double {
         x.requireFeatureSize(weights.size)
-        var sum = bias
-        for (i in 0 until weights.size) sum += x[i] * weights[i]
-        return sum
+        return bias + (x dot weights)
     }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -3,11 +3,11 @@
 
 package com.eignex.kumulant.math
 
+import com.eignex.koblas.copy
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dense.trsv
-import com.eignex.koblas.forEachStored
 import com.eignex.koblas.norm2
 import kotlin.math.absoluteValue
 import kotlin.math.sqrt
@@ -36,7 +36,7 @@ internal fun F64DenseMatrix.choleskyDowndateInPlace(x: F64VectorLike): Double {
     // Scatter rather than index x: SparseVector.get is a linear scan, so a per-element read would
     // be quadratic in its nonzeros.
     val s = DoubleArray(n)
-    x.forEachStored { i, v -> s[i] = v }
+    copy(x, F64DenseVector.wrap(s))
     trsv(s, lower = true)
 
     val norm = F64DenseVector.wrap(s).norm2()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -122,13 +122,7 @@ class BayesianRegressionStat(
     }
 
     // priorInfo = H_prior * mu_prior, the natural-form contribution from the prior.
-    private val priorInfo: DoubleArray = DoubleArray(featureSize).also { out ->
-        for (i in 0 until featureSize) {
-            var s = 0.0
-            for (j in 0 until featureSize) s += priorPrecisionMatrix[i, j] * initialWeights[j]
-            out[i] = s
-        }
-    }
+    private val priorInfo: DoubleArray = (priorPrecisionMatrix * F64DenseVector.of(initialWeights)).toDoubleArray()
 
     private val lock = concurrency.serializedLock()
     private val weights = F64DenseVector.of(initialWeights.copyOf())
@@ -253,18 +247,13 @@ class BayesianRegressionStat(
             }
 
             // b = H_self * mu_self + H_other * mu_other - H_prior * mu_prior.
-            val otherWeights = values.weights.toDoubleArray()
-            val selfWeights = weights.toDoubleArray()
-            val b = DoubleArray(n)
-            for (i in 0 until n) {
-                var s = -priorInfo[i]
-                for (j in 0 until n) s += hSelf[i, j] * selfWeights[j] + hOther[i, j] * otherWeights[j]
-                b[i] = s
-            }
+            val b = hSelf * weights
+            b.axpy(1.0, hOther * values.weights)
+            b.axpy(-1.0, F64DenseVector.wrap(priorInfo))
 
             // Solve H_new * mu_new = b via chol(H_new); reuse the same factor for Sum_new.
             val hChol = hNew.cholesky(CholeskyPolicy.Regularize())
-            val muNew = hChol.solve(b)
+            val muNew = hChol.solve(b.data)
             val sigmaNew = hChol.invert()
             val LsigmaNew = sigmaNew.cholesky(CholeskyPolicy.Regularize()).l.zeroUpperTriangle()
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -1,8 +1,11 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.axpy
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.dense.trmv
 import com.eignex.koblas.dot
+import com.eignex.koblas.forEachStored
 import com.eignex.koblas.times
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
@@ -107,10 +110,7 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
     ): Double {
         val eta = snapshot.linearPredictor(x)
         var variance = 0.0
-        for (i in 0 until x.size) {
-            val xi = x[i]
-            variance += xi * xi / snapshot.precision[i]
-        }
+        x.forEachStored { i, xi -> variance += xi * xi / snapshot.precision[i] }
         return snapshot.link.invMean(eta + sqrt(exploration * variance) * rng.nextNormal())
     }
 }
@@ -130,13 +130,8 @@ data object MultivariateGaussian : LinearPosterior<CovarianceRegressionResult> {
         val n = snapshot.weights.size
         val sd = sqrt(exploration)
         val u = DoubleArray(n) { rng.nextNormal(0.0, sd) }
-        val out = DoubleArray(n)
-        for (i in 0 until n) {
-            var s = snapshot.weights[i]
-            for (j in 0..i) s += snapshot.covarianceL[i, j] * u[j]
-            out[i] = s
-        }
-        return F64DenseVector.of(out)
+        snapshot.covarianceL.trmv(u, lower = true)
+        return F64DenseVector.wrap(u).also { it.axpy(1.0, snapshot.weights) }
     }
 
     /** Closes to `invMean(eta(x) + sqrt(exploration * xT * Sigma * x) * N(0,1))`; one

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -3,6 +3,7 @@ package com.eignex.kumulant.stat.regression.glm
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.dot
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result
@@ -47,9 +48,7 @@ sealed interface LinearRegressionResult :
     /** Linear predictor `eta = bias + x . weights`, before the inverse link. */
     fun linearPredictor(x: F64VectorLike): Double {
         x.requireFeatureSize(weights.size)
-        var sum = bias
-        for (i in 0 until weights.size) sum += x[i] * weights[i]
-        return sum
+        return bias + (x dot weights)
     }
 
     /** Mean response: `link.invMean(linearPredictor(x))`. For [Link.Identity] this is

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -5,12 +5,19 @@ package com.eignex.kumulant.math
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dense.cholesky
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CholeskyTest {
+
+    private class StridedVector(private val backing: DoubleArray) : F64VectorLike {
+        override val size: Int get() = backing.size / 2
+        override fun get(i: Int): Double = backing[i * 2]
+        override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
+    }
 
     // Reconstruct A = L * LT from the lower triangle of a factor.
     private fun product(l: F64DenseMatrix): Array<DoubleArray> {
@@ -112,6 +119,18 @@ class CholeskyTest {
 
         assertEquals(0.0, norm)
         val expected = Array(3) { i -> DoubleArray(3) { j -> a[i][j] - x[i] * x[j] } }
+        assertMatrixEquals(expected, product(l))
+    }
+
+    @Test
+    fun `downdate takes a generic strided vector`() {
+        val a = arrayOf(doubleArrayOf(4.0, 1.0), doubleArrayOf(1.0, 3.0))
+        val l = F64DenseMatrix.of(a).cholesky().l
+        val x = doubleArrayOf(0.5, 0.25)
+
+        assertEquals(0.0, l.choleskyDowndateInPlace(StridedVector(doubleArrayOf(0.5, 9.0, 0.25, 9.0))))
+
+        val expected = Array(2) { i -> DoubleArray(2) { j -> a[i][j] - x[i] * x[j] } }
         assertMatrixEquals(expected, product(l))
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
@@ -2,11 +2,19 @@ package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64VectorLike
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class SoftmaxRegressionResultTest {
+
+    private class StridedVector(private val backing: DoubleArray) : F64VectorLike {
+        override val size: Int get() = backing.size / 2
+        override fun get(i: Int): Double = backing[i * 2]
+        override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
+    }
 
     private fun result(weights: Array<DoubleArray>, biases: DoubleArray): SoftmaxRegressionResult =
         SoftmaxRegressionResult(
@@ -35,6 +43,27 @@ class SoftmaxRegressionResultTest {
         val r = result(arrayOf(doubleArrayOf(1.0, 2.0)), doubleArrayOf(0.0))
         assertFailsWith<IllegalArgumentException> {
             r.logit(F64DenseVector.of(doubleArrayOf(1.0)), 0)
+        }
+    }
+
+    @Test
+    fun `sparse and generic inputs preserve logits probabilities and predictions`() {
+        val r = result(
+            weights = arrayOf(doubleArrayOf(1.0, -2.0, 0.5, 3.0), doubleArrayOf(-1.0, 1.0, 2.0, -0.5)),
+            biases = doubleArrayOf(0.25, -0.75),
+        )
+        val dense = F64DenseVector.of(doubleArrayOf(2.0, 0.0, -1.0, 0.0))
+        val sparse = F64SparseVector.of(4, intArrayOf(0, 2), doubleArrayOf(2.0, -1.0))
+        val strided = StridedVector(doubleArrayOf(2.0, 9.0, 0.0, 9.0, -1.0, 9.0, 0.0, 9.0))
+
+        val expected = r.probabilities(dense)
+        for (x in listOf<F64VectorLike>(sparse, strided)) {
+            val actual = r.probabilities(x)
+            assertEquals(expected[0], actual[0], 1e-12)
+            assertEquals(expected[1], actual[1], 1e-12)
+            assertEquals(1.0, actual.sum(), 1e-12)
+            assertEquals(r.predict(dense), r.predict(x))
+            assertEquals(r.logit(dense, 0), r.logit(x, 0), 1e-12)
         }
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,6 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.fitLine
 import kotlin.math.abs
 import kotlin.math.exp
@@ -9,6 +10,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class BayesianRegressionStatTest {
+
+    private class StridedVector(private val backing: DoubleArray) : F64VectorLike {
+        override val size: Int get() = backing.size / 2
+        override fun get(i: Int): Double = backing[i * 2]
+        override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
+    }
 
     // The factor is downdated alongside the covariance rather than refactorized, so the two can
     // only be trusted to agree if every downdate lands. L * LT has to stay equal to S. The
@@ -45,6 +52,17 @@ class BayesianRegressionStatTest {
                 "Sum[$i,$i]=${r.covariance[i, i]} did not shrink from prior 1.0",
             )
         }
+    }
+
+    @Test
+    fun `linear predictor gives generic strided inputs the dense result`() {
+        val stat = BayesianRegressionStat(featureSize = 2)
+        stat.update(doubleArrayOf(1.0, -2.0), 3.0)
+        val snapshot = stat.read()
+        val dense = F64DenseVector.of(doubleArrayOf(0.5, -0.25))
+        val strided = StridedVector(doubleArrayOf(0.5, 9.0, -0.25, 9.0))
+
+        assertEquals(snapshot.linearPredictor(dense), snapshot.linearPredictor(strided), 1e-12)
     }
 
     @Test

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -2,6 +2,8 @@ package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.schema.optimizer.Sgd
 import kotlin.math.abs
 import kotlin.random.Random
@@ -113,6 +115,19 @@ class LinearPosteriorsTest {
     }
 
     @Test
+    fun `FactorisedGaussian evaluate gives sparse inputs the dense score`() {
+        val snap = diagonalSnapshot()
+        val dense = F64DenseVector.of(doubleArrayOf(0.1, 0.0))
+        val sparse = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.1))
+
+        assertEquals(
+            FactorisedGaussian.evaluate(snap, dense, Random(42), exploration = 0.1),
+            FactorisedGaussian.evaluate(snap, sparse, Random(42), exploration = 0.1),
+            1e-12,
+        )
+    }
+
+    @Test
     fun `MultivariateGaussian sample is centered on snapshot weights`() {
         val snap = bayesianSnapshot()
         val rng = Random(0)
@@ -126,6 +141,31 @@ class LinearPosteriorsTest {
         }
         assertTrue(abs(s0 / n - snap.weights[0]) < 0.05)
         assertTrue(abs(s1 / n - snap.weights[1]) < 0.05)
+    }
+
+    @Test
+    fun `MultivariateGaussian sample preserves triangular product and random draws`() {
+        val covariance = F64DenseMatrix.of(arrayOf(doubleArrayOf(4.0, 6.0), doubleArrayOf(6.0, 25.0)))
+        val snapshot = CovarianceRegressionResult(
+            weights = F64DenseVector.of(doubleArrayOf(1.0, -1.0)),
+            bias = 0.0,
+            biasPrecision = 1.0,
+            totalWeights = 0.0,
+            step = 0L,
+            covariance = covariance,
+            covarianceL = F64DenseMatrix.of(arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(3.0, 4.0))),
+        )
+        val expectedRng = Random(7)
+        val u0 = expectedRng.nextNormal(0.0, 0.5)
+        val u1 = expectedRng.nextNormal(0.0, 0.5)
+        val expectedNext = expectedRng.nextNormal()
+        val actualRng = Random(7)
+
+        val sample = MultivariateGaussian.sample(snapshot, actualRng, exploration = 0.25)
+
+        assertEquals(1.0 + 2.0 * u0, sample[0], 1e-12)
+        assertEquals(-1.0 + 3.0 * u0 + 4.0 * u1, sample[1], 1e-12)
+        assertEquals(expectedNext, actualRng.nextNormal(), 0.0)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Delegate linear prediction and linear regression predictors to KoBLAS dot with sparse inputs on the left.
- Delegate factorised posterior evaluation, Cholesky downdate preparation, multivariate sampling, and Bayesian natural-parameter products to KoBLAS kernels.
- Add representation coverage and parameterized JMH benchmarks for prediction, posterior sampling, and Bayesian prior/merge paths.
- Omit the Softmax result-scoring candidate after its dense regression was reproducible in the controlled comparison.

## Why

Sparse vectors previously triggered full-coordinate reads in read-only prediction and posterior paths. KoBLAS dispatches sparse inputs through stored entries, preserving behavior while making these paths proportional to nonzeros where applicable.

Explicit non-goals: no KNN or Gaussian Naive Bayes rewrites; no changes to live concurrent cells, update storage, targets, schemas, serialization, dependencies, or .github files.

## Testing

`./gradlew check lintDocs --rerun-tasks` passed before the benchmark-only extension; focused JVM tests passed for LinearPosteriorsTest, BayesianRegressionStatTest, SoftmaxRegressionResultTest, and CholeskyTest.

Benchmark method: JDK 25.0.1, one fork, one 1-second warmup, one 1-second measurement; identical temporary benchmark harnesses on origin/main and this branch; sizes 8, 32, 128, and 512 with 1%, 10%, and 100% density.

Representative 512-feature sparse results: linear prediction improved from 0.56M to 100.1M ops/s at 1% density and from 0.29M to 33.2M ops/s at 10%; posterior sampling improved from 3.8K to 30.7K ops/s at 1%. Dense linear prediction improved from 3.5M to 20.4M ops/s at 512 features. Bayesian prior/merge were neutral to improved, with merge +6–16% at 128–512 (apart from measurement noise at the smallest cases). The controlled run showed material dense softmax regressions (37–63% at 128–512), so that independently revertible candidate was omitted. The retained candidates had no material sparse regression.