### PR TITLE
feat: reuse contextual scoring workspace

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
@@ -6,6 +6,8 @@ import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionResult
+import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
+import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.stat.regression.glm.CovarianceRegressionResult
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.Link
@@ -31,6 +33,8 @@ open class PredictionKernelBenchmark {
     private lateinit var linear: StochasticRegressionResult
     private lateinit var softmax: SoftmaxRegressionResult
     private lateinit var posterior: CovarianceRegressionResult
+    private lateinit var gaussianNaiveBayes: com.eignex.kumulant.stat.regression.GaussianNaiveBayesResult
+    private lateinit var knn: KnnContextualBandit
     private lateinit var workspace: Workspace
     private lateinit var probabilities: DoubleArray
 
@@ -56,9 +60,19 @@ open class PredictionKernelBenchmark {
         )
         val identity = F64DenseMatrix.diagonal(featureSize, 1.0)
         posterior = CovarianceRegressionResult(weights, 0.25, 1.0, 0.0, 0L, identity, identity)
+        val naiveBayes = GaussianNaiveBayesStat(featureSize, 4)
+        repeat(16) { sample ->
+            naiveBayes.update(F64DenseVector.of(DoubleArray(featureSize) { i -> (sample - i % 7) * 0.1 }), (sample % 4).toDouble())
+        }
+        gaussianNaiveBayes = naiveBayes.read()
+        knn = KnnContextualBandit(nbrArms = 4, k = 8, exploration = 0.0)
+        repeat(4) { arm ->
+            repeat(32) { sample -> knn.update(arm, x, (sample - arm).toDouble()) }
+        }
         workspace = Workspace().apply {
             reserve(featureSize, count = 3)
             reserve(4, count = 1)
+            reserve(24, count = 1)
         }
         probabilities = DoubleArray(4)
     }
@@ -77,6 +91,18 @@ open class PredictionKernelBenchmark {
 
     @Benchmark
     fun softmaxPredictWorkspace(): Int = softmax.predict(x, workspace)
+
+    @Benchmark
+    fun gaussianNaiveBayesProbabilities(): DoubleArray = gaussianNaiveBayes.probabilities(x)
+
+    @Benchmark
+    fun gaussianNaiveBayesProbabilitiesInto(): DoubleArray = probabilities.also { gaussianNaiveBayes.probabilitiesInto(x, it) }
+
+    @Benchmark
+    fun knnChoose(): Int = knn.choose(x)
+
+    @Benchmark
+    fun knnChooseWorkspace(): Int = knn.choose(x, workspace)
 
     @Benchmark
     fun multivariateSample(): F64VectorLike = MultivariateGaussian.sample(posterior, Random(1234), 1.0)

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -214,6 +214,7 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public synthetic fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armWeight (I)D
 	public fun choose (Lcom/eignex/koblas/core/F64VectorLike;)I
+	public final fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
 	public fun evaluate (ILcom/eignex/koblas/core/F64VectorLike;)D
@@ -6851,9 +6852,11 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesResult 
 	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public final fun logPosterior (Lcom/eignex/koblas/core/F64VectorLike;I)D
+	public final fun logPosteriorsInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
 	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)I
 	public final fun prior (I)D
 	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
+	public final fun probabilitiesInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -1300,8 +1300,10 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
 
     final fun armWeight(kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.armWeight|armWeight(kotlin.Int){}[0]
     final fun choose(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.create|create(kotlin.random.Random){}[0]
     final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace){}[0]
     final fun historySize(kotlin/Int): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.historySize|historySize(kotlin.Int){}[0]
     final fun merge(kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult>) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.merge|merge(kotlin.collections.List<com.eignex.kumulant.bandit.contextual.KnnArmResult>){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.reset|reset(){}[0]
@@ -7541,9 +7543,11 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.e
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.hashCode|hashCode(){}[0]
     final fun logPosterior(com.eignex.koblas.core/F64VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.core.F64VectorLike;kotlin.Int){}[0]
+    final fun logPosteriorsInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosteriorsInto|logPosteriorsInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
     final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
     final fun prior(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.prior|prior(kotlin.Int){}[0]
     final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun probabilitiesInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult> { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.$serializer|null[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -1,5 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.Workspace
+import com.eignex.koblas.borrow
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
@@ -163,14 +165,28 @@ class KnnContextualBandit(
         return bestIdx
     }
 
+    /** Chooses with caller-owned scratch reused for every arm's nearest-neighbour scan. */
+    fun choose(x: F64VectorLike, workspace: Workspace): Int {
+        requireFeatureSize(x.size)
+        val bestIdx = workspace.borrow(3 * k) { scratch ->
+            argmaxArm(nbrArms) { armIndex -> evaluateWithScratch(armIndex, x, scratch) }
+        }
+        step++
+        return bestIdx
+    }
+
     /** Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus. */
     override fun evaluate(armIndex: Int, x: F64VectorLike): Double {
         requireArmIndex(armIndex, nbrArms)
         requireFeatureSize(x.size)
-        val ctx = historyContexts[armIndex]
-        if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
-        val mean = knnMean(armIndex, x)
-        return mean + ucbBonus(armIndex)
+        return evaluateWithScratch(armIndex, x, null)
+    }
+
+    /** Scores an arm with caller-owned scratch for its bounded top-k buffers. */
+    override fun evaluate(armIndex: Int, x: F64VectorLike, workspace: Workspace): Double {
+        requireArmIndex(armIndex, nbrArms)
+        requireFeatureSize(x.size)
+        return workspace.borrow(3 * k) { scratch -> evaluateWithScratch(armIndex, x, scratch) }
     }
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
@@ -252,32 +268,43 @@ class KnnContextualBandit(
         return exploration * sqrt(ln(t) / w)
     }
 
+    private fun evaluateWithScratch(armIndex: Int, x: F64VectorLike, scratch: DoubleArray?): Double {
+        val ctx = historyContexts[armIndex]
+        if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
+        val mean = if (scratch == null) knnMean(armIndex, x) else knnMean(armIndex, x, scratch)
+        return mean + ucbBonus(armIndex)
+    }
+
     private fun knnMean(armIndex: Int, x: F64VectorLike): Double {
+        val scratch = DoubleArray(3 * k)
+        return knnMean(armIndex, x, scratch)
+    }
+
+    private fun knnMean(armIndex: Int, x: F64VectorLike, scratch: DoubleArray): Double {
         val ctxs = historyContexts[armIndex]
         val rs = historyRewards[armIndex]
         val ws = historyWeights[armIndex]
         // Linear scan, bounded heap of size k. For typical maxHistoryPerArm values
         // (<= a few thousand) this is faster than maintaining a KD-tree under reweights.
-        val topD = DoubleArray(k) { Double.POSITIVE_INFINITY }
-        val topR = DoubleArray(k)
-        val topW = DoubleArray(k)
+        for (i in 0 until k) scratch[i] = Double.POSITIVE_INFINITY
         for (i in ctxs.indices) {
             val d = distance(ctxs[i], x)
             // Find insertion point: index of the max in topD.
             var worst = 0
-            for (j in 1 until k) if (topD[j] > topD[worst]) worst = j
-            if (d < topD[worst]) {
-                topD[worst] = d
-                topR[worst] = rs[i]
-                topW[worst] = ws[i]
+            for (j in 1 until k) if (scratch[j] > scratch[worst]) worst = j
+            if (d < scratch[worst]) {
+                scratch[worst] = d
+                scratch[k + worst] = rs[i]
+                scratch[2 * k + worst] = ws[i]
             }
         }
         var sumW = 0.0
         var sumWR = 0.0
         for (i in 0 until k) {
-            if (topD[i] == Double.POSITIVE_INFINITY) continue
-            sumW += topW[i]
-            sumWR += topW[i] * topR[i]
+            if (scratch[i] == Double.POSITIVE_INFINITY) continue
+            val weight = scratch[2 * k + i]
+            sumW += weight
+            sumWR += weight * scratch[k + i]
         }
         return if (sumW > 0.0) sumWR / sumW else coldStartScore
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -82,11 +82,22 @@ data class GaussianNaiveBayesResult(
         return s
     }
 
+    /** Writes unnormalised log-posteriors for [x] into [destination]. */
+    fun logPosteriorsInto(x: F64VectorLike, destination: DoubleArray) {
+        x.requireFeatureSize(featureSize)
+        require(destination.size == numClasses) {
+            "destination size ${destination.size} must match numClasses $numClasses"
+        }
+        for (c in 0 until numClasses) destination[c] = logPosterior(x, c)
+    }
+
     /** Normalised class probabilities via log-sum-exp on the log-posterior. */
-    fun probabilities(x: F64VectorLike): DoubleArray {
-        val logs = DoubleArray(numClasses) { logPosterior(x, it) }
-        logs.softmaxInPlace()
-        return logs
+    fun probabilities(x: F64VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
+
+    /** Writes normalised class probabilities for [x] into [destination]. */
+    fun probabilitiesInto(x: F64VectorLike, destination: DoubleArray) {
+        logPosteriorsInto(x, destination)
+        destination.softmaxInPlace()
     }
 
     /** Argmax class index for [x]. */

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.Workspace
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
@@ -145,6 +146,42 @@ class KnnContextualBanditTest {
         val a = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
         val b = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
         assertEquals(9.0, squaredL2(a, b))
+    }
+
+    @Test
+    fun `workspace scoring matches allocating scoring across sparse contexts`() {
+        val allocating = KnnContextualBandit(nbrArms = 2, k = 2, exploration = 0.0)
+        val reused = KnnContextualBandit(nbrArms = 2, k = 2, exploration = 0.0)
+        val samples = listOf(
+            Triple(0, F64SparseVector.of(3, intArrayOf(0), doubleArrayOf(1.0)), 0.5),
+            Triple(0, F64SparseVector.of(3, intArrayOf(1), doubleArrayOf(-2.0)), -1.0),
+            Triple(1, F64SparseVector.of(3, intArrayOf(2), doubleArrayOf(3.0)), 1.5),
+            Triple(1, F64SparseVector.of(3, intArrayOf(0, 2), doubleArrayOf(-1.0, 1.0)), 0.25),
+        )
+        for ((arm, x, reward) in samples) {
+            allocating.update(arm, x, reward)
+            reused.update(arm, x, reward)
+        }
+        val x = F64SparseVector.of(3, intArrayOf(0), doubleArrayOf(0.5))
+        val workspace = Workspace().apply { reserve(6, 1) }
+
+        for (arm in 0 until 2) assertEquals(allocating.evaluate(arm, x), reused.evaluate(arm, x, workspace), 1e-12)
+        assertEquals(allocating.choose(x), reused.choose(x, workspace))
+    }
+
+    @Test
+    fun `workspace borrow releases after a distance exception`() {
+        val bandit = KnnContextualBandit(
+            nbrArms = 1,
+            k = 1,
+            exploration = 0.0,
+            distance = { _, _ -> error("distance failed") },
+        )
+        bandit.update(0, feat(1.0), 1.0)
+        val workspace = Workspace().apply { reserve(3, 1) }
+
+        assertFailsWith<IllegalStateException> { bandit.evaluate(0, feat(1.0), workspace) }
+        assertFailsWith<IllegalStateException> { bandit.evaluate(0, feat(1.0), workspace) }
     }
 }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -1,14 +1,24 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.core.F64StridedVectorView
+import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class GaussianNaiveBayesStatTest {
+
+    private class CustomVector(private val values: DoubleArray) : F64VectorLike {
+        override val size: Int get() = values.size
+        override fun get(i: Int): Double = values[i]
+        override fun toDoubleArray(): DoubleArray = values.copyOf()
+    }
 
     @Test
     fun `per class means and variances match the running stats`() {
@@ -77,6 +87,47 @@ class GaussianNaiveBayesStatTest {
         assertEquals(1.0, p.sum(), 1e-9)
         assertTrue(p[1] > p[0])
         assertEquals(1, r.predict(F64DenseVector.of(doubleArrayOf(9.5))))
+    }
+
+    @Test
+    fun `destination scores match owned scores for dense sparse strided and custom inputs`() {
+        val stat = GaussianNaiveBayesStat(featureSize = 3, numClasses = 2)
+        stat.update(doubleArrayOf(1.0, 0.0, -2.0), 0.0, weight = 2.0)
+        stat.update(doubleArrayOf(-1.0, 0.0, 3.0), 1.0)
+        val result = stat.read()
+        val dense = F64DenseVector.of(doubleArrayOf(0.5, 0.0, -1.0))
+        val sparse = F64SparseVector.of(3, intArrayOf(0, 1, 2), doubleArrayOf(0.5, 0.0, -1.0))
+        val strided = F64StridedVectorView(doubleArrayOf(0.5, 9.0, 0.0, 9.0, -1.0, 9.0), 0, 3, 2)
+        val custom = CustomVector(doubleArrayOf(0.5, 0.0, -1.0))
+        val expected = result.probabilities(dense)
+
+        for (x in listOf<F64VectorLike>(sparse, strided, custom)) {
+            val logs = DoubleArray(2)
+            val probabilities = DoubleArray(2)
+            result.logPosteriorsInto(x, logs)
+            result.probabilitiesInto(x, probabilities)
+            assertEquals(result.logPosterior(x, 0), logs[0], 1e-12)
+            assertEquals(result.logPosterior(x, 1), logs[1], 1e-12)
+            assertEquals(expected[0], probabilities[0], 1e-12)
+            assertEquals(expected[1], probabilities[1], 1e-12)
+            assertEquals(result.predict(dense), result.predict(x))
+        }
+    }
+
+    @Test
+    fun `destination validation fails before mutation`() {
+        val stat = GaussianNaiveBayesStat(featureSize = 2, numClasses = 2)
+        val result = stat.read()
+        val destination = doubleArrayOf(7.0)
+
+        assertFailsWith<IllegalArgumentException> {
+            result.logPosteriorsInto(
+                F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                destination,
+            )
+        }
+
+        assertTrue(destination.contentEquals(doubleArrayOf(7.0)))
     }
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
@@ -1,0 +1,69 @@
+package com.eignex.kumulant.bandit.contextual
+
+import com.eignex.koblas.Workspace
+import com.eignex.koblas.core.F64DenseVector
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KnnWorkspaceAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun interface Body {
+        fun run()
+    }
+
+    private fun bytesPerCall(body: Body): Double {
+        repeat(1_000) { body.run() }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            repeat(2_000) { body.run() }
+            val after = bean.getThreadAllocatedBytes(id)
+            best = minOf(best, (after - before).toDouble() / 2_000)
+        }
+        return best
+    }
+
+    private fun populatedBandit(): KnnContextualBandit = KnnContextualBandit(
+        ARMS,
+        K,
+        exploration = 0.0,
+    ).also { bandit ->
+        repeat(ARMS) { arm ->
+            repeat(HISTORY) { sample ->
+                bandit.update(
+                    arm,
+                    F64DenseVector.of(DoubleArray(FEATURES) { (it + sample).toDouble() }),
+                    sample.toDouble(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `reserved workspace removes repeated k nearest neighbour scratch allocation`() {
+        val allocating = populatedBandit()
+        val reused = populatedBandit()
+        val x = F64DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
+        val workspace = Workspace().apply { reserve(3 * K, 1) }
+
+        val allocatedBytes = bytesPerCall { allocating.choose(x) }
+        val workspaceBytes = bytesPerCall { reused.choose(x, workspace) }
+
+        assertTrue(
+            workspaceBytes + 128.0 <= allocatedBytes,
+            "workspace choose allocated $workspaceBytes B/call versus $allocatedBytes B/call",
+        )
+    }
+
+    private companion object {
+        const val ARMS = 4
+        const val K = 8
+        const val HISTORY = 32
+        const val FEATURES = 32
+    }
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
@@ -1,0 +1,48 @@
+package com.eignex.kumulant.stat.regression
+
+import com.eignex.koblas.core.F64DenseVector
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GaussianNaiveBayesAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun interface Body {
+        fun run()
+    }
+
+    private fun bytesPerCall(body: Body): Double {
+        repeat(1_000) { body.run() }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            repeat(2_000) { body.run() }
+            val after = bean.getThreadAllocatedBytes(id)
+            best = minOf(best, (after - before).toDouble() / 2_000)
+        }
+        return best
+    }
+
+    @Test
+    fun `destination probabilities remove repeated class score allocation`() {
+        val stat = GaussianNaiveBayesStat(featureSize = 32, numClasses = 4)
+        repeat(16) { sample ->
+            stat.update(DoubleArray(32) { feature -> (sample - feature).toDouble() * 0.1 }, (sample % 4).toDouble())
+        }
+        val result = stat.read()
+        val x = F64DenseVector.of(DoubleArray(32) { it * 0.25 })
+        val destination = DoubleArray(4)
+
+        val allocatedBytes = bytesPerCall { result.probabilities(x) }
+        val destinationBytes = bytesPerCall { result.probabilitiesInto(x, destination) }
+
+        assertTrue(
+            destinationBytes + 32.0 <= allocatedBytes,
+            "destination probabilities allocated $destinationBytes B/call versus $allocatedBytes B/call",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add caller-owned Workspace scoring to k-NN and destination scoring to Gaussian Naive Bayes
- add allocation tests and focused JMH coverage
- regenerate Kotlin ABI baselines

## Verification

- `./gradlew :kumulant:jvmTest --tests ... --rerun-tasks`
- `./gradlew :kumulant:detektJvmTestSourceSet :kumulant:jvmTest --tests ...`
- `./gradlew :kumulant:updateKotlinAbi`

## Performance

Repeat-call allocation tests warm and reserve workspaces before measurement. k-NN workspace choosing removes the three top-k scratch arrays; Gaussian NB `probabilitiesInto` removes the class-score array. The direct JMH runner was not used for claims because its manually assembled classpath was incomplete.

## Omissions

No sparse Gaussian-NB rewrite: absent-coordinate baselines still dominate and destination reuse closes the measured allocation gap without densification.