### PR TITLE
perf: adopt owned KoBLAS storage

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/OwnedStorageBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/OwnedStorageBenchmark.kt
@@ -1,0 +1,51 @@
+package com.eignex.kumulant.bench
+
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
+import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+
+@State(Scope.Benchmark)
+open class OwnedStorageBenchmark {
+    @Param("32", "128", "512")
+    var featureSize: Int = 32
+
+    @Param("1", "10", "100")
+    var densityPercent: Int = 1
+
+    private lateinit var stochastic: StochasticRegressionStat
+    private lateinit var diagonal: DiagonalRegressionStat
+    private lateinit var bayesian: BayesianRegressionStat
+    private lateinit var naiveBayes: GaussianNaiveBayesStat
+    private lateinit var sparse: F64SparseVector
+    private lateinit var knn: KnnContextualBandit
+
+    @Setup
+    fun setup() {
+        val x = DoubleArray(featureSize) { (it % 7 - 3).toDouble() }
+        stochastic = StochasticRegressionStat(featureSize).also { it.update(x, 1.0) }
+        diagonal = DiagonalRegressionStat(featureSize).also { it.update(x, 1.0) }
+        bayesian = BayesianRegressionStat(featureSize).also { it.update(x, 1.0) }
+        naiveBayes = GaussianNaiveBayesStat(featureSize, 4).also { it.update(x, 0.0) }
+        val nnz = (featureSize * densityPercent / 100).coerceAtLeast(1)
+        sparse = F64SparseVector.of(
+            featureSize,
+            IntArray(nnz) { it * featureSize / nnz },
+            DoubleArray(nnz) { it.toDouble() },
+        )
+        knn = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 1, exploration = 0.0)
+    }
+
+    @Benchmark fun stochasticRead() = stochastic.read()
+    @Benchmark fun diagonalRead() = diagonal.read()
+    @Benchmark fun bayesianRead() = bayesian.read()
+    @Benchmark fun gaussianNaiveBayesRead() = naiveBayes.read()
+    @Benchmark fun sparseKnnUpdate(): Unit = knn.update(0, sparse, 1.0)
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -383,20 +383,12 @@ class KnnContextualBandit(
     }
 
     private fun copyOf(x: F64VectorLike): F64VectorStorage = when (x) {
-        is F64DenseVector -> F64DenseVector.of(x.toDoubleArray())
+        is F64DenseVector -> F64DenseVector.wrap(x.toDoubleArray())
 
         is F64SparseVector -> {
-            val keepIdx = IntArray(x.size)
-            val keepVal = DoubleArray(x.size)
-            var n = 0
-            x.forEachStored { i, v ->
-                keepIdx[n] = i
-                keepVal[n] = v
-                n++
-            }
-            F64SparseVector.of(x.size, keepIdx.copyOf(n), keepVal.copyOf(n))
+            F64SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
         }
 
-        else -> F64DenseVector.of(x.toDoubleArray())
+        else -> F64DenseVector.wrap(x.toDoubleArray())
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -175,23 +175,24 @@ class GaussianNaiveBayesStat(
     }
 
     override fun read(timestampNanos: Long): GaussianNaiveBayesResult = lock.guarded {
-        val meansFlat = DoubleArray(numClasses * featureSize) { meanCell.load(it) }
-        val varsFlat = DoubleArray(numClasses * featureSize) { idx ->
-            val c = idx / featureSize
+        val meansFlat = DoubleArray(numClasses * featureSize)
+        val varsFlat = DoubleArray(numClasses * featureSize)
+        for (c in 0 until numClasses) {
             val w = classWeightCell.load(c)
-            if (w > 0.0) m2Cell.load(idx) / w else 0.0
+            for (i in 0 until featureSize) {
+                val source = c * featureSize + i
+                val destination = c + i * numClasses
+                meansFlat[destination] = meanCell.load(source)
+                varsFlat[destination] = if (w > 0.0) m2Cell.load(source) / w else 0.0
+            }
         }
         val cw = DoubleArray(numClasses) { classWeightCell.load(it) }
         GaussianNaiveBayesResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            means = F64DenseMatrix.of(
-                Array(numClasses) { k -> meansFlat.copyOfRange(k * featureSize, (k + 1) * featureSize) },
-            ),
-            variances = F64DenseMatrix.of(
-                Array(numClasses) { k -> varsFlat.copyOfRange(k * featureSize, (k + 1) * featureSize) },
-            ),
-            classWeights = F64DenseVector.of(cw),
+            means = F64DenseMatrix.wrap(numClasses, featureSize, meansFlat),
+            variances = F64DenseMatrix.wrap(numClasses, featureSize, varsFlat),
+            classWeights = F64DenseVector.wrap(cw),
             totalWeights = totalWeightCell.load(),
             varianceFloor = varianceFloor,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -34,6 +34,12 @@ import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
 import kotlin.math.sqrt
 
+private fun F64MatrixLike.copyDenseMatrix(): F64DenseMatrix = F64DenseMatrix.wrap(
+    rows,
+    cols,
+    DoubleArray(rows * cols) { index -> this[index % rows, index / rows] },
+)
+
 /**
  * Bayesian generalised linear regression with a Gaussian prior on the weights and a
  * canonical [Link] for the response. Produces a full posterior covariance `S = H^-1`
@@ -111,7 +117,7 @@ class BayesianRegressionStat(
     // so a non-PD user prior throws at construction rather than silently corrupting fits.
     private val initialWeights: DoubleArray = priorMean?.toDoubleArray() ?: DoubleArray(featureSize)
     private val initialCovariance: F64DenseMatrix = priorCovariance
-        ?.let { F64DenseMatrix.of(it.toArray()) }
+        ?.copyDenseMatrix()
         ?: F64DenseMatrix.diagonal(featureSize, priorVariance)
     private val initialCovarianceL: F64DenseMatrix
 
@@ -125,12 +131,12 @@ class BayesianRegressionStat(
     }
 
     // priorInfo = H_prior * mu_prior, the natural-form contribution from the prior.
-    private val priorInfo: DoubleArray = (priorPrecisionMatrix * F64DenseVector.of(initialWeights)).toDoubleArray()
+    private val priorInfo: DoubleArray = (priorPrecisionMatrix * F64DenseVector.wrap(initialWeights)).toDoubleArray()
 
     private val lock = concurrency.serializedLock()
-    private val weights = F64DenseVector.of(initialWeights.copyOf())
-    private val covariance = F64DenseMatrix.of(initialCovariance.toArray())
-    private val covarianceL = F64DenseMatrix.of(initialCovarianceL.toArray())
+    private val weights = F64DenseVector.wrap(initialWeights.copyOf())
+    private val covariance = F64DenseMatrix.wrap(featureSize, featureSize, initialCovariance.data.copyOf())
+    private val covarianceL = F64DenseMatrix.wrap(featureSize, featureSize, initialCovarianceL.data.copyOf())
     private var bias: Double = 0.0
     private var biasPrecision: Double = 1.0 / priorVariance
     private var totalWeights: Double = 0.0
@@ -229,13 +235,13 @@ class BayesianRegressionStat(
 
     override fun read(timestampNanos: Long): CovarianceRegressionResult = lock.guarded {
         CovarianceRegressionResult(
-            weights = F64DenseVector.of(weights.toDoubleArray()),
+            weights = F64DenseVector.wrap(weights.data.copyOf()),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            covariance = F64DenseMatrix.of(covariance.toArray()),
-            covarianceL = F64DenseMatrix.of(covarianceL.toArray()),
+            covariance = F64DenseMatrix.wrap(featureSize, featureSize, covariance.data.copyOf()),
+            covarianceL = F64DenseMatrix.wrap(featureSize, featureSize, covarianceL.data.copyOf()),
             link = link,
             sse = sse,
         )
@@ -339,8 +345,8 @@ class BayesianRegressionStat(
         priorVariance = priorVariance,
         link = link,
         concurrency = concurrency ?: this.concurrency,
-        priorMean = F64DenseVector.of(initialWeights.copyOf()),
-        priorCovariance = F64DenseMatrix.of(initialCovariance.toArray()),
+        priorMean = F64DenseVector.wrap(initialWeights.copyOf()),
+        priorCovariance = F64DenseMatrix.wrap(featureSize, featureSize, initialCovariance.data.copyOf()),
     )
 
     /** Empirical-Bayes / hierarchical helpers that operate on populations of fitted snapshots. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -126,12 +126,12 @@ class DiagonalRegressionStat(
 
     override fun read(timestampNanos: Long): DiagonalRegressionResult = lock.guarded {
         DiagonalRegressionResult(
-            weights = F64DenseVector.of(weights),
+            weights = F64DenseVector.wrap(weights.copyOf()),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            precision = F64DenseVector.of(precision),
+            precision = F64DenseVector.wrap(precision.copyOf()),
             link = link,
             sse = sse,
         )
@@ -145,8 +145,6 @@ class DiagonalRegressionStat(
     override fun merge(values: DiagonalRegressionResult) {
         requireMergeFeatureSize(values.featureSize, featureSize)
         lock.guarded {
-            val otherWeights = values.weights.toDoubleArray()
-            val otherPrecision = values.precision.toDoubleArray()
             // Subtract one copy of the prior, as BayesianRegressionStat.merge does with
             // H_new = H_self + H_other - H_prior. Every replica seeds its precision at
             // priorPrecision, so pooling additively would count the prior once per replica and let an
@@ -154,10 +152,10 @@ class DiagonalRegressionStat(
             // contributes nothing to the information vector and only the denominator changes.
             for (i in 0 until featureSize) {
                 val p1 = precision[i]
-                val p2 = otherPrecision[i]
+                val p2 = values.precision[i]
                 val pNew = p1 + p2 - priorPrecision
                 if (pNew > 0.0) {
-                    weights[i] = (weights[i] * p1 + otherWeights[i] * p2) / pNew
+                    weights[i] = (weights[i] * p1 + values.weights[i] * p2) / pNew
                     precision[i] = pNew
                 }
             }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -232,7 +232,7 @@ class StochasticRegressionStat(
             }
         }
         StochasticRegressionResult(
-            weights = F64DenseVector.of(materialised),
+            weights = F64DenseVector.wrap(materialised),
             bias = biasCell.load(),
             totalWeights = totalWeightsCell.load(),
             step = stepCell.load(),
@@ -252,9 +252,8 @@ class StochasticRegressionStat(
             val w2 = values.totalWeights
             val wNew = w1 + w2
             if (wNew > 0.0) {
-                val other = values.weights.toDoubleArray()
                 for (i in 0 until featureSize) {
-                    val blended = (effectiveWeight(i) * w1 + other[i] * w2) / wNew
+                    val blended = (effectiveWeight(i) * w1 + values.weights[i] * w2) / wNew
                     weightsCell.store(i, blended)
                     l1LastApplied?.store(i, requireL1Pending().load())
                 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -132,6 +132,26 @@ class KnnContextualBanditTest {
     }
 
     @Test
+    fun `update retains an independent sparse snapshot including stored zeros`() {
+        val indices = intArrayOf(0, 2)
+        val values = doubleArrayOf(1.0, 0.0)
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, exploration = 0.0)
+        bandit.update(0, F64SparseVector.wrap(3, indices, values), 4.0)
+
+        indices[0] = 1
+        values[0] = 99.0
+        assertEquals(4.0, bandit.evaluate(0, feat(1.0, 0.0, 0.0)), 1e-12)
+    }
+
+    @Test
+    fun `update retains an empty sparse snapshot`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, exploration = 0.0)
+        bandit.update(0, F64SparseVector.wrap(3, IntArray(0), DoubleArray(0)), 4.0)
+
+        assertEquals(4.0, bandit.evaluate(0, feat(0.0, 0.0, 0.0)), 1e-12)
+    }
+
+    @Test
     fun `zero-weight update does not displace real history`() {
         val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 2, exploration = 0.0)
         val x = feat(0.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -21,6 +21,34 @@ class GaussianNaiveBayesStatTest {
     }
 
     @Test
+    fun `read owns matrix and vector storage independently from the stat`() {
+        val stat = GaussianNaiveBayesStat(featureSize = 1, numClasses = 2)
+        stat.update(doubleArrayOf(1.0), 0.0)
+        val first = stat.read()
+        val firstMean = first.means[0, 0]
+        val firstVariance = first.variances[0, 0]
+        val firstWeight = first.classWeights[0]
+
+        stat.update(doubleArrayOf(2.0), 0.0)
+        GaussianNaiveBayesStat(featureSize = 1, numClasses = 2).also {
+            it.update(doubleArrayOf(3.0), 0.0)
+            stat.merge(it.read())
+        }
+        stat.reset()
+        val second = stat.read()
+
+        assertEquals(firstMean, first.means[0, 0], DELTA)
+        assertEquals(firstVariance, first.variances[0, 0], DELTA)
+        assertEquals(firstWeight, first.classWeights[0], DELTA)
+        first.means.data[0] = 99.0
+        first.variances.data[0] = 99.0
+        first.classWeights.data[0] = 99.0
+        assertTrue(second.means[0, 0] != 99.0)
+        assertTrue(second.variances[0, 0] != 99.0)
+        assertTrue(second.classWeights[0] != 99.0)
+    }
+
+    @Test
     fun `per class means and variances match the running stats`() {
         val stat = GaussianNaiveBayesStat(featureSize = 2, numClasses = 2)
         // Class 0: feature 0 around 1.0, feature 1 around 5.0.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -18,6 +18,35 @@ class BayesianRegressionStatTest {
         override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
     }
 
+    @Test
+    fun `read owns vector and matrix storage independently from the stat`() {
+        val stat = BayesianRegressionStat(featureSize = 1)
+        stat.update(doubleArrayOf(1.0), 1.0)
+        val first = stat.read()
+        val firstWeight = first.weights[0]
+        val firstCovariance = first.covariance[0, 0]
+        val firstCovarianceL = first.covarianceL[0, 0]
+
+        stat.update(doubleArrayOf(1.0), -1.0)
+        BayesianRegressionStat(featureSize = 1).also {
+            it.update(doubleArrayOf(1.0), 1.0)
+            stat.merge(it.read())
+        }
+        stat.reset()
+        val second = stat.read()
+
+        assertEquals(firstWeight, first.weights[0], 1e-12)
+        assertEquals(firstCovariance, first.covariance[0, 0], 1e-12)
+        assertEquals(firstCovarianceL, first.covarianceL[0, 0], 1e-12)
+        assertEquals(0.0, second.weights[0], 1e-12)
+        first.weights.data[0] = 99.0
+        first.covariance.data[0] = 99.0
+        first.covarianceL.data[0] = 99.0
+        assertTrue(second.weights[0] != 99.0)
+        assertTrue(second.covariance[0, 0] != 99.0)
+        assertTrue(second.covarianceL[0, 0] != 99.0)
+    }
+
     // The factor is downdated alongside the covariance rather than refactorized, so the two can
     // only be trusted to agree if every downdate lands. L * LT has to stay equal to S. The
     // tolerance is relative because the covariance entries span many orders of magnitude across

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStatTest.kt
@@ -10,6 +10,31 @@ import kotlin.test.assertTrue
 class DiagonalRegressionStatTest {
 
     @Test
+    fun `read owns vectors independently from the stat and other snapshots`() {
+        val stat = DiagonalRegressionStat(featureSize = 1)
+        stat.update(doubleArrayOf(1.0), 1.0)
+        val first = stat.read()
+        val firstWeight = first.weights[0]
+        val firstPrecision = first.precision[0]
+        stat.update(doubleArrayOf(1.0), -1.0)
+        DiagonalRegressionStat(featureSize = 1).also {
+            it.update(doubleArrayOf(1.0), 1.0)
+            stat.merge(it.read())
+        }
+        stat.reset()
+        val second = stat.read()
+
+        assertEquals(firstWeight, first.weights[0], 1e-12)
+        assertEquals(firstPrecision, first.precision[0], 1e-12)
+        assertEquals(0.0, second.weights[0], 1e-12)
+        assertEquals(1.0, second.precision[0], 1e-12)
+        first.weights.data[0] = 99.0
+        first.precision.data[0] = 99.0
+        assertTrue(second.weights[0] != 99.0)
+        assertTrue(second.precision[0] != 99.0)
+    }
+
+    @Test
     fun `diagonal should recover ground truth weights with finite per-coefficient precision`() {
         val stat = DiagonalRegressionStat(featureSize = 3, priorPrecision = 0.01)
         val truth = doubleArrayOf(1.0, -1.5, 2.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -14,6 +14,26 @@ import kotlin.test.assertTrue
 class StochasticRegressionStatTest {
 
     @Test
+    fun `read owns weights independently from the stat and other snapshots`() {
+        val stat = StochasticRegressionStat(featureSize = 1, optimizer = Sgd(ConstantRate(0.1)))
+        stat.update(doubleArrayOf(1.0), 1.0)
+        val first = stat.read()
+        val firstWeight = first.weights[0]
+        stat.update(doubleArrayOf(1.0), -1.0)
+        StochasticRegressionStat(featureSize = 1, optimizer = Sgd(ConstantRate(0.1))).also {
+            it.update(doubleArrayOf(1.0), 1.0)
+            stat.merge(it.read())
+        }
+        stat.reset()
+        val second = stat.read()
+
+        assertEquals(firstWeight, first.weights[0], 1e-12)
+        assertEquals(0.0, second.weights[0], 1e-12)
+        first.weights.data[0] = 99.0
+        assertTrue(second.weights[0] != 99.0)
+    }
+
+    @Test
     fun `sgd should recover ground truth weights`() {
         val stat = StochasticRegressionStat(featureSize = 3, optimizer = Sgd(ConstantRate(0.05)))
         val truth = doubleArrayOf(1.5, -2.0, 0.5)

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
@@ -1,0 +1,90 @@
+package com.eignex.kumulant.stat.regression
+
+import com.eignex.koblas.core.F64SparseVector
+import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
+import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
+import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
+import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class OwnedStorageAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun interface Body {
+        fun run()
+    }
+
+    private fun bytesPerCall(body: Body): Double {
+        repeat(1_000) { body.run() }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            repeat(2_000) { body.run() }
+            val after = bean.getThreadAllocatedBytes(id)
+            best = minOf(best, (after - before).toDouble() / 2_000)
+        }
+        return best
+    }
+
+    @Test
+    fun `reads allocate only their retained snapshot storage`() {
+        val x = DoubleArray(32) { it.toDouble() }
+        val stochastic = StochasticRegressionStat(32).also { it.update(x, 1.0) }
+        val diagonal = DiagonalRegressionStat(32).also { it.update(x, 1.0) }
+        val bayesian = BayesianRegressionStat(32).also { it.update(x, 1.0) }
+        val naiveBayes = GaussianNaiveBayesStat(32, 4).also { it.update(x, 0.0) }
+
+        val stochasticBytes = bytesPerCall { stochastic.read() }
+        val diagonalBytes = bytesPerCall { diagonal.read() }
+        val bayesianBytes = bytesPerCall { bayesian.read() }
+        val naiveBayesBytes = bytesPerCall { naiveBayes.read() }
+
+        assertTrue(stochasticBytes < 400.0, "stochastic read allocated $stochasticBytes B/call")
+        assertTrue(diagonalBytes < 700.0, "diagonal read allocated $diagonalBytes B/call")
+        assertTrue(bayesianBytes < 17_000.0, "Bayesian read allocated $bayesianBytes B/call")
+        assertTrue(naiveBayesBytes < 2_500.0, "Gaussian NB read allocated $naiveBayesBytes B/call")
+    }
+
+    @Test
+    fun `regression merges avoid snapshot materialisation`() {
+        val x = DoubleArray(32) { it.toDouble() }
+        val stochastic = StochasticRegressionStat(32).also { it.update(x, 1.0) }
+        val diagonal = DiagonalRegressionStat(32).also { it.update(x, 1.0) }
+        val stochasticValue = stochastic.read()
+        val diagonalValue = diagonal.read()
+
+        val stochasticBytes = bytesPerCall { stochastic.merge(stochasticValue) }
+        val diagonalBytes = bytesPerCall { diagonal.merge(diagonalValue) }
+
+        assertTrue(stochasticBytes < 64.0, "stochastic merge allocated $stochasticBytes B/call")
+        assertTrue(diagonalBytes < 64.0, "diagonal merge allocated $diagonalBytes B/call")
+    }
+
+    @Test
+    fun `sparse updates retain nnz sized storage without feature sized scratch`() {
+        for (featureSize in intArrayOf(32, 128, 512)) {
+            for (density in intArrayOf(1, 10, 100)) {
+                val nnz = (featureSize * density / 100).coerceAtLeast(1)
+                val sparse = F64SparseVector.of(
+                    featureSize,
+                    IntArray(nnz) { it * featureSize / nnz },
+                    DoubleArray(nnz) { it.toDouble() },
+                )
+                val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 1, exploration = 0.0)
+                val allocatedBytes = bytesPerCall { bandit.update(0, sparse, 1.0) }
+                val retainedBytes = nnz * 12.0 + 128.0
+
+                assertTrue(
+                    allocatedBytes < retainedBytes + 256.0,
+                    "$featureSize features at $density% density allocated $allocatedBytes B/call; " +
+                        "retained storage is $retainedBytes B",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Transfer fresh regression snapshot buffers to KoBLAS with wrap instead of copying them again.
- Read merge snapshots through F64VectorLike indexing.
- Build Bayesian and Gaussian NB snapshots directly in owned column-major buffers.
- Retain k-NN sparse contexts with copied nnz-sized arrays instead of feature-width scratch.
- Add ownership, allocation, and JMH coverage.

## Why

Snapshots and retained contexts must stay independent from mutable stat and caller storage. These paths already establish fresh ownership, so wrapping removes redundant materialisation without weakening that boundary.

## Testing

./gradlew check lintDocs --rerun-tasks
./gradlew :kumulant:checkKotlinAbi :kumulant:checkLegacyAbi --rerun-tasks

OwnedStorageAllocationTest covers regression reads/merges and sparse k-NN updates at widths 32, 128, and 512 with 1%, 10%, and 100% density. JMH used JDK 25, the vector backend, 3 warmups x 1 s, 5 measurements x 1 s, and 1 fork: at width 32, Bayesian read improved from 86k to 354k ops/s and Gaussian NB read from 405k to 1.35M ops/s; sparse k-NN update at width 512/10% improved from 603k to 4.61M ops/s. Single-fork stochastic and diagonal read runs were noisy, so no throughput claim is made for them.