### PR TITLE
feat: optimize sparse vector reductions

### DIFF
--- a/kumulant-bench/build.gradle.kts
+++ b/kumulant-bench/build.gradle.kts
@@ -62,6 +62,14 @@ benchmark {
             iterationTime = 1
             iterationTimeUnit = "s"
         }
+        register("vectorReductions") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            include(".*VectorExprBenchmark.sum")
+            param("representation", "dense", "sparse")
+        }
     }
 }
 

--- a/kumulant-bench/build.gradle.kts
+++ b/kumulant-bench/build.gradle.kts
@@ -67,7 +67,7 @@ benchmark {
             iterations = 5
             iterationTime = 1
             iterationTimeUnit = "s"
-            include(".*VectorExprBenchmark.sum")
+            include(".*VectorExprBenchmark.(sum|mean|minimum|maximum|norm2|dot)")
             param("representation", "dense", "sparse")
         }
     }

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
@@ -5,9 +5,13 @@ import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64StridedVectorView
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.schema.expr.V
+import com.eignex.kumulant.schema.expr.ScalarExpr
+import com.eignex.kumulant.schema.expr.VFoldOp
 import com.eignex.kumulant.schema.expr.eval
 import com.eignex.kumulant.schema.expr.gt
 import com.eignex.kumulant.schema.expr.plus
+import com.eignex.kumulant.schema.expr.vDot
+import com.eignex.kumulant.schema.expr.vFold
 import com.eignex.kumulant.schema.expr.vectorOf
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.Param
@@ -30,6 +34,12 @@ open class VectorExprBenchmark {
     private val scalar = V(0) + V(1)
     private val predicate = V(0) gt 0.0
     private val vector = vectorOf(V(0), V(1))
+    private val sum = vFold(VFoldOp.Sum)
+    private val mean = vFold(VFoldOp.Mean)
+    private val minimum = vFold(VFoldOp.Min)
+    private val maximum = vFold(VFoldOp.Max)
+    private val norm2 = vFold(VFoldOp.Norm2)
+    private lateinit var dot: ScalarExpr
 
     @Setup
     fun setup() {
@@ -43,11 +53,18 @@ open class VectorExprBenchmark {
             "strided" -> F64StridedVectorView(DoubleArray(featureSize * 2) { values[it / 2] }, 0, featureSize, 2)
             else -> Vector(values)
         }
+        dot = vDot(List(featureSize) { if (it % 2 == 0) 1.0 else -1.0 })
     }
 
     @Benchmark fun scalar(): Double = scalar.eval(v = input)
     @Benchmark fun predicate(): Boolean = predicate.eval(v = input)
     @Benchmark fun vector(): DoubleArray = vector.eval(v = input)
+    @Benchmark fun sum(): Double = sum.eval(v = input)
+    @Benchmark fun mean(): Double = mean.eval(v = input)
+    @Benchmark fun minimum(): Double = minimum.eval(v = input)
+    @Benchmark fun maximum(): Double = maximum.eval(v = input)
+    @Benchmark fun norm2(): Double = norm2.eval(v = input)
+    @Benchmark fun dot(): Double = dot.eval(v = input)
     @Benchmark fun materializedScalar(): Double = scalar.eval(0.0, 0.0, input.toDoubleArray())
     @Benchmark fun materializedPredicate(): Boolean = predicate.eval(0.0, 0.0, input.toDoubleArray())
     @Benchmark fun materializedVector(): DoubleArray = vector.eval(0.0, 0.0, input.toDoubleArray())

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -848,7 +848,10 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
                 VFoldOp.Product -> Unit
             }
 
-            is VDot -> if (weights.all { it.isFinite() }) return sparseDot(v, weights)
+            is VDot -> {
+                require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
+                if (weights.all { it.isFinite() }) return sparseDot(v, weights)
+            }
 
             else -> Unit
         }
@@ -980,7 +983,6 @@ private fun sparseNorm2(v: F64SparseVector): Double {
 }
 
 private fun sparseDot(v: F64SparseVector, weights: List<Double>): Double {
-    require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
     var sum = 0.0
     v.forEachStored { index, value -> sum += weights[index] * value }
     return sum

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.schema.expr
 
+import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.HasCenterScale
@@ -902,7 +903,13 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
     }
 
     is VFold -> when (op) {
-        VFoldOp.Sum -> (0 until v.size).sumOf { v[it] }
+        VFoldOp.Sum -> if (v is F64SparseVector) {
+            var sum = 0.0
+            v.forEachStored { _, value -> sum += value }
+            sum
+        } else {
+            (0 until v.size).sumOf { v[it] }
+        }
 
         VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
 
@@ -910,34 +917,96 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
             require(
                 v.size != 0,
             ) { "VFold.Mean on empty vector" }
-            (0 until v.size).sumOf { v[it] } / v.size
+            if (v is F64SparseVector) {
+                var sum = 0.0
+                v.forEachStored { _, value -> sum += value }
+                sum / v.size
+            } else {
+                (0 until v.size).sumOf { v[it] } / v.size
+            }
         }
 
         VFoldOp.Min -> {
             require(
                 v.size != 0,
             ) { "VFold.Min on empty vector" }
-            var minimum = v[0]
-            for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
-            minimum
+            if (v is F64SparseVector) {
+                sparseMin(v)
+            } else {
+                var minimum = v[0]
+                for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
+                minimum
+            }
         }
 
         VFoldOp.Max -> {
             require(
                 v.size != 0,
             ) { "VFold.Max on empty vector" }
-            var maximum = v[0]
-            for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
-            maximum
+            if (v is F64SparseVector) {
+                sparseMax(v)
+            } else {
+                var maximum = v[0]
+                for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
+                maximum
+            }
         }
 
-        VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
+        VFoldOp.Norm2 -> if (v is F64SparseVector) {
+            var sum = 0.0
+            v.forEachStored { _, value -> sum += value * value }
+            sqrt(sum)
+        } else {
+            sqrt((0 until v.size).sumOf { v[it] * v[it] })
+        }
     }
 
     is VDot -> {
         require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
-        (0 until v.size).sumOf { weights[it] * v[it] }
+        if (v is F64SparseVector && weights.all { it.isFinite() }) {
+            var sum = 0.0
+            v.forEachStored { index, value -> sum += weights[index] * value }
+            sum
+        } else {
+            (0 until v.size).sumOf { weights[it] * v[it] }
+        }
     }
+}
+
+private fun sparseMin(v: F64SparseVector): Double {
+    var minimum = 0.0
+    var first = true
+    var next = 0
+    v.forEachStored { index, value ->
+        if (first) {
+            minimum = if (index == 0) value else 0.0
+            first = false
+        }
+        if (index > next && 0.0 < minimum) minimum = 0.0
+        if (index != 0 && value < minimum) minimum = value
+        next = index + 1
+    }
+    if (first) return 0.0
+    if (next < v.size && 0.0 < minimum) minimum = 0.0
+    return minimum
+}
+
+private fun sparseMax(v: F64SparseVector): Double {
+    var maximum = 0.0
+    var first = true
+    var next = 0
+    v.forEachStored { index, value ->
+        if (first) {
+            maximum = if (index == 0) value else 0.0
+            first = false
+        }
+        if (index > next && 0.0 > maximum) maximum = 0.0
+        if (index != 0 && value > maximum) maximum = value
+        next = index + 1
+    }
+    if (first) return 0.0
+    if (next < v.size && 0.0 > maximum) maximum = 0.0
+    return maximum
 }
 
 /** Evaluate this boolean expression against a borrowed KoBLAS vector without materialising it. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -836,7 +836,27 @@ sealed interface VectorExpr {
  * This overload is additive: [ScalarExpr.eval] with a [DoubleArray] remains the compatibility
  * surface for callers whose input is already dense.
  */
-fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): Double = when (this) {
+fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): Double {
+    if (v is F64SparseVector) {
+        when (this) {
+            is VFold -> when (op) {
+                VFoldOp.Sum -> return sparseSum(v)
+                VFoldOp.Mean -> return sparseMean(v)
+                VFoldOp.Min -> return sparseMin(v)
+                VFoldOp.Max -> return sparseMax(v)
+                VFoldOp.Norm2 -> return sparseNorm2(v)
+                VFoldOp.Product -> Unit
+            }
+
+            is VDot -> if (weights.all { it.isFinite() }) return sparseDot(v, weights)
+
+            else -> Unit
+        }
+    }
+    return evalVectorGeneric(x, y, v, primary)
+}
+
+private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike, primary: Result?): Double = when (this) {
     X -> x
 
     Y -> y
@@ -903,13 +923,7 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
     }
 
     is VFold -> when (op) {
-        VFoldOp.Sum -> if (v is F64SparseVector) {
-            var sum = 0.0
-            v.forEachStored { _, value -> sum += value }
-            sum
-        } else {
-            (0 until v.size).sumOf { v[it] }
-        }
+        VFoldOp.Sum -> (0 until v.size).sumOf { v[it] }
 
         VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
 
@@ -917,63 +931,62 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
             require(
                 v.size != 0,
             ) { "VFold.Mean on empty vector" }
-            if (v is F64SparseVector) {
-                var sum = 0.0
-                v.forEachStored { _, value -> sum += value }
-                sum / v.size
-            } else {
-                (0 until v.size).sumOf { v[it] } / v.size
-            }
+            (0 until v.size).sumOf { v[it] } / v.size
         }
 
         VFoldOp.Min -> {
             require(
                 v.size != 0,
             ) { "VFold.Min on empty vector" }
-            if (v is F64SparseVector) {
-                sparseMin(v)
-            } else {
-                var minimum = v[0]
-                for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
-                minimum
-            }
+            var minimum = v[0]
+            for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
+            minimum
         }
 
         VFoldOp.Max -> {
             require(
                 v.size != 0,
             ) { "VFold.Max on empty vector" }
-            if (v is F64SparseVector) {
-                sparseMax(v)
-            } else {
-                var maximum = v[0]
-                for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
-                maximum
-            }
+            var maximum = v[0]
+            for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
+            maximum
         }
 
-        VFoldOp.Norm2 -> if (v is F64SparseVector) {
-            var sum = 0.0
-            v.forEachStored { _, value -> sum += value * value }
-            sqrt(sum)
-        } else {
-            sqrt((0 until v.size).sumOf { v[it] * v[it] })
-        }
+        VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
     }
 
     is VDot -> {
         require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
-        if (v is F64SparseVector && weights.all { it.isFinite() }) {
-            var sum = 0.0
-            v.forEachStored { index, value -> sum += weights[index] * value }
-            sum
-        } else {
-            (0 until v.size).sumOf { weights[it] * v[it] }
-        }
+        (0 until v.size).sumOf { weights[it] * v[it] }
     }
 }
 
+private fun sparseSum(v: F64SparseVector): Double {
+    var sum = 0.0
+    v.forEachStored { _, value -> sum += value }
+    return sum
+}
+
+private fun sparseMean(v: F64SparseVector): Double {
+    require(v.size != 0) { "VFold.Mean on empty vector" }
+    return sparseSum(v) / v.size
+}
+
+private fun sparseNorm2(v: F64SparseVector): Double {
+    var sum = 0.0
+    v.forEachStored { _, value -> sum += value * value }
+    return sqrt(sum)
+}
+
+private fun sparseDot(v: F64SparseVector, weights: List<Double>): Double {
+    require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
+    var sum = 0.0
+    v.forEachStored { index, value -> sum += weights[index] * value }
+    return sum
+}
+
 private fun sparseMin(v: F64SparseVector): Double {
+    require(v.size != 0) { "VFold.Min on empty vector" }
     var minimum = 0.0
     var first = true
     var next = 0
@@ -992,6 +1005,7 @@ private fun sparseMin(v: F64SparseVector): Double {
 }
 
 private fun sparseMax(v: F64SparseVector): Double {
+    require(v.size != 0) { "VFold.Max on empty vector" }
     var maximum = 0.0
     var first = true
     var next = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -856,110 +856,111 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
     return evalVectorGeneric(x, y, v, primary)
 }
 
-private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike, primary: Result?): Double = when (this) {
-    X -> x
+private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike, primary: Result?): Double =
+    when (this) {
+        X -> x
 
-    Y -> y
+        Y -> y
 
-    Center -> primary.feedbackPrimary<HasCenterScale>("Center").center
+        Center -> primary.feedbackPrimary<HasCenterScale>("Center").center
 
-    Scale -> primary.feedbackPrimary<HasCenterScale>("Scale").scale
+        Scale -> primary.feedbackPrimary<HasCenterScale>("Scale").scale
 
-    Low -> primary.feedbackPrimary<HasMinMax>("Low").min
+        Low -> primary.feedbackPrimary<HasMinMax>("Low").min
 
-    High -> primary.feedbackPrimary<HasMinMax>("High").max
+        High -> primary.feedbackPrimary<HasMinMax>("High").max
 
-    VIndex -> {
-        check(
-            primary is IndexedResult,
-        ) { "VIndex requires an element-wise feedback context; got ${primary?.let { it::class.simpleName }}" }
-        primary.index.toDouble()
-    }
-
-    is V -> v[index]
-
-    is Const -> this.v
-
-    is Add -> l.eval(x, y, v, primary) + r.eval(x, y, v, primary)
-
-    is Sub -> l.eval(x, y, v, primary) - r.eval(x, y, v, primary)
-
-    is Mul -> l.eval(x, y, v, primary) * r.eval(x, y, v, primary)
-
-    is Div -> l.eval(x, y, v, primary) / r.eval(x, y, v, primary)
-
-    is Neg -> -a.eval(x, y, v, primary)
-
-    is Abs -> abs(a.eval(x, y, v, primary))
-
-    is Log -> ln(a.eval(x, y, v, primary))
-
-    is Exp -> exp(a.eval(x, y, v, primary))
-
-    is Sqrt -> sqrt(a.eval(x, y, v, primary))
-
-    is Pow -> a.eval(x, y, v, primary).pow(b.eval(x, y, v, primary))
-
-    is MinExpr -> min(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
-
-    is MaxExpr -> max(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
-
-    is IfExpr -> if (cond.eval(x, y, v, primary)) then.eval(x, y, v, primary) else otherwise.eval(x, y, v, primary)
-
-    is Switch -> {
-        val key = on.eval(x, y, v, primary)
-        cases.firstOrNull { it.value == key }?.then?.eval(x, y, v, primary) ?: otherwise.eval(x, y, v, primary)
-    }
-
-    Standardize -> {
-        val result = primary.feedbackPrimary<HasCenterScale>("Standardize")
-        if (result.scale > 0.0) (x - result.center) / result.scale else 0.0
-    }
-
-    is MinMax -> {
-        val result = primary.feedbackPrimary<HasMinMax>("MinMax")
-        val span = result.max - result.min
-        if (span > 0.0) targetLow + (x - result.min) / span * (targetHigh - targetLow) else targetLow
-    }
-
-    is VFold -> when (op) {
-        VFoldOp.Sum -> (0 until v.size).sumOf { v[it] }
-
-        VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
-
-        VFoldOp.Mean -> {
-            require(
-                v.size != 0,
-            ) { "VFold.Mean on empty vector" }
-            (0 until v.size).sumOf { v[it] } / v.size
+        VIndex -> {
+            check(
+                primary is IndexedResult,
+            ) { "VIndex requires an element-wise feedback context; got ${primary?.let { it::class.simpleName }}" }
+            primary.index.toDouble()
         }
 
-        VFoldOp.Min -> {
-            require(
-                v.size != 0,
-            ) { "VFold.Min on empty vector" }
-            var minimum = v[0]
-            for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
-            minimum
+        is V -> v[index]
+
+        is Const -> this.v
+
+        is Add -> l.eval(x, y, v, primary) + r.eval(x, y, v, primary)
+
+        is Sub -> l.eval(x, y, v, primary) - r.eval(x, y, v, primary)
+
+        is Mul -> l.eval(x, y, v, primary) * r.eval(x, y, v, primary)
+
+        is Div -> l.eval(x, y, v, primary) / r.eval(x, y, v, primary)
+
+        is Neg -> -a.eval(x, y, v, primary)
+
+        is Abs -> abs(a.eval(x, y, v, primary))
+
+        is Log -> ln(a.eval(x, y, v, primary))
+
+        is Exp -> exp(a.eval(x, y, v, primary))
+
+        is Sqrt -> sqrt(a.eval(x, y, v, primary))
+
+        is Pow -> a.eval(x, y, v, primary).pow(b.eval(x, y, v, primary))
+
+        is MinExpr -> min(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
+
+        is MaxExpr -> max(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
+
+        is IfExpr -> if (cond.eval(x, y, v, primary)) then.eval(x, y, v, primary) else otherwise.eval(x, y, v, primary)
+
+        is Switch -> {
+            val key = on.eval(x, y, v, primary)
+            cases.firstOrNull { it.value == key }?.then?.eval(x, y, v, primary) ?: otherwise.eval(x, y, v, primary)
         }
 
-        VFoldOp.Max -> {
-            require(
-                v.size != 0,
-            ) { "VFold.Max on empty vector" }
-            var maximum = v[0]
-            for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
-            maximum
+        Standardize -> {
+            val result = primary.feedbackPrimary<HasCenterScale>("Standardize")
+            if (result.scale > 0.0) (x - result.center) / result.scale else 0.0
         }
 
-        VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
-    }
+        is MinMax -> {
+            val result = primary.feedbackPrimary<HasMinMax>("MinMax")
+            val span = result.max - result.min
+            if (span > 0.0) targetLow + (x - result.min) / span * (targetHigh - targetLow) else targetLow
+        }
 
-    is VDot -> {
-        require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
-        (0 until v.size).sumOf { weights[it] * v[it] }
+        is VFold -> when (op) {
+            VFoldOp.Sum -> (0 until v.size).sumOf { v[it] }
+
+            VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
+
+            VFoldOp.Mean -> {
+                require(
+                    v.size != 0,
+                ) { "VFold.Mean on empty vector" }
+                (0 until v.size).sumOf { v[it] } / v.size
+            }
+
+            VFoldOp.Min -> {
+                require(
+                    v.size != 0,
+                ) { "VFold.Min on empty vector" }
+                var minimum = v[0]
+                for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
+                minimum
+            }
+
+            VFoldOp.Max -> {
+                require(
+                    v.size != 0,
+                ) { "VFold.Max on empty vector" }
+                var maximum = v[0]
+                for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
+                maximum
+            }
+
+            VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
+        }
+
+        is VDot -> {
+            require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
+            (0 until v.size).sumOf { weights[it] * v[it] }
+        }
     }
-}
 
 private fun sparseSum(v: F64SparseVector): Double {
     var sum = 0.0

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -487,6 +487,20 @@ class ExprTest {
         assertEquals(0.0, VDot(listOf(0.0, 0.0)).eval(v = sparse(doubleArrayOf(3.0, -4.0))))
     }
 
+    @Test fun `vector vdot validates sparse length before reading weights`() {
+        val weights = object : AbstractList<Double>() {
+            override val size: Int get() = 1
+            override fun get(index: Int): Double = error("VDot read a mismatched weight")
+            override fun iterator(): Iterator<Double> = error("VDot iterated mismatched weights")
+        }
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            VDot(weights).eval(v = sparse(doubleArrayOf(1.0, 2.0)))
+        }
+
+        assertEquals("VDot length mismatch: weights=1, v=2", error.message)
+    }
+
     @Test fun `vector aware in evaluates its operand once and matches double array equality`() {
         val empty = In(V(1), emptyList())
         assertFailsWith<IndexOutOfBoundsException> { empty.eval(v = NoMaterializeVector(doubleArrayOf(1.0))) }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -402,6 +402,91 @@ class ExprTest {
         assertFailsWith<IllegalArgumentException> { VFold(VFoldOp.Max).eval(v = input) }
     }
 
+    @Test fun `vector reductions match double arrays across storage representations`() {
+        val values = listOf(
+            doubleArrayOf(),
+            doubleArrayOf(-0.0),
+            doubleArrayOf(0.0, 3.0, -4.0, 0.0),
+            doubleArrayOf(Double.NaN, 0.0, 2.0),
+            doubleArrayOf(1.0, 0.0, Double.NaN, 2.0),
+            doubleArrayOf(0.0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
+            doubleArrayOf(-0.0, 0.0, Double.MAX_VALUE, Double.MIN_VALUE),
+        )
+        val folds = VFoldOp.entries.map(::VFold)
+
+        for (array in values) {
+            val representations = listOf<F64VectorLike>(
+                F64DenseVector.of(array),
+                sparse(array),
+                F64StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
+                NoMaterializeVector(array),
+            )
+            for (fold in folds) {
+                for (input in representations) {
+                    if (array.isEmpty() && fold.op in setOf(VFoldOp.Mean, VFoldOp.Min, VFoldOp.Max)) {
+                        assertFailsWith<IllegalArgumentException> { fold.eval(v = input) }
+                    } else {
+                        assertEquals(fold.eval(0.0, 0.0, array).toBits(), fold.eval(v = input).toBits())
+                    }
+                }
+            }
+        }
+    }
+
+    @Test fun `vector vdot matches double arrays for sparse edge cases`() {
+        val cases = listOf(
+            doubleArrayOf(),
+            doubleArrayOf(0.0),
+            doubleArrayOf(0.0, 2.0, -3.0, 0.0),
+            doubleArrayOf(Double.NaN, 0.0, 2.0),
+            doubleArrayOf(0.0, Double.POSITIVE_INFINITY, -0.0),
+            doubleArrayOf(Double.MAX_VALUE, Double.MIN_VALUE, 0.0),
+        )
+        val weightSets = listOf(
+            emptyList(),
+            listOf(0.0),
+            listOf(1.0, 0.0, -1.0, 2.0),
+            listOf(1.0, 0.0, -1.0),
+            listOf(0.0, 1.0, -1.0),
+            listOf(1.0, -1.0, 0.0),
+        )
+
+        for ((array, weights) in cases.zip(weightSets)) {
+            val expr = VDot(weights)
+            val expected = expr.eval(0.0, 0.0, array)
+            for (input in listOf<F64VectorLike>(
+                F64DenseVector.of(array),
+                sparse(array),
+                F64StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
+                NoMaterializeVector(array),
+            )) {
+                assertEquals(expected.toBits(), expr.eval(v = input).toBits())
+            }
+        }
+    }
+
+    @Test fun `vector reductions preserve explicit sparse zeroes`() {
+        val array = doubleArrayOf(2.0, 0.0, -3.0)
+        val input = F64SparseVector.of(3, intArrayOf(0, 1, 2), array)
+
+        for (op in VFoldOp.entries) {
+            val fold = VFold(op)
+            assertEquals(fold.eval(0.0, 0.0, array).toBits(), fold.eval(v = input).toBits())
+        }
+    }
+
+    @Test fun `vector vdot preserves non finite implicit zero behavior`() {
+        val values = doubleArrayOf(0.0, 2.0, 0.0)
+        val expr = VDot(listOf(Double.POSITIVE_INFINITY, 1.0, Double.NaN))
+
+        assertEquals(expr.eval(0.0, 0.0, values).toBits(), expr.eval(v = sparse(values)).toBits())
+    }
+
+    @Test fun `vector vdot preserves length mismatch and zero weights`() {
+        assertFailsWith<IllegalArgumentException> { VDot(listOf(1.0)).eval(v = sparse(doubleArrayOf(1.0, 2.0))) }
+        assertEquals(0.0, VDot(listOf(0.0, 0.0)).eval(v = sparse(doubleArrayOf(3.0, -4.0))))
+    }
+
     @Test fun `vector aware in evaluates its operand once and matches double array equality`() {
         val empty = In(V(1), emptyList())
         assertFailsWith<IndexOutOfBoundsException> { empty.eval(v = NoMaterializeVector(doubleArrayOf(1.0))) }
@@ -433,6 +518,14 @@ class ExprTest {
         assertFailsWith<IllegalArgumentException> {
             VDot(weights = listOf(1.0, 1.0)).eval(0.0, 0.0, doubleArrayOf(1.0, 2.0, 3.0))
         }
+    }
+
+    private fun sparse(values: DoubleArray): F64SparseVector {
+        val indices = values.indices.filter {
+            values[it] != 0.0 || values[it].toBits() == (-0.0).toBits() ||
+                values[it].isNaN()
+        }
+        return F64SparseVector.of(values.size, indices.toIntArray(), DoubleArray(indices.size) { values[indices[it]] })
     }
 
     @Test fun `foldPaired lifts series to paired with xy expression`() {


### PR DESCRIPTION
## What changed

- Adds sparse storage-aware evaluation paths for Sum, Mean, Min, Max, Norm2, and finite-weight VDot.
- Keeps Product and VDot with non-finite weights on the original logical-index scan.
- Restores the original generic evaluator for dense, strided, and custom vectors; sparse dispatch occurs before it.
- Adds exact-bit parity coverage and a dedicated full vector-reduction JMH configuration.

## Why

Sparse indexed reads are O(log nnz), making logical-index reduction scans expensive. Stored entries are traversed in ascending index order. Product remains a full scan because implicit-zero placement affects NaN, infinity, and signed-zero behavior. VDot falls back when a non-finite omitted weight could make an implicit zero term NaN. Workspace is not applicable because the paths retain scalar state only; allocation behavior was not measured.

## Testing

Ran `./gradlew :kumulant:jvmTest --tests com.eignex.kumulant.schema.ExprTest --rerun-tasks --no-daemon`, `./gradlew check lintDocs --rerun-tasks --no-daemon`, and `./gradlew :kumulant:checkKotlinAbi --no-daemon`.

JMH compared exact baseline `945a8b7` and corrected head `007f108` on JDK 25: one fork, 3 x 1s warmups, 5 x 1s measurements, sizes 8/32/128/512, densities 1/10/100%, and dense/sparse representations. At 512 features, sparse speedups were: Sum 235.81x / 320.66x / 23.45x; Mean 640.49x / 378.27x / 26.85x; Min 269.04x / 70.74x / 15.02x; Max 306.75x / 95.67x / 33.69x; Norm2 755.95x / 388.09x / 40.15x; VDot 6.56x / 14.58x / 10.92x, respectively at 1% / 10% / 100% stored density. Dense results had no regression: Sum was within measurement noise, and the remaining reductions were faster across the full matrix.