### PR TITLE
feat: add EXP4 distribution destination API

### DIFF
--- a/kumulant-bench/build.gradle.kts
+++ b/kumulant-bench/build.gradle.kts
@@ -70,6 +70,13 @@ benchmark {
             include(".*VectorExprBenchmark.(sum|mean|minimum|maximum|norm2|dot)")
             param("representation", "dense", "sparse")
         }
+        register("exp4Mixing") {
+            warmups = 3
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            include(".*Exp4MixingBenchmark.(playDistribution|playDistributionInto|choose|update)")
+        }
     }
 }
 

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Exp4MixingBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Exp4MixingBenchmark.kt
@@ -1,0 +1,54 @@
+package com.eignex.kumulant.bench
+
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.kumulant.bandit.contextual.Exp4Bandit
+import com.eignex.kumulant.bandit.contextual.Exp4Expert
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+
+@State(Scope.Benchmark)
+open class Exp4MixingBenchmark {
+
+    @Param("8x8", "32x32", "128x128", "512x512", "8x512", "512x8")
+    lateinit var shape: String
+
+    @Param("reusable", "allocating")
+    lateinit var advice: String
+
+    private lateinit var bandit: Exp4Bandit
+    private lateinit var x: F64DenseVector
+    private lateinit var out: DoubleArray
+    private var arm: Int = 0
+
+    @Setup
+    fun setup() {
+        val (experts, arms) = shape.split('x').map(String::toInt)
+        val values = Array(experts) { DoubleArray(arms) { 1.0 / arms } }
+        val expertPool = values.map { value ->
+            Exp4Expert { _, _ -> if (advice == "reusable") value else value.copyOf() }
+        }
+        bandit = Exp4Bandit(arms, expertPool, gamma = 0.1)
+        x = F64DenseVector.of(doubleArrayOf(1.0))
+        out = DoubleArray(arms)
+    }
+
+    @Benchmark
+    fun playDistribution(): DoubleArray = bandit.playDistribution(x)
+
+    @Benchmark
+    fun playDistributionInto() {
+        bandit.playDistributionInto(x, out)
+    }
+
+    @Benchmark
+    fun choose(): Int = bandit.choose(x)
+
+    @Benchmark
+    fun update() {
+        bandit.update(arm, x, reward = 0.0)
+        arm = (arm + 1) % bandit.nbrArms
+    }
+}

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -131,6 +131,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public fun merge (Lcom/eignex/kumulant/bandit/contextual/Exp4State;)V
 	public synthetic fun merge (Ljava/lang/Object;)V
 	public final fun playDistribution (Lcom/eignex/koblas/core/F64VectorLike;)[D
+	public final fun playDistributionInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
 	public fun reset ()V
 	public fun snapshot ()Lcom/eignex/kumulant/bandit/contextual/Exp4State;
 	public synthetic fun snapshot ()Ljava/lang/Object;

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -1207,6 +1207,7 @@ final class com.eignex.kumulant.bandit.contextual/Exp4Bandit : com.eignex.kumula
     final fun expertWeights(): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.expertWeights|expertWeights(){}[0]
     final fun merge(com.eignex.kumulant.bandit.contextual/Exp4State) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.merge|merge(com.eignex.kumulant.bandit.contextual.Exp4State){}[0]
     final fun playDistribution(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun playDistributionInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistributionInto|playDistributionInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/Exp4Bandit.reset|reset(){}[0]
     final fun snapshot(): com.eignex.kumulant.bandit.contextual/Exp4State // com.eignex.kumulant.bandit.contextual/Exp4Bandit.snapshot|snapshot(){}[0]
     final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -118,6 +118,7 @@ class Exp4Bandit(
 
     private val weights: DoubleArray = DoubleArray(experts.size) { 1.0 }
     private val lastAdvice: Array<DoubleArray> = Array(experts.size) { DoubleArray(nbrArms) }
+    private val lastDistribution = DoubleArray(nbrArms)
 
     // The probability each arm was last played with, and how many of its pulls are still awaiting
     // feedback. The importance weight has to divide by the probability in force when the arm was
@@ -128,20 +129,33 @@ class Exp4Bandit(
 
     /** Build the round's play distribution and sample an arm. */
     override fun choose(x: F64VectorLike): Int {
-        val p = playDistribution(x)
-        val chosen = random.sampleFromDistribution(p)
-        pendingPropensity[chosen] = p[chosen]
+        playDistributionInto(x, lastDistribution)
+        val chosen = random.sampleFromDistribution(lastDistribution)
+        pendingPropensity[chosen] = lastDistribution[chosen]
         pendingPulls[chosen]++
         return chosen
     }
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with
      *  uniform exploration via [gamma]. */
-    fun playDistribution(x: F64VectorLike): DoubleArray {
+    fun playDistribution(x: F64VectorLike): DoubleArray = DoubleArray(nbrArms).also {
+        playDistributionInto(x, it)
+    }
+
+    /**
+     * Writes the mean of the expert distributions at [x], weighted by current weights and blended
+     * with uniform exploration via [gamma], into [out]. [out] must have [nbrArms] entries and must
+     * not be returned by an [Exp4Expert] during this call.
+     *
+     * The destination is caller-owned. It is not retained after this method returns.
+     */
+    fun playDistributionInto(x: F64VectorLike, out: DoubleArray) {
+        require(out.size == nbrArms) { "out has ${out.size} probs, expected $nbrArms" }
         var wSum = 0.0
         for (i in experts.indices) {
             val xi = experts[i].advise(x, nbrArms)
             require(xi.size == nbrArms) { "expert $i returned ${xi.size} probs, expected $nbrArms" }
+            require(xi !== out) { "expert $i returned the play distribution destination" }
             lastAdvice[i] = xi
             wSum += weights[i]
         }
@@ -150,7 +164,6 @@ class Exp4Bandit(
         // "always the last arm". Fall back to the unweighted expert mean, which still uses the
         // advice even though the experts' relative standing has been lost.
         val usable = wSum > 0.0 && wSum.isFinite()
-        val out = DoubleArray(nbrArms)
         val uniform = gamma / nbrArms
         for (a in 0 until nbrArms) {
             var s = 0.0
@@ -160,7 +173,6 @@ class Exp4Bandit(
             }
             out[a] = (1.0 - gamma) * s + uniform
         }
-        return out
     }
 
     /** Fold a `(context, reward)` observation back into the expert weights. */
@@ -173,7 +185,7 @@ class Exp4Bandit(
         // See Stat.
         if (weight.isInertWeight()) return
         // Re-evaluate experts in case caller calls update without a prior choose at this x.
-        playDistribution(x)
+        playDistributionInto(x, lastDistribution)
         val pPlayed = propensityOf(armIndex, x).coerceAtLeast(MIN_PLAY_PROB)
         val gainPlayed = (reward * weight) / pPlayed
         for (i in experts.indices) {
@@ -190,7 +202,10 @@ class Exp4Bandit(
      * the best available estimate and what an off-policy caller implicitly asks for.
      */
     private fun propensityOf(armIndex: Int, x: F64VectorLike): Double {
-        if (pendingPulls[armIndex] <= 0) return playDistribution(x)[armIndex]
+        if (pendingPulls[armIndex] <= 0) {
+            playDistributionInto(x, lastDistribution)
+            return lastDistribution[armIndex]
+        }
         pendingPulls[armIndex]--
         return pendingPropensity[armIndex]
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+
 class Exp4BanditTest {
 
     @Test
@@ -25,6 +26,96 @@ class Exp4BanditTest {
         val bandit = Exp4Bandit(nbrArms = 3, experts = listOf(uniformExpert(3)), random = Random(0))
         val p = bandit.playDistribution(feat(0.0, 0.0))
         for (a in 0 until 3) assertTrue(abs(p[a] - 1.0 / 3) < 1e-9, "p[$a]=${p[a]}")
+    }
+
+    @Test
+    fun `playDistributionInto agrees with owned distribution and keeps its destination`() {
+        val bandit = Exp4Bandit(
+            nbrArms = 3,
+            experts = listOf(oneHotExpert(3, 0), oneHotExpert(3, 2)),
+            gamma = 0.2,
+        )
+        val out = DoubleArray(3)
+
+        bandit.playDistributionInto(feat(0.0), out)
+        val owned = bandit.playDistribution(feat(0.0))
+
+        assertEquals(owned.toList(), out.toList())
+        assertTrue(out !== owned)
+    }
+
+    @Test
+    fun `playDistributionInto validates its destination before consulting experts`() {
+        var calls = 0
+        val bandit = Exp4Bandit(
+            nbrArms = 2,
+            experts = listOf(
+                Exp4Expert { _, _ ->
+                    calls++
+                    doubleArrayOf(0.5, 0.5)
+                },
+            ),
+        )
+
+        assertFailsWith<IllegalArgumentException> { bandit.playDistributionInto(feat(0.0), DoubleArray(1)) }
+
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `playDistributionInto evaluates experts in order once and preserves shared advice`() {
+        val shared = doubleArrayOf(1.0, 0.0)
+        val calls = mutableListOf<Int>()
+        val experts = listOf(
+            Exp4Expert { _, _ ->
+                calls += 0
+                shared[0] = 1.0
+                shared[1] = 0.0
+                shared
+            },
+            Exp4Expert { _, _ ->
+                calls += 1
+                shared[0] = 0.0
+                shared[1] = 1.0
+                shared
+            },
+        )
+        val bandit = Exp4Bandit(nbrArms = 2, experts = experts, gamma = 0.0)
+        val out = DoubleArray(2)
+
+        bandit.playDistributionInto(feat(0.0), out)
+
+        assertEquals(listOf(0, 1), calls)
+        assertEquals(listOf(0.0, 1.0), out.toList())
+    }
+
+    @Test
+    fun `playDistributionInto preserves exceptional arithmetic`() {
+        val advice = arrayOf(
+            doubleArrayOf(Double.POSITIVE_INFINITY, -0.0),
+            doubleArrayOf(0.0, Double.NaN),
+        )
+        val allocating = Exp4Bandit(2, advice.map { values -> Exp4Expert { _, _ -> values } }, gamma = 1.0)
+        val destination = Exp4Bandit(2, advice.map { values -> Exp4Expert { _, _ -> values } }, gamma = 1.0)
+        val out = DoubleArray(2)
+
+        val expected = allocating.playDistribution(feat(0.0))
+        destination.playDistributionInto(feat(0.0), out)
+
+        for (i in out.indices) assertEquals(expected[i], out[i])
+    }
+
+    @Test
+    fun `choose consumes one draw and matches destination distribution away from a boundary`() {
+        val experts = listOf(oneHotExpert(2, 0), oneHotExpert(2, 0), oneHotExpert(2, 1))
+        val expected = Exp4Bandit(2, experts, gamma = 0.0, random = Random(17))
+        val actual = Exp4Bandit(2, experts, gamma = 0.0, random = Random(17))
+        val out = DoubleArray(2)
+
+        expected.playDistributionInto(feat(0.0), out)
+        val arm = actual.choose(feat(0.0))
+
+        assertEquals(if (Random(17).nextDouble() < out[0]) 0 else 1, arm)
     }
 
     @Test
@@ -122,6 +213,18 @@ class Exp4BanditTest {
         val before = bandit.expertWeights().toList()
         bandit.update(0, feat(0.0), 1.0, weight = 0.0)
         assertEquals(before, bandit.expertWeights().toList())
+    }
+
+    @Test
+    fun `inert update does not consume a pending propensity`() {
+        val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(oneHotExpert(2, 0), oneHotExpert(2, 1)), gamma = 0.2)
+        val x = feat(0.0)
+        val arm = bandit.choose(x)
+
+        bandit.update(arm, x, 1.0, weight = 0.0)
+        bandit.update(arm, x, 1.0)
+
+        assertTrue(bandit.expertWeights()[arm] > 0.5)
     }
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
@@ -1,0 +1,76 @@
+package com.eignex.kumulant.bandit.contextual
+
+import com.eignex.koblas.core.F64DenseVector
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class Exp4BanditAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun interface Body {
+        fun run()
+    }
+
+    private fun bytesPerCall(body: Body): Double {
+        repeat(1_000) { body.run() }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            repeat(2_000) { body.run() }
+            val after = bean.getThreadAllocatedBytes(id)
+            best = minOf(best, (after - before).toDouble() / 2_000)
+        }
+        return best
+    }
+
+    @Test
+    fun `destination distribution removes Kumulant output allocation with reusable advice`() {
+        val allocating = reusableBandit()
+        val destination = reusableBandit()
+        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        val out = DoubleArray(ARMS)
+
+        val allocatingBytes = bytesPerCall { allocating.playDistribution(x) }
+        val destinationBytes = bytesPerCall { destination.playDistributionInto(x, out) }
+
+        assertTrue(
+            destinationBytes + 128.0 <= allocatingBytes,
+            "destination distribution allocated $destinationBytes B/call versus $allocatingBytes B/call",
+        )
+    }
+
+    @Test
+    fun `choose and update retain their distribution storage with reusable advice`() {
+        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        val choosing = reusableBandit()
+        val updating = reusableBandit()
+        val arm = updating.choose(x)
+
+        val chooseBytes = bytesPerCall { choosing.choose(x) }
+        val updateBytes = bytesPerCall {
+            updating.update(arm, x, reward = 0.0)
+            updating.choose(x)
+        } / 2.0
+
+        assertTrue(chooseBytes < 128.0, "choose allocated $chooseBytes B/call")
+        assertTrue(updateBytes < 128.0, "update allocated $updateBytes B/call")
+    }
+
+    private fun reusableBandit(): Exp4Bandit {
+        val advice = Array(EXPERTS) { expert -> DoubleArray(ARMS) { arm -> (expert + arm + 1).toDouble() } }
+        return Exp4Bandit(
+            nbrArms = ARMS,
+            experts = advice.map { values -> Exp4Expert { _, _ -> values } },
+            gamma = 0.1,
+        )
+    }
+
+    private companion object {
+        const val EXPERTS = 8
+        const val ARMS = 32
+    }
+}


### PR DESCRIPTION
## What changed

- Added `Exp4Bandit.playDistributionInto(x, out)` and retained owned-output `playDistribution(x)`.
- Reused private distribution storage in `choose` and `update`; the storage is never exposed or retained from callers.
- Added EXP4 compatibility/allocation tests and an EXP4 JMH configuration.

## Why

The KoBLAS audit found that dense GEMV would require packing every callback result and use transpose scratch, while the existing loop preserves callback aliasing and IEEE arithmetic. It did not demonstrate a defensible improvement, so this partial change removes the Kumulant-controlled output allocation without adding Workspace or a GEMV route. Destination size is checked before expert callbacks; an expert returning the destination is rejected to avoid unsafe overlap.

Allocation on JVM with reusable advice: `playDistribution` 272 B/call; `playDistributionInto` 0 B/call; `choose` 0 B/call; update/choose cycle 0 B/call. Expert-created arrays are intentionally outside these figures.

JMH used JDK 25, resolved KoBLAS `0.1.1-SNAPSHOT:20260828.214842-126`, 3x1s warmups, 5x1s iterations, one fork, and square/tall/wide 8/32/128/512 shapes with reusable and allocating advice. Destination mixing has no output allocation; baseline and candidate legacy paths remained within the run-to-run variation at small shapes. No native-only result was used.

Deferred: dense F64DenseMatrix/GEMV packing, Workspace overloads, and choose/update Workspace overloads. The retained loop needs neither scratch nor Workspace, and packing would risk the existing shared/reused advice and exceptional arithmetic behavior.

## Testing

- `./gradlew :kumulant:jvmTest --tests com.eignex.kumulant.bandit.contextual.Exp4BanditTest --tests com.eignex.kumulant.bandit.contextual.Exp4BanditAllocationTest --no-daemon`
- Exact baseline JMH from `2e3d0896830fbdc545c17fafa6d83a6aa7ff1da2`, then `./gradlew :kumulant-bench:jvmExp4MixingBenchmark --no-daemon` on this branch.
- `./gradlew check lintDocs --rerun-tasks --no-daemon`

Residual risk: JMH variance is high for some large allocating-advice cells; the retained public optimization is accepted on measured allocation reduction, not a throughput claim.