### PR TITLE
perf: reuse Bayesian prior information storage

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -19,7 +19,6 @@ import com.eignex.koblas.dot
 import com.eignex.koblas.ger
 import com.eignex.koblas.koblas
 import com.eignex.koblas.scale
-import com.eignex.koblas.times
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
@@ -131,7 +130,9 @@ class BayesianRegressionStat(
     }
 
     // priorInfo = H_prior * mu_prior, the natural-form contribution from the prior.
-    private val priorInfo: DoubleArray = (priorPrecisionMatrix * F64DenseVector.wrap(initialWeights)).toDoubleArray()
+    private val priorInfo = DoubleArray(featureSize).also {
+        priorPrecisionMatrix.multiplyInto(F64DenseVector.wrap(initialWeights), it)
+    }
 
     private val lock = concurrency.serializedLock()
     private val weights = F64DenseVector.wrap(initialWeights.copyOf())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -149,6 +149,35 @@ class BayesianRegressionStatPriorTest {
     }
 
     @Test
+    fun `merging an empty custom prior state preserves the populated posterior`() {
+        val priorMean = F64DenseVector.of(doubleArrayOf(0.4, -0.7))
+        val priorCovariance = F64DenseMatrix.of(
+            arrayOf(
+                doubleArrayOf(0.8, 0.2),
+                doubleArrayOf(0.2, 0.6),
+            ),
+        )
+        fun fresh() = BayesianRegressionStat(
+            featureSize = 2,
+            priorMean = priorMean,
+            priorCovariance = priorCovariance,
+        )
+        val populated = fresh().also {
+            it.update(doubleArrayOf(1.0, -0.25), 0.5)
+            it.update(doubleArrayOf(-0.5, 1.0), -1.0)
+        }
+        val expected = populated.read()
+
+        populated.merge(fresh().read())
+
+        val actual = populated.read()
+        for (i in 0 until 2) {
+            assertEquals(expected.weights[i], actual.weights[i], 1e-12)
+            for (j in 0 until 2) assertEquals(expected.covariance[i, j], actual.covariance[i, j], 1e-12)
+        }
+    }
+
+    @Test
     fun `fitPopulationPrior returns the simple mean for identical posteriors`() {
         val mean = doubleArrayOf(1.0, -0.5)
         val cov = F64DenseMatrix.diagonal(2, 0.4)

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
@@ -1,0 +1,54 @@
+package com.eignex.kumulant.stat.regression.glm
+
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.times
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class BayesianPriorInfoAllocationTest {
+
+    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+    private fun interface Body {
+        fun run()
+    }
+
+    private fun bytesPerRun(body: Body): Double {
+        repeat(1_000) { body.run() }
+        val id = Thread.currentThread().threadId()
+        var best = Double.MAX_VALUE
+        repeat(5) {
+            val before = bean.getThreadAllocatedBytes(id)
+            repeat(2_000) { body.run() }
+            val after = bean.getThreadAllocatedBytes(id)
+            best = minOf(best, (after - before).toDouble() / 2_000)
+        }
+        return best
+    }
+
+    @Test
+    fun `destination prior information kernel avoids the materialized vector copy`() {
+        val size = 128
+        val precision = F64DenseMatrix.diagonal(size, 2.0)
+        val mean = F64DenseVector.of(DoubleArray(size) { it * 0.01 })
+        val destination = DoubleArray(size)
+        var sink = 0.0
+
+        val materializedBytes = bytesPerRun {
+            sink += (precision * mean).toDoubleArray()[0]
+        }
+        val destinationBytes = bytesPerRun {
+            precision.multiplyInto(mean, destination)
+            sink += destination[0]
+        }
+
+        assertTrue(sink.isFinite())
+        assertTrue(
+            destinationBytes + 1_024.0 <= materializedBytes,
+            "destination priorInfo allocated $destinationBytes B/run versus $materializedBytes B/run",
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- Computes the Bayesian prior natural-information vector directly into its final owned DoubleArray through the existing destination GEMV helper.
- Adds an exact custom-prior merge identity test.
- Adds a JVM allocation test comparing the destination prior-information kernel with the prior materialize-and-copy shape.

## Why

The priorInfo construction previously allocated a dense matrix-vector result and then copied it with toDoubleArray. The retained kernel writes directly into the owned field while keeping the same dense GEMV route and constructor validation order. The field owns its array; no Workspace is borrowed, retained, or exposed.

Retained candidate: priorInfo destination GEMV. Rejected/deferred candidates: merge H_new axpy/copy conversion and fitPopulationPrior axpy/ger/Workspace overload. Their existing loops define the grouped natural-parameter and within-plus-between covariance expressions; reassociation can alter NaN, infinity, signed-zero, or rounding behavior, and no independently measured benefit justified a compatibility path.

## Testing

Focused JVM tests: ./gradlew :kumulant:jvmTest --tests com.eignex.kumulant.stat.regression.glm.BayesianPriorInfoAllocationTest --tests com.eignex.kumulant.stat.regression.glm.BayesianRegressionStatPriorTest --tests com.eignex.kumulant.stat.regression.glm.BayesianWorkspaceAllocationTest --no-daemon.

Full gate: ./gradlew check lintDocs --rerun-tasks --no-daemon. This passed JVM and native tests, ABI validation, Detekt, Dokka lint, and documentation generation.

Allocation evidence: the focused ThreadMXBean test at 128 features requires the destination kernel to allocate at least 1,024 B/run less than materialize-and-toDoubleArray; it passed.

Baseline/final JMH command used Temurin 25.0.1, resolved KoBLAS 0.1.1-SNAPSHOT 20260828.214842-126/129, the routed JVM backend, 3 warmups, 5 one-second measurements, one fork, and sizes 8/32/128/512. It covered nonzero-prior construction plus merge and mergeWorkspace controls. Construction throughput remained within normal run variance; merge controls had no material reproducible regression. No population-prior benchmark applies because that API was deliberately unchanged.

Residual risk: destination GEMV retains the existing dense operand route. The new merge identity test confirms the nonzero natural prior correction remains effective; the broader prior tests and full gate cover the public regression behavior.