### PR TITLE
perf: hold each KnnContextualBandit arm history in a ring buffer

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -95,22 +95,24 @@ data class KnnArmResult(
  * **Arms:** contextual with caller-defined feature dimension; `nbrArms`
  * fixed at construction. Per-arm reservoir is bounded by [maxHistoryPerArm].
  *
- * **Memory:** O(nbrArms · maxHistoryPerArm · featureSize); bounded
- * per-arm history of context copies plus parallel reward/weight arrays.
+ * **Memory:** O(nbrArms · maxHistoryPerArm · featureSize); each arm owns a
+ * fixed-capacity ring of context copies plus parallel primitive reward and
+ * weight arrays. A dense slot's buffer is rewritten in place as the ring
+ * wraps, so a saturated arm stops allocating altogether.
  *
  * **Choose:** O(nbrArms · maxHistoryPerArm · (featureSize + k)); linear
  * scan over each arm's history with a bounded top-k heap.
  *
- * **Update:** O(featureSize); append context copy and roll the oldest
- * entry off when capped.
+ * **Update:** O(featureSize); copy the context into the ring's next slot and
+ * advance the head past the oldest entry when capped.
  *
  * **Randomness:** [random] is held for API uniformity but currently unused;
  * `choose` is deterministic, breaking ties by lowest arm index.
  *
- * **Concurrency:** not thread-safe; per-arm history mutable lists, the
+ * **Concurrency:** not thread-safe; the per-arm history rings, the
  * total-weight array, and the step counter are mutated without
- * synchronisation. Serialise `choose` and `update` externally for
- * multi-thread use.
+ * synchronisation, and an eviction rewrites a live context buffer in place.
+ * Serialise `choose` and `update` externally for multi-thread use.
  */
 class KnnContextualBandit(
     /** Number of arms. */
@@ -137,9 +139,7 @@ class KnnContextualBandit(
         require(exploration >= 0.0) { "exploration must be non-negative, got $exploration" }
     }
 
-    private val historyContexts: Array<MutableList<F64VectorStorage>> = Array(nbrArms) { mutableListOf() }
-    private val historyRewards: Array<MutableList<Double>> = Array(nbrArms) { mutableListOf() }
-    private val historyWeights: Array<MutableList<Double>> = Array(nbrArms) { mutableListOf() }
+    private val histories: Array<ArmHistory> = Array(nbrArms) { ArmHistory(maxHistoryPerArm) }
     private val totalWeights: DoubleArray = DoubleArray(nbrArms)
     private var step: Long = 0L
 
@@ -184,25 +184,15 @@ class KnnContextualBandit(
         // while two slots are spent. ReservoirHistogramStat guards the same way. See Stat.
         if (weight.isNotPositiveWeight()) return
         requireFeatureSize(x.size)
-        val ctxs = historyContexts[armIndex]
-        val rs = historyRewards[armIndex]
-        val ws = historyWeights[armIndex]
-        if (ctxs.size >= maxHistoryPerArm) {
-            val dropped = ws.removeAt(0)
-            ctxs.removeAt(0)
-            rs.removeAt(0)
-            totalWeights[armIndex] -= dropped
-        }
-        ctxs += copyOf(x)
-        rs += reward
-        ws += weight
+        val dropped = histories[armIndex].add(x, reward, weight)
+        totalWeights[armIndex] -= dropped
         totalWeights[armIndex] += weight
     }
 
     /** Live arm history size for [armIndex]. */
     fun historySize(armIndex: Int): Int {
         requireArmIndex(armIndex, nbrArms)
-        return historyContexts[armIndex].size
+        return histories[armIndex].size
     }
 
     /** Cumulative observation weight folded into arm [armIndex]. */
@@ -212,10 +202,11 @@ class KnnContextualBandit(
     }
 
     override fun snapshot(): List<KnnArmResult> = List(nbrArms) { a ->
+        val history = histories[a]
         KnnArmResult(
-            contexts = historyContexts[a].map { it.toDoubleArray() },
-            rewards = historyRewards[a].toDoubleArray(),
-            weights = historyWeights[a].toDoubleArray(),
+            contexts = List(history.size) { history.contextCopy(it) },
+            rewards = DoubleArray(history.size) { history.reward(it) },
+            weights = DoubleArray(history.size) { history.weight(it) },
             totalWeight = totalWeights[a],
         )
     }
@@ -233,9 +224,7 @@ class KnnContextualBandit(
     /** Clear every arm's history. */
     override fun reset() {
         for (a in 0 until nbrArms) {
-            historyContexts[a].clear()
-            historyRewards[a].clear()
-            historyWeights[a].clear()
+            histories[a].clear()
             totalWeights[a] = 0.0
         }
         step = 0L
@@ -255,8 +244,7 @@ class KnnContextualBandit(
     }
 
     private fun evaluateWithScratch(armIndex: Int, x: F64VectorLike, scratch: DoubleArray?): Double {
-        val ctx = historyContexts[armIndex]
-        if (ctx.size < k) return coldStartScore + ucbBonus(armIndex)
+        if (histories[armIndex].size < k) return coldStartScore + ucbBonus(armIndex)
         val mean = if (scratch == null) knnMean(armIndex, x) else knnMean(armIndex, x, scratch)
         return mean + ucbBonus(armIndex)
     }
@@ -267,21 +255,20 @@ class KnnContextualBandit(
     }
 
     private fun knnMean(armIndex: Int, x: F64VectorLike, scratch: DoubleArray): Double {
-        val ctxs = historyContexts[armIndex]
-        val rs = historyRewards[armIndex]
-        val ws = historyWeights[armIndex]
+        val history = histories[armIndex]
         // Linear scan, bounded heap of size k. For typical maxHistoryPerArm values
         // (<= a few thousand) this is faster than maintaining a KD-tree under reweights.
         for (i in 0 until k) scratch[i] = Double.POSITIVE_INFINITY
-        for (i in ctxs.indices) {
-            val d = distance(ctxs[i], x)
+        // Oldest first, so equal distances resolve to the same neighbour the arrival order picks.
+        for (i in 0 until history.size) {
+            val d = distance(history.context(i), x)
             // Find insertion point: index of the max in topD.
             var worst = 0
             for (j in 1 until k) if (scratch[j] > scratch[worst]) worst = j
             if (d < scratch[worst]) {
                 scratch[worst] = d
-                scratch[k + worst] = rs[i]
-                scratch[2 * k + worst] = ws[i]
+                scratch[k + worst] = history.reward(i)
+                scratch[2 * k + worst] = history.weight(i)
             }
         }
         var sumW = 0.0
@@ -367,14 +354,79 @@ class KnnContextualBandit(
             return s
         }
     }
+}
 
-    private fun copyOf(x: F64VectorLike): F64VectorStorage = when (x) {
-        is F64DenseVector -> F64DenseVector.wrap(x.toDoubleArray())
+// Fixed-capacity FIFO of (context, reward, weight) samples for one arm, addressed by age with 0 the
+// oldest live sample. Rewards and weights sit in DoubleArrays so a sample costs no boxing, and
+// eviction advances the head onto the slot it overwrites, so a full arm admits a sample in O(width)
+// rather than shifting the whole history.
+//
+// Contexts stay in koblas storages rather than one flat buffer because koblas has no dense vector
+// over an (array, offset, length) slice: a window type declared here would be a third implementation
+// of F64VectorLike, which drops the scan out of squaredL2's dense/dense branch onto its generic one
+// and costs more per choose than the flat layout saves per update.
+private class ArmHistory(private val capacity: Int) {
+    var size: Int = 0
+        private set
 
-        is F64SparseVector -> {
-            F64SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
+    private val rewards = DoubleArray(capacity)
+    private val weights = DoubleArray(capacity)
+    private val contexts = arrayOfNulls<F64VectorStorage>(capacity)
+
+    private var head = 0
+
+    fun reward(age: Int): Double = rewards[slotOf(age)]
+
+    fun weight(age: Int): Double = weights[slotOf(age)]
+
+    /** The stored context at [age], oldest first. */
+    fun context(age: Int): F64VectorLike = contexts[slotOf(age)]!!
+
+    /** The stored context at [age], densified into an array that outlives the slot. */
+    fun contextCopy(age: Int): DoubleArray = contexts[slotOf(age)]!!.toDoubleArray()
+
+    /** Admits `(x, reward, weight)` and returns the weight of the sample it evicted, `0.0` if none. */
+    fun add(x: F64VectorLike, reward: Double, weight: Double): Double {
+        val slot: Int
+        var dropped = 0.0
+        if (size == capacity) {
+            dropped = weights[head]
+            slot = head
+            head = if (head + 1 == capacity) 0 else head + 1
+        } else {
+            slot = slotOf(size)
+            size++
         }
-
-        else -> F64DenseVector.wrap(x.toDoubleArray())
+        rewards[slot] = reward
+        weights[slot] = weight
+        contexts[slot] = retain(contexts[slot], x)
+        return dropped
     }
+
+    fun clear() {
+        size = 0
+        head = 0
+        contexts.fill(null)
+    }
+
+    private fun slotOf(age: Int): Int {
+        val raw = head + age
+        return if (raw >= capacity) raw - capacity else raw
+    }
+}
+
+// The copy of x an arm keeps, reusing the dense buffer already in the slot when the widths agree so a
+// saturated arm evicts without allocating. A sparse sample always takes a fresh copy: its stored
+// length tracks the sample rather than the feature width, and the caller keeps arrays it may mutate.
+private fun retain(slot: F64VectorStorage?, x: F64VectorLike): F64VectorStorage {
+    if (x is F64SparseVector) return F64SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
+    if (slot is F64DenseVector && slot.size == x.size) {
+        if (x is F64DenseVector) {
+            x.data.copyInto(slot.data)
+        } else {
+            for (i in 0 until x.size) slot.data[i] = x[i]
+        }
+        return slot
+    }
+    return F64DenseVector.wrap(x.toDoubleArray())
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -7,6 +7,7 @@ import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squar
 import com.eignex.kumulant.feat
 import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -63,6 +64,60 @@ class KnnContextualBanditTest {
         // Latest x=9 dominates; querying near 9 should return the recent reward.
         val s = bandit.evaluate(0, feat(9.0))
         assertTrue(s in 6.5..9.5, "expected score near recent rewards 7/8/9, got $s")
+    }
+
+    @Test
+    fun `snapshot lists the surviving history oldest first after the ring wraps`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 3, exploration = 0.0)
+        repeat(5) { bandit.update(0, feat(it.toDouble()), it.toDouble()) }
+
+        val arm = bandit.snapshot()[0]
+
+        assertContentEquals(listOf(2.0, 3.0, 4.0), arm.contexts.map { it.single() })
+        assertContentEquals(doubleArrayOf(2.0, 3.0, 4.0), arm.rewards)
+        assertContentEquals(doubleArrayOf(1.0, 1.0, 1.0), arm.weights)
+        assertEquals(3.0, arm.totalWeight, 1e-9)
+    }
+
+    @Test
+    fun `evaluate scores a wrapped history from the survivors alone`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 3, exploration = 0.0)
+        repeat(5) { bandit.update(0, feat(it.toDouble()), it.toDouble()) }
+
+        assertEquals(2.0, bandit.evaluate(0, feat(2.0)), 1e-12)
+        assertEquals(4.0, bandit.evaluate(0, feat(4.0)), 1e-12)
+        // x=0 was evicted, so the nearest neighbour of x=0 is the oldest survivor.
+        assertEquals(2.0, bandit.evaluate(0, feat(0.0)), 1e-12)
+    }
+
+    @Test
+    fun `merge appends foreign samples and trims the oldest across a wrap`() {
+        val local = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 4, exploration = 0.0)
+        val foreign = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 4, exploration = 0.0)
+        local.update(0, feat(0.0), 0.0)
+        local.update(0, feat(1.0), 1.0)
+        for (i in 2..4) foreign.update(0, feat(i.toDouble()), i.toDouble())
+
+        local.merge(foreign.snapshot())
+
+        val arm = local.snapshot()[0]
+        assertContentEquals(listOf(1.0, 2.0, 3.0, 4.0), arm.contexts.map { it.single() })
+        assertContentEquals(doubleArrayOf(1.0, 2.0, 3.0, 4.0), arm.rewards)
+        assertEquals(4.0, arm.totalWeight, 1e-9)
+    }
+
+    @Test
+    fun `a wrapped history keeps dense and sparse slots apart as they overwrite each other`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 2, exploration = 0.0)
+        bandit.update(0, feat(1.0, 0.0), 1.0)
+        bandit.update(0, feat(0.0, 2.0), 2.0)
+        bandit.update(0, F64SparseVector.of(2, intArrayOf(1), doubleArrayOf(3.0)), 3.0)
+        bandit.update(0, feat(4.0, 0.0), 4.0)
+
+        val contexts = bandit.snapshot()[0].contexts
+
+        assertContentEquals(doubleArrayOf(0.0, 3.0), contexts[0])
+        assertContentEquals(doubleArrayOf(4.0, 0.0), contexts[1])
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Each `KnnContextualBandit` arm holds one fixed-capacity ring buffer instead of three parallel `MutableList`s.
- Rewards and weights live in `DoubleArray`s, so a sample no longer boxes two `Double`s.
- Eviction advances a head index onto the slot it overwrites, replacing `removeAt(0)` on three lists.
- A dense context is copied into the buffer the evicted slot already owns, so a saturated arm admits a sample without allocating.
- The `Memory`, `Update`, and `Concurrency` KDoc clauses now describe the ring rather than the lists.
- New tests cover the wrap: snapshot age order, scoring a wrapped history, merge trimming across a wrap, and dense and sparse slots overwriting each other.

## Why

The per-arm history is already a bounded FIFO, but `removeAt(0)` shifted the whole history on every insert once an arm filled, so steady-state insertion was O(history) while the `Update` clause claimed O(featureSize). The parallel `MutableList<Double>`s boxed every reward and weight, and every sample allocated a fresh context copy even when the slot it replaced already owned a buffer of the right width.

Nothing the bandit exposes changes. Eviction order, the age order of the snapshot's `contexts`, `rewards`, and `weights` arrays, `historySize`, the total-weight bookkeeping, and the guards that keep an inert or negative-weight observation from spending a slot all behave as before. The scan still visits samples oldest first, so equal distances resolve to the same neighbour arrival order picked.

Contexts stay in koblas storages rather than one flat `DoubleArray` per arm. koblas has no dense vector over an `(array, offset, length)` slice, so a flat layout needs a window type declared here, and that window becomes a third `F64VectorLike` implementation which drops the scan out of `squaredL2`'s dense/dense branch onto its generic one. A first attempt did exactly that and roughly doubled `choose`, so the slots keep their storages and reuse the dense buffer instead. Sparse contexts also keep their own storage, which preserves both the memory a sparse caller pays for and the `squaredL2` branch a sparse sample selects.

## Testing

`./gradlew check lintDocs --rerun-tasks`.

`KnnContextualBanditTest` and `KnnContextDimensionTest` pass unchanged, including the three tests that assert sparse retention. An ad-hoc JVM probe, not a `:kumulant-bench` suite, put steady-state `update` at 0 bytes per call against 336 before, and flat in capacity at 46 ns per call at `maxHistoryPerArm` 256 and 54 ns at 4096, where the list version scaled 100 ns to 792 ns over the same range.
