### PR TITLE
perf: hold the knn scan buffer on the bandit and carry the displaced slot

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -1,7 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.borrow
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
@@ -98,10 +97,14 @@ data class KnnArmResult(
  * **Memory:** O(nbrArms · maxHistoryPerArm · featureSize); each arm owns a
  * fixed-capacity ring of context copies plus parallel primitive reward and
  * weight arrays. A dense slot's buffer is rewritten in place as the ring
- * wraps, so a saturated arm stops allocating altogether.
+ * wraps, so a saturated arm stops allocating altogether. One `3 · k` scan
+ * buffer is owned by the bandit and reused across every call.
  *
- * **Choose:** O(nbrArms · maxHistoryPerArm · (featureSize + k)); linear
- * scan over each arm's history with a bounded top-k heap.
+ * **Choose:** O(nbrArms · maxHistoryPerArm · featureSize), plus O(k) for each
+ * candidate that displaces one of the k nearest; a candidate that does not is
+ * rejected on a single comparison. Contexts arriving in descending distance
+ * order displace on every step and reach O(nbrArms · maxHistoryPerArm · k) for
+ * the selection term.
  *
  * **Update:** O(featureSize); copy the context into the ring's next slot and
  * advance the head past the oldest entry when capped.
@@ -110,9 +113,11 @@ data class KnnArmResult(
  * `choose` is deterministic, breaking ties by lowest arm index.
  *
  * **Concurrency:** not thread-safe; the per-arm history rings, the
- * total-weight array, and the step counter are mutated without
- * synchronisation, and an eviction rewrites a live context buffer in place.
- * Serialise `choose` and `update` externally for multi-thread use.
+ * total-weight array, the step counter, and one shared scan buffer are mutated
+ * without synchronisation, and an eviction rewrites a live context buffer in
+ * place. Serialise `choose` and `update` externally for multi-thread use. The
+ * shared buffer also rules out re-entrant scoring, so [distance] must not call
+ * back into `choose` or `evaluate`.
  */
 class KnnContextualBandit(
     /** Number of arms. */
@@ -143,6 +148,14 @@ class KnnContextualBandit(
     private val totalWeights: DoubleArray = DoubleArray(nbrArms)
     private var step: Long = 0L
 
+    // One scan buffer for the life of the bandit: k distances, then the k rewards, then the k
+    // weights that go with them. The class already asks callers to serialise `choose` and `update`,
+    // so the buffer can be owned outright rather than borrowed per call, which is what makes scoring
+    // allocation-free with no workspace to hand. The cost is that scoring is not re-entrant: a
+    // [distance] that called back into `choose` or `evaluate` would scan into the buffer its own
+    // caller is still reading.
+    private val scratch: DoubleArray = DoubleArray(3 * k)
+
     // Width of the contexts this bandit has been shown, learned from the first one. Without it the
     // only check is the one inside the distance kernel, which does not run until an arm holds k
     // contexts - so a mis-sized context is accepted, and the first call to throw is a later choose
@@ -158,21 +171,30 @@ class KnnContextualBandit(
         require(size == featureSize) { "context size $size != $featureSize" }
     }
 
-    /** Argmax over per-arm [evaluate] scores. Ties broken by lowest index. */
+    /**
+     * Argmax over per-arm [evaluate] scores. Ties broken by lowest index.
+     *
+     * [workspace] is accepted for interface uniformity and ignored; the scan buffer is owned, so
+     * there is no scratch left to borrow.
+     */
+    @Suppress("UnusedParameter")
     override fun choose(x: F64VectorLike, workspace: Workspace?): Int {
         requireFeatureSize(x.size)
-        val bestIdx = workspace.borrow(3 * k) { scratch ->
-            argmaxArm(nbrArms) { armIndex -> evaluateWithScratch(armIndex, x, scratch) }
-        }
+        val bestIdx = argmaxArm(nbrArms) { armIndex -> score(armIndex, x) }
         step++
         return bestIdx
     }
 
-    /** Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus. */
+    /**
+     * Score arm [armIndex] at context [x]: k-NN mean reward + UCB bonus.
+     *
+     * [workspace] is accepted for interface uniformity and ignored, as in [choose].
+     */
+    @Suppress("UnusedParameter")
     override fun evaluate(armIndex: Int, x: F64VectorLike, workspace: Workspace?): Double {
         requireArmIndex(armIndex, nbrArms)
         requireFeatureSize(x.size)
-        return workspace.borrow(3 * k) { scratch -> evaluateWithScratch(armIndex, x, scratch) }
+        return score(armIndex, x)
     }
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
@@ -243,32 +265,39 @@ class KnnContextualBandit(
         return exploration * sqrt(ln(t) / w)
     }
 
-    private fun evaluateWithScratch(armIndex: Int, x: F64VectorLike, scratch: DoubleArray?): Double {
+    private fun score(armIndex: Int, x: F64VectorLike): Double {
         if (histories[armIndex].size < k) return coldStartScore + ucbBonus(armIndex)
-        val mean = if (scratch == null) knnMean(armIndex, x) else knnMean(armIndex, x, scratch)
-        return mean + ucbBonus(armIndex)
+        return knnMean(armIndex, x) + ucbBonus(armIndex)
     }
 
     private fun knnMean(armIndex: Int, x: F64VectorLike): Double {
-        val scratch = DoubleArray(3 * k)
-        return knnMean(armIndex, x, scratch)
-    }
-
-    private fun knnMean(armIndex: Int, x: F64VectorLike, scratch: DoubleArray): Double {
         val history = histories[armIndex]
-        // Linear scan, bounded heap of size k. For typical maxHistoryPerArm values
+        // Linear scan holding the k nearest seen so far. For typical maxHistoryPerArm values
         // (<= a few thousand) this is faster than maintaining a KD-tree under reweights.
+        // Distances alone are reset: a reward or weight slot is read only where its distance is
+        // finite, so whatever the previous arm left in the other two thirds is unreachable.
         for (i in 0 until k) scratch[i] = Double.POSITIVE_INFINITY
+        // The slot the next admission displaces, carried rather than rescanned for. Rescanning ran
+        // k comparisons for every candidate, admitted or not; carrying it costs one comparison to
+        // reject, and past the first k arrivals nearly every candidate is rejected.
+        var worst = 0
+        var worstDistance = Double.POSITIVE_INFINITY
         // Oldest first, so equal distances resolve to the same neighbour the arrival order picks.
         for (i in 0 until history.size) {
             val d = distance(history.context(i), x)
-            // Find insertion point: index of the max in topD.
-            var worst = 0
-            for (j in 1 until k) if (scratch[j] > scratch[worst]) worst = j
-            if (d < scratch[worst]) {
+            // Stated positively so a NaN distance is rejected: negating the test would admit it.
+            if (d < worstDistance) {
                 scratch[worst] = d
                 scratch[k + worst] = history.reward(i)
                 scratch[2 * k + worst] = history.weight(i)
+                worst = 0
+                worstDistance = scratch[0]
+                for (j in 1 until k) {
+                    if (scratch[j] > worstDistance) {
+                        worst = j
+                        worstDistance = scratch[j]
+                    }
+                }
             }
         }
         var sumW = 0.0

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -245,18 +245,42 @@ class KnnContextualBanditTest {
     }
 
     @Test
-    fun `workspace borrow releases after a distance exception`() {
+    fun `a failed distance leaves the scan buffer usable for the next call`() {
+        var failing = true
         val bandit = KnnContextualBandit(
             nbrArms = 1,
             k = 1,
             exploration = 0.0,
-            distance = { _, _ -> error("distance failed") },
+            distance = { a, b -> if (failing) error("distance failed") else squaredL2(a, b) },
         )
-        bandit.update(0, feat(1.0), 1.0)
-        val workspace = Workspace().apply { reserve(3, 1) }
+        bandit.update(0, feat(1.0), 4.0)
 
-        assertFailsWith<IllegalStateException> { bandit.evaluate(0, feat(1.0), workspace) }
-        assertFailsWith<IllegalStateException> { bandit.evaluate(0, feat(1.0), workspace) }
+        assertFailsWith<IllegalStateException> { bandit.evaluate(0, feat(1.0)) }
+        failing = false
+
+        assertEquals(4.0, bandit.evaluate(0, feat(1.0)), 1e-12)
+    }
+
+    @Test
+    fun `the k nearest are the same whatever order the contexts arrive in`() {
+        // Contexts sit at 1..6 from the query, so the three nearest carry rewards 1, 2 and 3 and
+        // average 2.0. Ascending admits each candidate once and then rejects; descending displaces
+        // on every step, which is the order that exercises the rescan hardest.
+        val ascending = listOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        for (order in listOf(ascending, ascending.reversed(), listOf(4.0, 1.0, 6.0, 2.0, 5.0, 3.0))) {
+            val bandit = KnnContextualBandit(nbrArms = 1, k = 3, exploration = 0.0)
+            for (d in order) bandit.update(0, feat(d), d)
+            assertEquals(2.0, bandit.evaluate(0, feat(0.0)), 1e-12, "arrival order $order")
+        }
+    }
+
+    @Test
+    fun `equal distances keep the neighbour that arrived first`() {
+        val bandit = KnnContextualBandit(nbrArms = 1, k = 1, exploration = 0.0)
+        bandit.update(0, feat(1.0), 10.0)
+        bandit.update(0, feat(1.0), 20.0)
+
+        assertEquals(10.0, bandit.evaluate(0, feat(1.0)), 1e-12)
     }
 }
 

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
@@ -45,19 +45,19 @@ class KnnWorkspaceAllocationTest {
     }
 
     @Test
-    fun `reserved workspace removes repeated k nearest neighbour scratch allocation`() {
-        val allocating = populatedBandit()
+    fun `k nearest neighbour scoring allocates nothing with or without a workspace`() {
+        val bare = populatedBandit()
         val reused = populatedBandit()
         val x = F64DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
         val workspace = Workspace().apply { reserve(3 * K, 1) }
 
-        val allocatedBytes = bytesPerCall { allocating.choose(x) }
+        val bareBytes = bytesPerCall { bare.choose(x) }
         val workspaceBytes = bytesPerCall { reused.choose(x, workspace) }
 
-        assertTrue(
-            workspaceBytes + 128.0 <= allocatedBytes,
-            "workspace choose allocated $workspaceBytes B/call versus $allocatedBytes B/call",
-        )
+        // The scan buffer is owned by the bandit, so there is nothing left for a workspace to save
+        // and nothing left to allocate when one is absent.
+        assertTrue(bareBytes <= CEILING, "choose allocated $bareBytes B/call without a workspace")
+        assertTrue(workspaceBytes <= CEILING, "choose allocated $workspaceBytes B/call with a workspace")
     }
 
     private companion object {
@@ -65,5 +65,8 @@ class KnnWorkspaceAllocationTest {
         const val K = 8
         const val HISTORY = 32
         const val FEATURES = 32
+
+        /** Slack for sampling noise in the allocation counter; a real per-call buffer is 3 * K * 8 B. */
+        const val CEILING = 8.0
     }
 }


### PR DESCRIPTION
## What changed

- `KnnContextualBandit` owns one `3 * k` scan buffer for its lifetime instead of borrowing one per `choose` and `evaluate`.
- The top-k scan carries the slot it would displace next, rather than rescanning all k slots for it on every candidate.
- `choose` and `evaluate` ignore the `workspace` parameter. It stays in the signature because the interfaces declare it.
- The allocating `knnMean` overload and the nullable scratch parameter are gone. Nothing reached them.
- The Memory, Choose and Concurrency KDoc clauses describe the owned buffer, the new selection cost, and the re-entrancy it rules out.

## Why

Both halves of the scan were paying for something the class does not need.

The scratch was borrowed per call, so scoring allocated `3 * k` doubles per arm per decision whenever no workspace was passed, which is the common path. The bandit already asks callers to serialise `choose` and `update`, so it can own the buffer outright, the same way each arm's history already owns its reward and weight arrays. That makes scoring allocation-free with no workspace to hand.

The selection ran k comparisons to locate the worst retained neighbour before every candidate, admitted or not, so it cost O(history * k) per arm per decision. Carrying that slot and rescanning only after an admission costs one comparison to reject, and past the first k arrivals nearly every candidate is rejected. Worst case is unchanged: contexts arriving in descending distance order displace on every step.

Selection results are identical. The admission test stays strictly less-than, so equal distances still keep the neighbour that arrived first, and a NaN distance is still rejected. The rescan keeps the lowest index on ties, as the old one did.

An earlier plan for this used koblas `F64IndexedVector` as the scratch. It does not fit: it is a sparse accumulator whose value comes from touching few of many slots, while all k distance slots here are live, so its index list is pure overhead and its O(count) clear degenerates to O(k). It is also one logical vector rather than three parallel k-slices.

## Testing

`./gradlew check lintDocs --rerun-tasks` and `./gradlew :kumulant:checkKotlinAbi`, both green. No public API moved.

Three tests changed or added. `a failed distance leaves the scan buffer usable for the next call` replaces the test that covered workspace release on exception, since there is no borrow left to release, and it asserts the stronger property that the next call scores correctly. `the k nearest are the same whatever order the contexts arrive in` covers ascending, descending and shuffled arrival, descending being the order that admits on every step. `equal distances keep the neighbour that arrived first` pins the tie rule the carried slot has to preserve.

`KnnWorkspaceAllocationTest` asserted that a reserved workspace saved at least 128 B per `choose`. It cannot any more, because neither path allocates, so it now asserts both are at or near zero.

An ad-hoc JVM probe, not a `:kumulant-bench` suite, over 16 features with a single populated arm:

| history | k | before | after |
|---|---|---|---|
| 256 | 4 | 8.0 us | 6.8 us |
| 256 | 16 | 9.8 us | 6.2 us |
| 256 | 64 | 41.2 us | 12.3 us |
| 4096 | 4 | 183.6 us | 96.9 us |
| 4096 | 16 | 224.1 us | 103.3 us |
| 4096 | 64 | 439.6 us | 116.9 us |

The shape matters more than the ratios. At history 4096 the old scan grew 2.4x going from k 4 to k 64; the new one grows 1.2x over the same range.