### PR TITLE
perf: score every softmax class from one pass over the context

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -65,7 +65,10 @@ data class SoftmaxRegressionResult(
     fun logit(x: F64VectorLike, k: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = biases[k]
-        for (i in 0 until featureSize) s += weights[k, i] * x[i]
+        // Walk what x stores rather than every feature index. Reading a sparse x position by
+        // position binary-searches its stored indices on each one, so a handful of nonzeros would
+        // cost featureSize searches; an unstored position contributes nothing to the sum anyway.
+        x.forEachStored { i, v -> s += weights[k, i] * v }
         return s
     }
 
@@ -88,14 +91,17 @@ data class SoftmaxRegressionResult(
         destination.softmaxInPlace()
     }
 
-    /** Finds the argmax for [x], borrowing logits only for the duration of this call. */
-    fun predict(x: F64VectorLike, workspace: Workspace? = null): Int = when (workspace) {
-        null -> argMaxOf(numClasses) { k -> logit(x, k) }
-
-        else -> workspace.borrow(numClasses) { logits ->
-            logitsInto(x, logits)
-            argMaxOf(numClasses) { logits[it] }
-        }
+    /**
+     * Finds the argmax for [x], borrowing logits only for the duration of this call.
+     *
+     * All [numClasses] logits come from one pass over [x] rather than a pass per class. Scoring a
+     * class at a time re-reads the whole context K times, and on a sparse [x] each of those reads
+     * is a search through its stored indices. Without a [workspace] to borrow from, the single pass
+     * costs one length-[numClasses] buffer, which is the cheaper side of that trade.
+     */
+    fun predict(x: F64VectorLike, workspace: Workspace? = null): Int = workspace.borrow(numClasses) { logits ->
+        logitsInto(x, logits)
+        argMaxOf(numClasses) { logits[it] }
     }
 }
 

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
@@ -48,7 +48,7 @@ class SoftmaxWorkspaceAllocationTest {
     }
 
     @Test
-    fun `softmax prediction stays allocation free with null and reserved workspace`() {
+    fun `a reserved workspace removes the logits buffer softmax prediction otherwise allocates`() {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
@@ -67,8 +67,10 @@ class SoftmaxWorkspaceAllocationTest {
         val nullBytes = bytesPerCall { result.predict(x, null) }
         val workspaceBytes = bytesPerCall { result.predict(x, workspace) }
 
-        assertTrue(defaultBytes <= 8.0, "default prediction allocated $defaultBytes B/call")
-        assertTrue(nullBytes <= 8.0, "null prediction allocated $nullBytes B/call")
+        // Scoring every class from one pass over x needs somewhere to put the logits, so without a
+        // workspace that is one length-numClasses array per call. The workspace lends it instead.
         assertTrue(workspaceBytes <= 8.0, "workspace prediction allocated $workspaceBytes B/call")
+        assertTrue(defaultBytes > workspaceBytes, "default prediction allocated $defaultBytes B/call")
+        assertTrue(nullBytes > workspaceBytes, "null prediction allocated $nullBytes B/call")
     }
 }


### PR DESCRIPTION
## What changed

- `SoftmaxRegressionResult.predict` computes all `numClasses` logits from one pass over the context instead of one pass per class. It goes through `logitsInto` on a borrowed buffer whether or not a workspace is supplied.
- `SoftmaxRegressionResult.logit` walks what the context stores instead of reading every feature index.
- The weight matrix layout is unchanged. That was the original plan for this work and measurement rejected it; see below.

## Why

`predict` without a workspace called `logit` once per class, and `logit` read `x[i]` for every feature. On a sparse context each of those reads binary-searches the stored indices, so scoring cost `numClasses * featureSize` searches to consume a handful of nonzeros.

Measured with an ad-hoc JVM probe, not a `:kumulant-bench` suite, at `featureSize` 512 and `numClasses` 8:

| context | predict before | predict after |
|---|---|---|
| sparse, 1 percent dense | 27461 ns | 250 ns |
| dense | 14695 ns | 4591 ns |

`predict` now costs about what `probabilitiesInto` costs on the same input, which is right, because it is the same work plus an argmax.

A side effect worth noting: `predict(x)` and `predict(x, workspace)` used to run different arithmetic, one accumulating the bias first and the other adding it after the matrix-vector product. They could in principle disagree on an exact tie between two classes. Both now run the same path.

## Why the weight matrix was not transposed

The task this came from proposed storing weights as `featureSize x numClasses` so each class's coefficients would be a contiguous column rather than a row at stride `numClasses`. Measurement says that trades the wrong way.

Dense matrices are column-major, so with the current `numClasses x featureSize` shape the inner loop of `multiplyInto` runs down a contiguous column for both the dense and the sparse branch. Transposing keeps the dense branch contiguous but makes the sparse branch stride by `featureSize`. The sparse batch path is currently the fast one, at 199 ns against 4670 ns for dense on the same probe, so the regression would land squarely on the case that matters most.

The strided access the transpose was meant to fix only ever showed up in `logit`, and only because `predict` called it per class. With that gone, `logit` is a single-class convenience off the hot path.

## Testing

`./gradlew check lintDocs --rerun-tasks`, green.

Correctness is already covered. `sparse and generic inputs preserve logits probabilities and predictions` asserts logits, probabilities and predictions agree across dense, sparse and strided contexts, which is exactly what the `logit` rewrite has to preserve. `failed workspace prediction releases its borrowed logits` still applies, since `predict` still borrows.

`SoftmaxWorkspaceAllocationTest` asserted that prediction allocates at most 8 B per call on all three paths. That was true only because the no-workspace path avoided a buffer by re-reading the context per class. It now asserts what the workspace is actually for: the workspace path allocates nothing, and the two paths without one allocate the single logits buffer.