### PR TITLE
perf: reduce the expr sum and mean folds through koblas

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -3,6 +3,8 @@ package com.eignex.kumulant.schema.expr
 import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.forEachStored
+import com.eignex.koblas.koblas
+import com.eignex.koblas.sum
 import com.eignex.kumulant.core.HasCenterScale
 import com.eignex.kumulant.core.HasMinMax
 import com.eignex.kumulant.core.IndexedResult
@@ -506,11 +508,7 @@ internal data class VFold(
     val op: VFoldOp,
 ) : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double = when (op) {
-        VFoldOp.Sum -> {
-            var s = 0.0
-            for (e in v) s += e
-            s
-        }
+        VFoldOp.Sum -> koblas.kernels.sum(v, 0, v.size)
 
         VFoldOp.Product -> {
             var p = 1.0
@@ -520,9 +518,7 @@ internal data class VFold(
 
         VFoldOp.Mean -> {
             require(v.isNotEmpty()) { "VFold.Mean on empty vector" }
-            var s = 0.0
-            for (e in v) s += e
-            s / v.size
+            koblas.kernels.sum(v, 0, v.size) / v.size
         }
 
         VFoldOp.Min -> {
@@ -835,17 +831,26 @@ sealed interface VectorExpr {
  *
  * This overload is additive: [ScalarExpr.eval] with a [DoubleArray] remains the compatibility
  * surface for callers whose input is already dense.
+ *
+ * [VFoldOp.Sum] and [VFoldOp.Mean] reduce through koblas, which pairs terms across SIMD lanes for a
+ * dense operand and accumulates in order for every other storage. Those associate differently, so
+ * the same coordinates reduced from a dense vector and from a sparse one can disagree in the last
+ * bits, and a snapshot carrying such a value is only equal to another that was fed the same storage.
+ * Every other fold is order-independent and agrees exactly whatever the storage.
  */
 fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): Double {
     if (v is F64SparseVector) {
         when (this) {
             is VFold -> when (op) {
-                VFoldOp.Sum -> return sparseSum(v)
-                VFoldOp.Mean -> return sparseMean(v)
                 VFoldOp.Min -> return sparseMin(v)
+
                 VFoldOp.Max -> return sparseMax(v)
+
                 VFoldOp.Norm2 -> return sparseNorm2(v)
-                VFoldOp.Product -> Unit
+
+                // Sum and Mean need no fast path: the generic evaluator reduces through
+                // koblas, which already visits only what a sparse vector stores.
+                VFoldOp.Sum, VFoldOp.Mean, VFoldOp.Product -> Unit
             }
 
             is VDot -> {
@@ -927,7 +932,7 @@ private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike,
         }
 
         is VFold -> when (op) {
-            VFoldOp.Sum -> (0 until v.size).sumOf { v[it] }
+            VFoldOp.Sum -> v.sum()
 
             VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
 
@@ -935,7 +940,7 @@ private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike,
                 require(
                     v.size != 0,
                 ) { "VFold.Mean on empty vector" }
-                (0 until v.size).sumOf { v[it] } / v.size
+                v.sum() / v.size
             }
 
             VFoldOp.Min -> {
@@ -964,17 +969,6 @@ private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike,
             (0 until v.size).sumOf { weights[it] * v[it] }
         }
     }
-
-private fun sparseSum(v: F64SparseVector): Double {
-    var sum = 0.0
-    v.forEachStored { _, value -> sum += value }
-    return sum
-}
-
-private fun sparseMean(v: F64SparseVector): Double {
-    require(v.size != 0) { "VFold.Mean on empty vector" }
-    return sparseSum(v) / v.size
-}
 
 private fun sparseNorm2(v: F64SparseVector): Double {
     var sum = 0.0

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -18,6 +18,7 @@ import com.eignex.kumulant.stat.regression.glm.UnivariateRegressionResult
 import com.eignex.kumulant.stat.summary.SumResult
 import com.eignex.kumulant.stat.summary.WeightedMeanResult
 import com.eignex.skema.SchemaJson
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -411,6 +412,9 @@ class ExprTest {
             doubleArrayOf(1.0, 0.0, Double.NaN, 2.0),
             doubleArrayOf(0.0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
             doubleArrayOf(-0.0, 0.0, Double.MAX_VALUE, Double.MIN_VALUE),
+            // One dominant term ahead of many small ones, long enough to fill SIMD lanes: the only
+            // shape in this set where associativity is observable.
+            DoubleArray(64) { if (it == 0) 1e16 else 1.0 },
         )
         val folds = VFoldOp.entries.map(::VFold)
 
@@ -425,8 +429,15 @@ class ExprTest {
                 for (input in representations) {
                     if (array.isEmpty() && fold.op in setOf(VFoldOp.Mean, VFoldOp.Min, VFoldOp.Max)) {
                         assertFailsWith<IllegalArgumentException> { fold.eval(v = input) }
+                        continue
+                    }
+                    val expected = fold.eval(0.0, 0.0, array)
+                    val actual = fold.eval(v = input)
+                    val message = "${fold.op} over ${input::class.simpleName} of ${array.size}"
+                    if (fold.op in reassociating && expected.isFinite()) {
+                        assertEquals(expected, actual, abs(expected) * reassociationTolerance, message)
                     } else {
-                        assertEquals(fold.eval(0.0, 0.0, array).toBits(), fold.eval(v = input).toBits())
+                        assertEquals(expected.toBits(), actual.toBits(), message)
                     }
                 }
             }
@@ -533,6 +544,17 @@ class ExprTest {
             VDot(weights = listOf(1.0, 1.0)).eval(0.0, 0.0, doubleArrayOf(1.0, 2.0, 3.0))
         }
     }
+
+    /**
+     * Folds whose result depends on how the terms associate. Sum and Mean reduce through koblas,
+     * which pairs terms across SIMD lanes for a dense operand and accumulates in order for every
+     * other storage, so the two answers differ in the last bits. The remaining folds are
+     * order-independent and still have to agree exactly.
+     */
+    private val reassociating = setOf(VFoldOp.Sum, VFoldOp.Mean)
+
+    /** Relative slack for [reassociating] folds; reassociation moves the last bits, nothing more. */
+    private val reassociationTolerance = 1e-12
 
     private fun sparse(values: DoubleArray): F64SparseVector {
         val indices = values.indices.filter {


### PR DESCRIPTION
## What changed

- `VFold.eval` over a `DoubleArray` reduces Sum and Mean with `koblas.kernels.sum` instead of a hand-written loop.
- The `F64VectorLike` evaluator uses `F64VectorLike.sum()`, whose own dispatch is exactly what kumulant was doing by hand: dense reaches the kernel, any other storage sums its stored entries.
- The sparse fast-path arms for Sum and Mean are gone, and with them `sparseSum` and `sparseMean`. The dispatcher stays for Min, Max, Norm2 and Product.
- The storage-dependence this introduces is documented on the `F64VectorLike` overload and covered by a test case that exercises it.

## Why

Four hand-rolled reductions across two evaluators did what one library call does. The dense path also went through virtual `v[it]` indexing, so it gets faster as well as shorter. This is a per-update path, hit once per observation per fold or transform node.

## The behaviour change, which is the reason to read this carefully

`ExprTest.vector reductions match double arrays across storage representations` asserted bit-exact equality between the `DoubleArray` evaluator and dense, sparse, strided and non-materialising storage. That no longer holds for Sum and Mean.

koblas pairs terms across SIMD lanes for a dense operand and accumulates in order for everything else, so the two associate differently. Measured, with one dominant term ahead of many small ones, they diverge from 64 elements and the gap widens with length:

    n=64    DoubleArray and dense agree; sparse differs in the last bits
    n=4096  same shape, larger gap

The consequence is that a value reduced from a dense vector and the same value reduced from a sparse one are not necessarily equal, so a snapshot carrying one is only equal to another fed the same storage. That is now the documented contract rather than an accident.

The test keeps bit-exact assertions for Min, Max, Product and Norm2, which are order-independent, and for any non-finite expected value, since NaN and infinity propagation is semantics rather than precision. Sum and Mean get a relative tolerance. A 64-element case was added because every array in the existing set was four elements or fewer, short enough that the divergence never appeared, so without it the test would have passed while testing nothing.

Note koblas makes no cross-storage bit-equality promise either; `sum()` has the same dense and sparse split internally. This brings kumulant in line with its dependency rather than holding a stricter contract than the layer underneath it.

## Testing

`./gradlew check lintDocs --rerun-tasks`, green.