### PR TITLE
perf: take the dense knn distance from the koblas ssqd kernel

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -6,6 +6,7 @@ import com.eignex.koblas.core.F64SparseVector
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.core.F64VectorStorage
 import com.eignex.koblas.forEachStored
+import com.eignex.koblas.koblas
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
@@ -335,14 +336,8 @@ class KnnContextualBandit(
             }
         }
 
-        private fun denseSquaredL2(a: F64DenseVector, b: F64DenseVector): Double {
-            var s = 0.0
-            for (i in 0 until a.size) {
-                val d = a[i] - b[i]
-                s += d * d
-            }
-            return s
-        }
+        private fun denseSquaredL2(a: F64DenseVector, b: F64DenseVector): Double =
+            koblas.kernels.ssqd(a.data, 0, b.data, 0, a.size)
 
         private fun genericSquaredL2(a: F64VectorLike, b: F64VectorLike): Double {
             var s = 0.0


### PR DESCRIPTION
Stacked on #110.

## What changed

`KnnContextualBandit.denseSquaredL2` is `koblas.kernels.ssqd(a.data, 0, b.data, 0, a.size)` instead of a scalar loop through the bounds-checked `F64DenseVector.get`.

## Why

It is the last hand-rolled arm of the distance kernel, and the kernel runs once per history entry per arm per `choose`, so it is the hot path for dense contexts. koblas gained `ssqd`, sum of squared differences, which is exactly this reduction.

Unlike `axpy`, `ssqd` is not host-routed, so there is no dispatch layer to pay before the length gate. The gate itself still applies inside the JVM's bundled-C kernels at 128 elements.

## Testing

`./gradlew check lintDocs --rerun-tasks`, green.

Measured with `:kumulant-bench` `PredictionKernelBenchmark` through a temporary filtered configuration, at densityPercent 100, which is the dense path:

| featureSize | before | after |
|---|---|---|
| 128 | 176081 +/- 14273 ops/s | 172923 +/- 28543 ops/s |
| 512 | 34482 +/- 2209 ops/s | 65446 +/- 7695 ops/s |
| 128, workspace | 170107 +/- 7177 ops/s | 167891 +/- 6361 ops/s |
| 512, workspace | 33970 +/- 854 ops/s | 64411 +/- 3525 ops/s |

1.9x at 512, and a wash at 128 with overlapping error bars. That break-even sits where koblas puts `SSQD_C_CROSSOVER`, at 128, so a context of that width is right on the boundary between the scalar path and the bundled-C one. Nothing regresses.

The other three arms stay as they are. `genericSquaredL2` has no backing array to hand a kernel, `mixedSquaredL2` is a norm-then-correct rather than a paired difference, and `sparseSquaredL2` is an index merge walk that handles explicitly stored zeros deliberately. `ssqd` fits none of them.