### PR TITLE
perf: sum the contiguous confusion matrix totals through koblas

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -1,5 +1,6 @@
 package com.eignex.kumulant.stat.score
 
+import com.eignex.koblas.koblas
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -41,11 +42,7 @@ data class ConfusionMatrixResult(
     fun count(predicted: Int, truth: Int): Double = counts[predicted * numClasses + truth]
 
     /** Total weight across all cells. */
-    val totalWeights: Double get() {
-        var s = 0.0
-        for (c in counts) s += c
-        return s
-    }
+    val totalWeights: Double get() = koblas.kernels.sum(counts, 0, counts.size)
 
     /** Sum of the diagonal (correctly classified weight). */
     val correct: Double get() {
@@ -58,13 +55,14 @@ data class ConfusionMatrixResult(
     val accuracy: Double get() = totalWeights.let { if (it > 0.0) correct / it else 0.0 }
 
     /** Predicted-class total: weight of all rows where prediction = [c]. */
-    fun predictedTotal(c: Int): Double {
-        var s = 0.0
-        for (t in 0 until numClasses) s += count(c, t)
-        return s
-    }
+    fun predictedTotal(c: Int): Double = koblas.kernels.sum(counts, c * numClasses, numClasses)
 
-    /** True-class total: weight of all columns where truth = [c]. */
+    /**
+     * True-class total: weight of all columns where truth = [c].
+     *
+     * A column is `numClasses` apart in this row-major backing, and the summation kernel takes a
+     * length but no stride, so this stays an indexed walk while [predictedTotal] does not.
+     */
     fun actualTotal(c: Int): Double {
         var s = 0.0
         for (p in 0 until numClasses) s += count(p, c)


### PR DESCRIPTION
Stacked on #112.

## What changed

- `ConfusionMatrixResult.totalWeights` sums the whole `counts` array through `koblas.kernels.sum`.
- `predictedTotal(c)` sums the contiguous row at offset `c * numClasses` the same way.
- `actualTotal(c)` stays an indexed walk, and now says why.

## Why

Both replaced reductions are contiguous in the row-major backing, so they were hand-written loops over exactly what a summation kernel takes.

They are on the read path, but an amplified one. `macroPrecision`, `macroRecall` and `macroF1` each call `precision` and `recall` per class, and `mcc` builds both margin vectors and recomputes the total, so a single `mcc` read walks the matrix several times over.

`actualTotal` is deliberately left alone. A column is `numClasses` apart in this layout and `F64Kernels.sum` takes a length but no stride, so the two functions are asymmetric on purpose. That asymmetry looks like an oversight, so the reason is now in its KDoc rather than left for someone to "fix".

## On reduction order

The kernel pairs terms across lanes where the loop accumulated in order, so these totals can move in the last bits.

Unlike the Expr folds in #109 that is inert here, because there is no second path to disagree with. `counts` is always a `DoubleArray`, materialised at read time from the atomic cells, so nothing compares a dense reduction against a sparse one and no cross-storage contract exists to weaken. That is also why this is legal on the read path and would not be on the update path, where the state lives in `StreamDouble` cells no kernel can address.

## Testing

`./gradlew check lintDocs --rerun-tasks`, green.