### PR TITLE
refactor: accumulate the population prior with axpy and syr

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -22,6 +22,7 @@ import com.eignex.koblas.dense.trmv
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.dot
 import com.eignex.koblas.koblas
+import com.eignex.koblas.syr
 import com.eignex.koblas.zeroStrictUpper
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -368,16 +369,25 @@ class BayesianRegressionStat(
             // One buffer for every snapshot's covariance: the inversion writes each entry, so it
             // never sees what the previous instance left behind.
             val cov = F64DenseMatrix.zero(n, n)
+            // Both matrices are square, n by n, and column-major, so their flat backings line up
+            // entry for entry and the matrix add is a level-1 axpy over the whole of them.
+            val sigmaFlat = F64DenseVector.wrap(sigmaPop.data)
+            val covFlat = F64DenseVector.wrap(cov.data)
+            val deviation = DoubleArray(n)
+            val deviationVector = F64DenseVector.wrap(deviation)
             for (s in snapshots.indices) {
                 val wi = weights[s] / wTotal
                 snapshots[s].covarianceInto(cov)
                 val mu = snapshots[s].weights
-                for (i in 0 until n) {
-                    val di = mu[i] - muPop[i]
-                    for (j in 0 until n) {
-                        sigmaPop[i, j] = sigmaPop[i, j] + wi * (cov[i, j] + di * (mu[j] - muPop[j]))
-                    }
-                }
+                sigmaFlat.axpy(wi, covFlat)
+                for (i in 0 until n) deviation[i] = mu[i] - muPop[i]
+                sigmaPop.syr(wi, deviationVector)
+            }
+            // The axpy filled both triangles, since each Sigma_i is symmetric, but syr writes only
+            // the lower one. Reflecting once here rather than per snapshot is what keeps the
+            // published matrix symmetric, which callers reading either half depend on.
+            for (i in 0 until n) {
+                for (j in i + 1 until n) sigmaPop[i, j] = sigmaPop[j, i]
             }
 
             return PopulationPrior(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -205,6 +205,37 @@ class BayesianRegressionStatPriorTest {
     }
 
     @Test
+    fun `fitPopulationPrior returns a symmetric covariance with off-diagonal spread`() {
+        // The between-instance term is accumulated one triangle at a time, so the off-diagonal
+        // has to be filled by reflection rather than written twice. Means that differ in both
+        // coordinates are what puts anything there to reflect.
+        val sqrt01 = sqrt(0.01)
+        fun snap(mu: DoubleArray) = PrecisionRegressionResult(
+            weights = F64DenseVector.of(mu),
+            bias = 0.0,
+            biasPrecision = 1.0,
+            totalWeights = 100.0,
+            step = 100L,
+            precisionL = F64DenseMatrix.diagonal(3, 1.0 / sqrt01),
+            sse = 0.0,
+        )
+        val prior = BayesianRegressionStat.fitPopulationPrior(
+            listOf(
+                snap(doubleArrayOf(2.0, -1.0, 0.5)),
+                snap(doubleArrayOf(-1.0, 3.0, -2.0)),
+                snap(doubleArrayOf(0.0, 1.0, 4.0)),
+            ),
+        )
+
+        for (i in 0 until 3) {
+            for (j in 0 until 3) {
+                assertEquals(prior.covariance[i, j], prior.covariance[j, i], 0.0, "asymmetric at ($i, $j)")
+            }
+        }
+        assertTrue(abs(prior.covariance[0, 1]) > 1e-6, "off-diagonal is ${prior.covariance[0, 1]}")
+    }
+
+    @Test
     fun `fitPopulationPrior captures between-instance spread`() {
         // Two posteriors with very different means and tight covariance: the population
         // covariance should be dominated by the between-instance term (~ (mu_diff/2)^2).


### PR DESCRIPTION
Stacked on #113.

## What changed

`fitPopulationPrior`'s per-snapshot n by n double loop becomes two koblas calls:

- `sigmaPop += wi * Sigma_i` is a level-1 axpy over the flat backings. Both matrices are square, n by n and column-major, constructed two lines apart, so the layouts line up entry for entry.
- `sigmaPop += wi * d dT` for `d = mu_i - mu_pop` is `syr`.

The wrappers and the deviation buffer are hoisted above the loop, so a refit over m instances allocates none of them per snapshot.

## The triangle

`syr` writes one triangle; the axpy writes both, because each `Sigma_i` is symmetric. So after the loop the lower triangle holds everything and the upper is missing the rank-1 term. One reflection after the loop fixes it, rather than a second `syr` per snapshot.

`PopulationPrior.covariance` is public and a caller may read either half, so symmetry is a contract rather than an implementation detail.

`fitPopulationPrior returns a symmetric covariance with off-diagonal spread` pins it. Three instances whose means differ in every coordinate, so there is something off-diagonal to reflect, then symmetry asserted exactly and the off-diagonal asserted non-zero so the test cannot pass by both halves being empty. Disabling the reflection fails it, which I checked rather than assumed.

## Why

Offline path, reached through `HierarchicalBayesianRegression.refit()`, so this is clarity and consistency rather than throughput. It is the last hand-written matrix accumulation in the file now that the update path is a rank-1 factor update and merge is `syrk`.

## Testing

`./gradlew check lintDocs --rerun-tasks`, green. The existing `fitPopulationPrior captures between-instance spread` and `fitPopulationPrior returns the simple mean for identical posteriors` cover the arithmetic itself and pass unchanged.