### PR TITLE
chore: bump the kbuild convention plugin to 1.3.3

### DIFF
--- a/kumulant/build.gradle.kts
+++ b/kumulant/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.concurrent.TimeUnit
 
 plugins {
-    id("com.eignex.kmp") version "1.3.2"
+    id("com.eignex.kmp") version "1.3.3"
     kotlin("plugin.serialization") version "2.4.10"
 }
 


### PR DESCRIPTION
## What changed

- Bump the kbuild convention plugin from 1.3.2 to 1.3.3.

## Why

kbuild 1.3.3 (Eignex/kbuild#52) disables the detekt tasks that re-analyse files the per-source-set tasks already cover, so each file is linted once instead of twice.

## Testing

Ran the gate and confirmed the redundant `:detekt` task reports SKIPPED while the per-source-set tasks still run.
