### PR TITLE
test: warm the softmax allocation arms until C2 has compiled the chain

### DIFF
--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
@@ -18,8 +18,18 @@ class SoftmaxWorkspaceAllocationTest {
         fun run()
     }
 
+    /**
+     * Best-of-five bytes per call, taken only after the call chain has had time to reach C2.
+     *
+     * koblas builds a small shape record on every `gemv` and only escape analysis removes it, so until
+     * C2 has compiled the chain from `predict` down to the kernel the workspace arm is charged 24 B for
+     * a record it never asked for and misses a ceiling meant for the buffer it borrows. From a fresh
+     * JVM that compile landed anywhere between 70k and 400k calls in, later the busier the compile
+     * queue, so the warmup is sized for the slow end and the workspace arm measures last with the other
+     * arms' calls behind it.
+     */
     private fun bytesPerCall(body: Body): Double {
-        repeat(1_000) { body.run() }
+        repeat(200_000) { body.run() }
         val id = Thread.currentThread().threadId()
         var best = Double.MAX_VALUE
         repeat(5) {


### PR DESCRIPTION
## What changed

- Warm each arm of SoftmaxWorkspaceAllocationTest for 200k calls before reading the allocation counter, up from 1k.
- Document why the warmup has to carry the whole call chain into C2 before the counter is read.

## Why

The prediction test failed on main with the workspace arm at 24 B per call against a ceiling of 8 B. koblas builds a two-int GemvShape record on every gemv since its shape refactor of Sep 4, and only C2 escape analysis removes it. Until C2 has compiled the chain from predict down to the kernel the workspace arm is charged for that record and misses a ceiling meant for the logits buffer it borrows. The whole test made 33k calls, and from a fresh JVM the compile landed after about 70k calls on a 20-core machine and anywhere between 124k and 378k calls pinned to two cores, later the busier the compile queue. Whether the test passed depended on where that compile landed relative to the third arm, which is why the same koblas snapshot went green on the kbuild 1.3.3 branch and red on main twelve minutes later, and why it failed six of six local runs. The warmup is sized for the slow end, and the workspace arm still measures last with the other arms' calls behind it.

The same mechanism is a plausible reading of the earlier KnnWorkspaceAllocationTest failure, where the workspace arm failed while the bare arm passed. The lasting cure is for koblas to derive the gemv extents without a per-call record, which would let the ceiling drop back to a few bytes.

## Testing

`./gradlew check lintDocs --rerun-tasks` passes. The class failed six of six local runs at the 1k warmup and passed four of four at 200k. It also passed three runs pinned to two cores and three more pinned to two cores with a busy loop on each of those cores. In the full JVM suite the two tests take 62 ms and 195 ms unpinned and 129 ms and 301 ms pinned to two cores.
