### PR TITLE
test: share one allocation harness that waits out the JIT and trim the timing and hot-loop tests

### DIFF
--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/MonotonicClockTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stream/MonotonicClockTest.kt
@@ -15,14 +15,4 @@ class MonotonicClockTest {
             )
         }
     }
-
-    @Test
-    fun `currentTimeNanos advances between two calls separated by work`() {
-        val a = currentTimeNanos()
-
-        var sink = 0L
-        repeat(100_000) { sink += it.toLong() }
-        val b = currentTimeNanos()
-        assertTrue(b > a, "expected clock to advance, got a=$a b=$b (sink=$sink)")
-    }
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/AllocationTestUtil.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/AllocationTestUtil.kt
@@ -1,0 +1,80 @@
+package com.eignex.kumulant
+
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import java.util.function.IntConsumer
+import kotlin.test.fail
+
+// kotlinx-benchmark 0.4.13 does not expose JMH's `gc` profiler - its `advanced` options are limited to
+// fork and bridge settings - so per-operation allocation is invisible to the benchmark suite. It is
+// measured here through the HotSpot thread allocation counter instead, which is exact for the current
+// thread and cheap enough to run as an ordinary test.
+//
+// What the counter cannot see past is the JIT. Until C2 has compiled a call chain, objects that escape
+// analysis later removes are still allocated - a koblas kernel's shape record, a capturing lambda - and
+// they show up as tens of bytes per call that the steady state never spends. Both helpers below are
+// shaped around that: one waits for the steady state, the other measures its arms side by side so a
+// transient they share cancels out.
+//
+// A body is an `IntConsumer` handed the call index rather than a Kotlin `(Int) -> Unit`, which compiles
+// to `Function1<Integer, Unit>` and boxes the index on every call: 16 B per iteration that would swamp
+// what is being measured. `IntConsumer.accept` compiles to `(I)V` and allocates nothing.
+
+private val threads = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+internal const val ALLOCATION_PASS_CALLS = 2_000
+private const val WARMUP_CALLS = 10_000
+private const val PASSES = 10
+private const val SETTLE_BUDGET_NANOS = 3_000_000_000L
+
+/** Bytes allocated per call by one pass of [body] on the current thread. */
+private fun measurePass(callsPerPass: Int, body: IntConsumer): Double {
+    val id = Thread.currentThread().threadId()
+    val before = threads.getThreadAllocatedBytes(id)
+    for (i in 0 until callsPerPass) body.accept(i)
+    val after = threads.getThreadAllocatedBytes(id)
+    return (after - before).toDouble() / callsPerPass
+}
+
+/**
+ * Asserts that [body] settles at or under [ceiling] bytes per call.
+ *
+ * Passes repeat until one comes in under the ceiling, since bytes per call only fall as compilation
+ * lands, and give up on a wall-clock budget rather than a call count so a slow compile queue is waited
+ * out instead of raced. A pass that clears the ceiling is sound on its own: nothing the JIT does later
+ * makes the same code allocate more. [callsPerPass] is raised for a body whose allocation is amortised
+ * over many calls, so that one pass spans several of its epochs.
+ */
+internal fun assertAllocatesAtMost(
+    ceiling: Double,
+    what: String,
+    callsPerPass: Int = ALLOCATION_PASS_CALLS,
+    body: IntConsumer,
+) {
+    val deadline = System.nanoTime() + SETTLE_BUDGET_NANOS
+    var best = Double.MAX_VALUE
+    do {
+        best = minOf(best, measurePass(callsPerPass, body))
+        if (best <= ceiling) return
+    } while (System.nanoTime() < deadline)
+    fail("$what allocated $best B/call, expected at most $ceiling")
+}
+
+/**
+ * Best-of-passes bytes per call for each of [bodies], measured in interleaved passes after a shared
+ * warmup.
+ *
+ * Interleaving keeps every arm in the same JIT state as its neighbours, so a transient the arms share
+ * cancels out of a difference between them; measuring one arm to completion before starting the next
+ * would charge it to whichever arm ran first. Read the result differentially, asserting that one arm
+ * undercuts another by the buffer it is meant to save. An absolute claim about a single arm belongs
+ * in [assertAllocatesAtMost].
+ */
+internal fun bytesPerCall(vararg bodies: IntConsumer): DoubleArray {
+    for (body in bodies) for (i in 0 until WARMUP_CALLS) body.accept(i)
+    val best = DoubleArray(bodies.size) { Double.MAX_VALUE }
+    repeat(PASSES) {
+        for (b in bodies.indices) best[b] = minOf(best[b], measurePass(ALLOCATION_PASS_CALLS, bodies[b]))
+    }
+    return best
+}

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
@@ -1,31 +1,12 @@
 package com.eignex.kumulant.bandit.contextual
 
 import com.eignex.koblas.core.F64DenseVector
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
+import com.eignex.kumulant.assertAllocatesAtMost
+import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class Exp4BanditAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerCall(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     @Test
     fun `destination distribution removes Kumulant output allocation with reusable advice`() {
@@ -34,8 +15,10 @@ class Exp4BanditAllocationTest {
         val x = F64DenseVector.of(doubleArrayOf(1.0))
         val out = DoubleArray(ARMS)
 
-        val allocatingBytes = bytesPerCall { allocating.playDistribution(x) }
-        val destinationBytes = bytesPerCall { destination.playDistributionInto(x, out) }
+        val (allocatingBytes, destinationBytes) = bytesPerCall(
+            { allocating.playDistribution(x) },
+            { destination.playDistributionInto(x, out) },
+        )
 
         assertTrue(
             destinationBytes + 128.0 <= allocatingBytes,
@@ -50,14 +33,11 @@ class Exp4BanditAllocationTest {
         val updating = reusableBandit()
         val arm = updating.choose(x)
 
-        val chooseBytes = bytesPerCall { choosing.choose(x) }
-        val updateBytes = bytesPerCall {
+        assertAllocatesAtMost(0.0, "choose") { choosing.choose(x) }
+        assertAllocatesAtMost(0.0, "update followed by choose") {
             updating.update(arm, x, reward = 0.0)
             updating.choose(x)
-        } / 2.0
-
-        assertTrue(chooseBytes < 128.0, "choose allocated $chooseBytes B/call")
-        assertTrue(updateBytes < 128.0, "update allocated $updateBytes B/call")
+        }
     }
 
     private fun reusableBandit(): Exp4Bandit {

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
@@ -2,31 +2,10 @@ package com.eignex.kumulant.bandit.contextual
 
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.core.F64DenseVector
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
+import com.eignex.kumulant.assertAllocatesAtMost
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class KnnWorkspaceAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerCall(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     private fun populatedBandit(): KnnContextualBandit = KnnContextualBandit(
         ARMS,
@@ -51,13 +30,11 @@ class KnnWorkspaceAllocationTest {
         val x = F64DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
         val workspace = Workspace().apply { reserve(3 * K, 1) }
 
-        val bareBytes = bytesPerCall { bare.choose(x) }
-        val workspaceBytes = bytesPerCall { reused.choose(x, workspace) }
-
         // The scan buffer is owned by the bandit, so there is nothing left for a workspace to save
-        // and nothing left to allocate when one is absent.
-        assertTrue(bareBytes <= CEILING, "choose allocated $bareBytes B/call without a workspace")
-        assertTrue(workspaceBytes <= CEILING, "choose allocated $workspaceBytes B/call with a workspace")
+        // and nothing left to allocate when one is absent. A buffer coming back would be a
+        // `DoubleArray(3 * K)`, about 208 B, spent once per arm scored.
+        assertAllocatesAtMost(0.0, "choose without a workspace") { bare.choose(x) }
+        assertAllocatesAtMost(0.0, "choose with a workspace") { reused.choose(x, workspace) }
     }
 
     private companion object {
@@ -65,17 +42,5 @@ class KnnWorkspaceAllocationTest {
         const val K = 8
         const val HISTORY = 32
         const val FEATURES = 32
-
-        /**
-         * A per-call scan buffer would be a `DoubleArray(3 * K)`, about 208 B, and `choose` scored
-         * [ARMS] arms so the old path spent one per arm. Anything at this ceiling is an order of
-         * magnitude below that and still catches a buffer coming back.
-         *
-         * It is not tighter because `getThreadAllocatedBytes` reports TLAB accounting rather than
-         * exact per-call bytes, so a thread can be charged for a refill it did not spend here. At
-         * 2000 calls a ceiling of 8 B budgeted 16 KB in total, less than one TLAB, and CI failed on
-         * the workspace arm while the identical bare arm passed.
-         */
-        const val CEILING = 64.0
     }
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
@@ -1,13 +1,12 @@
 package com.eignex.kumulant.schema
 
 import com.eignex.koblas.core.F64VectorLike
+import com.eignex.kumulant.bytesPerCall
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.VElements
 import com.eignex.kumulant.schema.expr.eval
 import com.eignex.kumulant.schema.expr.gt
 import com.eignex.kumulant.schema.expr.plus
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -19,35 +18,32 @@ class ExprAllocationTest {
         override fun toDoubleArray(): DoubleArray = error("unexpected materialisation")
     }
 
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun bytesPerCall(input: F64VectorLike, body: (F64VectorLike) -> Unit): Double {
-        repeat(50_000) { body(input) }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(100_000) { body(input) }
-            best = minOf(best, (bean.getThreadAllocatedBytes(id) - before).toDouble() / 100_000)
-        }
-        return best
-    }
-
     @Test
     fun `vector aware scalar bool and fixed output vector evaluation do not scale allocations with input width`() {
         val scalar = V(0) + V(1)
         val predicate = V(0) gt 0.0
         val vector = VElements(listOf(V(0)))
-        fun measure(size: Int): Double = bytesPerCall(Vector(DoubleArray(size) { 1.0 })) { input ->
+        fun evaluate(input: F64VectorLike) {
             scalar.eval(v = input)
             predicate.eval(v = input)
             vector.eval(v = input)
         }
+        val widths = intArrayOf(8, 32, 128, 512)
+        val inputs = widths.map { width -> Vector(DoubleArray(width) { 1.0 }) }
 
-        val baseline = measure(8)
-        for (size in listOf(32, 128, 512)) {
-            val bytes = measure(size)
-            assertTrue(bytes - baseline <= 32.0, "input-width allocation grew from $baseline B to $bytes B at $size")
+        val bytes = bytesPerCall(
+            { evaluate(inputs[0]) },
+            { evaluate(inputs[1]) },
+            { evaluate(inputs[2]) },
+            { evaluate(inputs[3]) },
+        )
+
+        val baseline = bytes[0]
+        for (w in 1 until widths.size) {
+            assertTrue(
+                bytes[w] - baseline <= 32.0,
+                "input-width allocation grew from $baseline B to ${bytes[w]} B at ${widths[w]}",
+            )
         }
     }
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
@@ -1,31 +1,11 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.core.F64DenseVector
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
+import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class GaussianNaiveBayesAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerCall(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     @Test
     fun `destination probabilities remove repeated class score allocation`() {
@@ -37,8 +17,10 @@ class GaussianNaiveBayesAllocationTest {
         val x = F64DenseVector.of(DoubleArray(32) { it * 0.25 })
         val destination = DoubleArray(4)
 
-        val allocatedBytes = bytesPerCall { result.probabilities(x) }
-        val destinationBytes = bytesPerCall { result.probabilitiesInto(x, destination) }
+        val (allocatedBytes, destinationBytes) = bytesPerCall(
+            { result.probabilities(x) },
+            { result.probabilitiesInto(x, destination) },
+        )
 
         assertTrue(
             destinationBytes + 32.0 <= allocatedBytes,

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
@@ -1,35 +1,14 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.core.F64SparseVector
+import com.eignex.kumulant.assertAllocatesAtMost
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class OwnedStorageAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerCall(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     @Test
     fun `reads allocate only their retained snapshot storage`() {
@@ -39,15 +18,10 @@ class OwnedStorageAllocationTest {
         val bayesian = BayesianRegressionStat(32).also { it.update(x, 1.0) }
         val naiveBayes = GaussianNaiveBayesStat(32, 4).also { it.update(x, 0.0) }
 
-        val stochasticBytes = bytesPerCall { stochastic.read() }
-        val diagonalBytes = bytesPerCall { diagonal.read() }
-        val bayesianBytes = bytesPerCall { bayesian.read() }
-        val naiveBayesBytes = bytesPerCall { naiveBayes.read() }
-
-        assertTrue(stochasticBytes < 400.0, "stochastic read allocated $stochasticBytes B/call")
-        assertTrue(diagonalBytes < 700.0, "diagonal read allocated $diagonalBytes B/call")
-        assertTrue(bayesianBytes < 17_000.0, "Bayesian read allocated $bayesianBytes B/call")
-        assertTrue(naiveBayesBytes < 2_500.0, "Gaussian NB read allocated $naiveBayesBytes B/call")
+        assertAllocatesAtMost(400.0, "stochastic read") { stochastic.read() }
+        assertAllocatesAtMost(700.0, "diagonal read") { diagonal.read() }
+        assertAllocatesAtMost(17_000.0, "Bayesian read") { bayesian.read() }
+        assertAllocatesAtMost(2_500.0, "Gaussian NB read") { naiveBayes.read() }
     }
 
     @Test
@@ -58,11 +32,8 @@ class OwnedStorageAllocationTest {
         val stochasticValue = stochastic.read()
         val diagonalValue = diagonal.read()
 
-        val stochasticBytes = bytesPerCall { stochastic.merge(stochasticValue) }
-        val diagonalBytes = bytesPerCall { diagonal.merge(diagonalValue) }
-
-        assertTrue(stochasticBytes < 64.0, "stochastic merge allocated $stochasticBytes B/call")
-        assertTrue(diagonalBytes < 64.0, "diagonal merge allocated $diagonalBytes B/call")
+        assertAllocatesAtMost(0.0, "stochastic merge") { stochastic.merge(stochasticValue) }
+        assertAllocatesAtMost(0.0, "diagonal merge") { diagonal.merge(diagonalValue) }
     }
 
     @Test
@@ -76,14 +47,12 @@ class OwnedStorageAllocationTest {
                     DoubleArray(nnz) { it.toDouble() },
                 )
                 val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 1, exploration = 0.0)
-                val allocatedBytes = bytesPerCall { bandit.update(0, sparse, 1.0) }
                 val retainedBytes = nnz * 12.0 + 128.0
 
-                assertTrue(
-                    allocatedBytes < retainedBytes + 256.0,
-                    "$featureSize features at $density% density allocated $allocatedBytes B/call; " +
-                        "retained storage is $retainedBytes B",
-                )
+                assertAllocatesAtMost(
+                    retainedBytes + 256.0,
+                    "$featureSize features at $density% density with $retainedBytes B of retained storage",
+                ) { bandit.update(0, sparse, 1.0) }
             }
         }
     }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
@@ -3,43 +3,14 @@ package com.eignex.kumulant.stat.regression
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
+import com.eignex.kumulant.assertAllocatesAtMost
+import com.eignex.kumulant.bytesPerCall
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class SoftmaxWorkspaceAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    /**
-     * Best-of-five bytes per call, taken only after the call chain has had time to reach C2.
-     *
-     * koblas builds a small shape record on every `gemv` and only escape analysis removes it, so until
-     * C2 has compiled the chain from `predict` down to the kernel the workspace arm is charged 24 B for
-     * a record it never asked for and misses a ceiling meant for the buffer it borrows. From a fresh
-     * JVM that compile landed anywhere between 70k and 400k calls in, later the busier the compile
-     * queue, so the warmup is sized for the slow end and the workspace arm measures last with the other
-     * arms' calls behind it.
-     */
-    private fun bytesPerCall(body: Body): Double {
-        repeat(200_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     @Test
     fun `reserved workspace removes softmax update logits allocation`() {
@@ -48,8 +19,10 @@ class SoftmaxWorkspaceAllocationTest {
         val x = F64DenseVector.of(DoubleArray(8) { (it + 1).toDouble() / 8.0 })
         val workspace = Workspace().apply { reserve(4, 1) }
 
-        val allocatedBytes = bytesPerCall { allocating.update(x, 1.0) }
-        val workspaceBytes = bytesPerCall { reused.update(x, 1.0, workspace = workspace) }
+        val (allocatedBytes, workspaceBytes) = bytesPerCall(
+            { allocating.update(x, 1.0) },
+            { reused.update(x, 1.0, workspace = workspace) },
+        )
 
         assertTrue(
             workspaceBytes + 32.0 <= allocatedBytes,
@@ -73,14 +46,16 @@ class SoftmaxWorkspaceAllocationTest {
         val x = F64DenseVector.of(doubleArrayOf(1.0, 0.5))
         val workspace = Workspace().apply { reserve(3, 1) }
 
-        val defaultBytes = bytesPerCall { result.predict(x) }
-        val nullBytes = bytesPerCall { result.predict(x, null) }
-        val workspaceBytes = bytesPerCall { result.predict(x, workspace) }
+        val (defaultBytes, nullBytes, workspaceBytes) = bytesPerCall(
+            { result.predict(x) },
+            { result.predict(x, null) },
+            { result.predict(x, workspace) },
+        )
 
         // Scoring every class from one pass over x needs somewhere to put the logits, so without a
         // workspace that is one length-numClasses array per call. The workspace lends it instead.
-        assertTrue(workspaceBytes <= 8.0, "workspace prediction allocated $workspaceBytes B/call")
-        assertTrue(defaultBytes > workspaceBytes, "default prediction allocated $defaultBytes B/call")
-        assertTrue(nullBytes > workspaceBytes, "null prediction allocated $nullBytes B/call")
+        assertAllocatesAtMost(0.0, "workspace prediction") { result.predict(x, workspace) }
+        assertTrue(workspaceBytes + 32.0 <= defaultBytes, "default prediction allocated $defaultBytes B/call")
+        assertTrue(workspaceBytes + 32.0 <= nullBytes, "null prediction allocated $nullBytes B/call")
     }
 }

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
@@ -3,31 +3,11 @@ package com.eignex.kumulant.stat.regression.glm
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.times
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
+import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class BayesianPriorInfoAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerRun(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     @Test
     fun `destination prior information kernel avoids the materialized vector copy`() {
@@ -37,13 +17,13 @@ class BayesianPriorInfoAllocationTest {
         val destination = DoubleArray(size)
         var sink = 0.0
 
-        val materializedBytes = bytesPerRun {
-            sink += (precision * mean).toDoubleArray()[0]
-        }
-        val destinationBytes = bytesPerRun {
-            precision.multiplyInto(mean, destination)
-            sink += destination[0]
-        }
+        val (materializedBytes, destinationBytes) = bytesPerCall(
+            { sink += (precision * mean).toDoubleArray()[0] },
+            {
+                precision.multiplyInto(mean, destination)
+                sink += destination[0]
+            },
+        )
 
         assertTrue(sink.isFinite())
         assertTrue(

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianWorkspaceAllocationTest.kt
@@ -1,31 +1,11 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.Workspace
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
+import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class BayesianWorkspaceAllocationTest {
-
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    private fun interface Body {
-        fun run()
-    }
-
-    private fun bytesPerMerge(body: Body): Double {
-        repeat(1_000) { body.run() }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            repeat(2_000) { body.run() }
-            val after = bean.getThreadAllocatedBytes(id)
-            best = minOf(best, (after - before).toDouble() / 2_000)
-        }
-        return best
-    }
 
     private fun populatedStat(): BayesianRegressionStat = BayesianRegressionStat(featureSize = 8).also { stat ->
         repeat(8) { i ->
@@ -40,14 +20,16 @@ class BayesianWorkspaceAllocationTest {
         val workspace = Workspace().apply { reserve(8, 8) }
         val reused = populatedStat()
 
-        val allocatedBytes = bytesPerMerge {
-            allocated.reset()
-            allocated.merge(merged)
-        }
-        val workspaceBytes = bytesPerMerge {
-            reused.reset()
-            reused.merge(merged, workspace)
-        }
+        val (allocatedBytes, workspaceBytes) = bytesPerCall(
+            {
+                allocated.reset()
+                allocated.merge(merged)
+            },
+            {
+                reused.reset()
+                reused.merge(merged, workspace)
+            },
+        )
 
         assertTrue(
             workspaceBytes + 128.0 <= allocatedBytes,

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -103,9 +103,11 @@ class ConcurrentReadInvariantsTest {
     @Test
     fun `HdrHistogramStat read does not throw while buckets are being populated`() {
         for (level in levels) {
-            // Spread values widely so fresh buckets keep appearing mid-read.
-            val stat = HdrHistogramStat(concurrency = level)
-            assertReadInvariants("HdrHistogramStat[$level]", stat, write = { t, i ->
+            // Spread values widely so fresh buckets keep appearing mid-read. Every read snapshots every
+            // cell of a histogram that keeps growing, so this case runs a third of the usual iterations
+            // and does not track the decades below 1.0 that no write reaches.
+            val stat = HdrHistogramStat(lowestDiscernibleValue = 1.0, concurrency = level)
+            assertReadInvariants("HdrHistogramStat[$level]", stat, iters = 1_000, write = { t, i ->
                 stat.update(1.0 + (t * 7919L + i * 104_729L) % 1_000_000L)
             }) { r ->
                 assertTrue(

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/UpdateAllocationTest.kt
@@ -1,5 +1,7 @@
 package com.eignex.kumulant.stream
 
+import com.eignex.kumulant.ALLOCATION_PASS_CALLS
+import com.eignex.kumulant.assertAllocatesAtMost
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.stat.change.AdwinStat
@@ -10,57 +12,18 @@ import com.eignex.kumulant.stat.summary.MeanStat
 import com.eignex.kumulant.stat.summary.MomentsStat
 import com.eignex.kumulant.stat.summary.SumStat
 import com.eignex.kumulant.stat.summary.VarianceStat
-import com.sun.management.ThreadMXBean
-import java.lang.management.ManagementFactory
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
-// kotlinx-benchmark 0.4.13 does not expose JMH's `gc` profiler - its `advanced` options are limited
-// to fork and bridge settings - so per-operation allocation is invisible to the benchmark suite. It
-// is measured here through the HotSpot thread allocation counter, which is exact for a
-// single-threaded loop and cheap enough to run as an ordinary test.
-//
 // Thresholds are ceilings meant to catch a regression, not exact figures.
 class UpdateAllocationTest {
 
-    private val bean = ManagementFactory.getThreadMXBean() as ThreadMXBean
-
-    /**
-     * Loop body taking a primitive `Int`.
-     *
-     * A Kotlin `(Int) -> Unit` compiles to `Function1<Integer, Unit>`, so every call boxes the
-     * index and the harness allocates 16 B per iteration, swamping what is being measured. A
-     * `fun interface` over a primitive parameter compiles to `(I)V` and allocates nothing.
-     */
-    private fun interface IntBody {
-        fun run(i: Int)
-    }
-
-    /**
-     * Best-of-five bytes per iteration.
-     *
-     * Warmup matters more than it looks: at 20k iterations the JIT has not settled and even a
-     * genuinely allocation-free stat reports several bytes per op. Taking the minimum of
-     * several passes after a 50k warmup removes that noise.
-     */
-    private fun bytesPerOp(iterations: Int, body: IntBody): Double {
-        repeat(50_000) { body.run(it) }
-        val id = Thread.currentThread().threadId()
-        var best = Double.MAX_VALUE
-        repeat(5) {
-            val before = bean.getThreadAllocatedBytes(id)
-            for (i in 0 until iterations) body.run(i)
-            val after = bean.getThreadAllocatedBytes(id)
-            val per = (after - before).toDouble() / iterations
-            if (per < best) best = per
-        }
-        return best
-    }
-
-    private fun assertUpdateAllocation(name: String, limit: Double, stat: SeriesStat<*>, span: Int = 97) {
-        val perOp = bytesPerOp(200_000) { i -> stat.update(1.0 + (i % span), 0L, 1.0) }
-        assertTrue(perOp <= limit, "$name allocated $perOp B/update, expected at most $limit")
-    }
+    private fun assertUpdateAllocation(
+        name: String,
+        limit: Double,
+        stat: SeriesStat<*>,
+        span: Int = 97,
+        callsPerPass: Int = ALLOCATION_PASS_CALLS,
+    ) = assertAllocatesAtMost(limit, "$name update", callsPerPass) { i -> stat.update(1.0 + (i % span), 0L, 1.0) }
 
     @Test
     fun `summary stats allocate nothing per update`() {
@@ -93,13 +56,20 @@ class UpdateAllocationTest {
     fun `the amortised allocators stay under their ceiling`() {
         // Ceilings for the two stats that allocate by design, as tripwires against a large regression
         // rather than as precise figures. Both allocate the same amount under every [Concurrency]
-        // level, so what is left is structural.
+        // level, so what is left is structural. Their allocation lands in bursts, so a pass has to
+        // span many of them for the per-update figure to mean anything.
         //
         // AdwinStat allocates one Bucket per observation, and its bucket-walk scratch buffer grows
         // with the window. Measured 75 B/op.
-        assertUpdateAllocation("AdwinStat", 110.0, AdwinStat(concurrency = Concurrency.None))
+        assertUpdateAllocation("AdwinStat", 110.0, AdwinStat(concurrency = Concurrency.None), callsPerPass = 200_000)
         // TDigestStat allocates the merged centroid arrays once per compression epoch, amortised
         // over the buffer. Measured 54 B/op.
-        assertUpdateAllocation("TDigestStat", 80.0, TDigestStat(concurrency = Concurrency.None), span = 9973)
+        assertUpdateAllocation(
+            "TDigestStat",
+            80.0,
+            TDigestStat(concurrency = Concurrency.None),
+            span = 9973,
+            callsPerPass = 200_000,
+        )
     }
 }


### PR DESCRIPTION
## What changed

- Add a shared jvmTest allocation harness in AllocationTestUtil with two entry points. assertAllocatesAtMost repeats passes until one clears the ceiling and gives up on a wall-clock budget, for absolute claims about one arm. bytesPerCall measures its arms in interleaved passes after a shared warmup, for differential claims between arms.
- Move all nine allocation tests onto that harness and delete their seven private copies of the same measurement loop.
- Replace the absolute ceilings in the Knn, Exp4, OwnedStorage merge, and softmax workspace arms with zero, now that the harness waits for the steady state instead of racing it.
- Drop the currentTimeNanos advances between two calls test from MonotonicClockTest.
- Run the HdrHistogram concurrent reader case for 1000 iterations instead of 3000 and stop it tracking values below 1.0.

## Why

Nine tests read the HotSpot thread allocation counter, which is exact for the current thread. What varied between runs was the JIT. Until C2 compiles a call chain, objects that escape analysis later removes are still allocated, so an arm can report tens of bytes per call that the steady state never spends. The softmax prediction test failed on main that way, the Knn test failed in CI the same way on Sep 3, and the TLAB explanation in its comment did not hold. Six of the nine tests still warmed for 1k calls against absolute ceilings, and each carried its own copy of the loop.

The harness turns both kinds of claim into ones the JIT cannot fail. A per-call figure only falls as compilation lands, so a pass that clears a ceiling is sound on its own, and repeating passes until one does waits a slow compile queue out rather than racing it. Two arms measured in interleaved passes sit in the same JIT state, so a transient they share cancels out of the difference between them. That let the ceilings on arms that are meant to allocate nothing drop to zero, which is what the tests claim.

The clock test asserted that a monotonic clock advances across a 100k iteration addition loop. That loop runs in tens of microseconds once compiled, and browsers coarsen performance.now to 100 µs in Chrome and 1 ms in Firefox, so two reads can be equal on the browser targets. The sibling test already covers monotonicity.

The HdrHistogram case was the slowest test in the suite by a wide margin, 2.9 s alone and 5.3 s under check. Every read snapshots every cell of a histogram that keeps growing, and none of its writes go below 1.0, so it neither needs the decades below that nor 3000 reads per level to keep fresh buckets appearing mid-read.

## Testing

`./gradlew check lintDocs --rerun-tasks` passes. The full JVM suite passed twice unpinned and once pinned to two cores with all allocation ceilings at their new values. In the unpinned suite the slowest touched test is the HdrHistogram case at 0.8 s, down from 2.9 s, and every allocation test is under 0.33 s. Pinned to two cores the Bayesian merge test is the slowest allocation test at 0.58 s.

The koblas side of the same finding, packing the per-call gemv and syrk shape records into value classes, is a separate PR in that repository.
