### PR TITLE
refactor: move portable Cholesky routines into kumulant

### DIFF
--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -35,63 +35,96 @@ internal sealed interface CholeskyPolicy {
 internal class NotPositiveDefinite(val pivotIndex: Int, val pivot: Double, message: String) :
     IllegalArgumentException(message)
 
-internal class CholeskyFactor(val l: F64DenseMatrix) {
-    init {
-        require(l.rows == l.cols) { "cholesky factor must be square" }
-    }
-
-    val n: Int get() = l.rows
-    var regularizations: Int = 0
-
-    fun rankUpdate(v: DoubleArray, sigma: Double, workspace: Workspace? = null): CholeskyFactor {
-        require(v.size == n) { "update vector has ${v.size} entries, expected $n" }
-        require(sigma >= 0.0 && sigma.isFinite()) { "sigma must be non-negative and finite, got $sigma" }
-        return referenceCholeskyRankUpdate(koblas.kernels, this, v, sigma, workspace)
-    }
-
-    fun solveInto(b: DoubleArray, out: DoubleArray): DoubleArray {
-        require(b.size == n && out.size == n) { "solve requires vectors of size $n" }
-        if (out !== b) b.copyInto(out)
-        l.trsv(out, lower = true)
-        l.trsv(out, lower = true, transpose = true)
-        return out
-    }
-
-    fun invert(workspace: Workspace? = null): F64DenseMatrix = invertInto(F64DenseMatrix.zero(n, n), workspace)
-
-    fun invertInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix {
-        require(out.rows == n && out.cols == n) { "inverse destination must be ${n}x$n" }
-        require(out.data !== l.data) { "inverse destination must not share the factor's storage" }
-        return referenceSpdInvert(koblas.kernels, this, out, workspace)
+internal fun F64DenseMatrix.choleskyRankUpdate(v: DoubleArray, sigma: Double, workspace: Workspace? = null) {
+    require(rows == cols) { "cholesky factor must be square" }
+    require(v.size == rows) { "update vector has ${v.size} entries, expected $rows" }
+    require(sigma >= 0.0 && sigma.isFinite()) { "sigma must be non-negative and finite, got $sigma" }
+    val n = rows
+    if (n == 0 || sigma == 0.0) return
+    val ld = data
+    val kernels = koblas.kernels
+    val scale = sqrt(sigma)
+    workspace.borrow(n) { x ->
+        v.copyInto(x)
+        if (scale != 1.0) kernels.scale(x, 0, scale, n)
+        for (k in 0 until n) {
+            val base = k + k * n
+            val diagonal = ld[base]
+            // Inline the rotation to avoid allocating a Givens object per coordinate. A positive
+            // hypot keeps the factor diagonal non-negative and avoids squaring overflow or underflow.
+            val entry = x[k]
+            val r = hypot(diagonal, entry)
+            if (r != 0.0) {
+                ld[base] = r
+                val len = n - k - 1
+                // Two divisions rather than a reciprocal and two multiplies: this rotation sets the
+                // factor's numerical quality, and an extra rounding per entry compounds across n of them.
+                if (len > 0) kernels.rot(ld, base + 1, x, k + 1, len, diagonal / r, entry / r)
+            }
+        }
     }
 }
 
-internal fun F64DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): CholeskyFactor =
-    referenceCholesky(koblas.kernels, this, policy)
+internal fun F64DenseMatrix.choleskySolveInto(b: DoubleArray, out: DoubleArray): DoubleArray {
+    require(rows == cols) { "cholesky factor must be square" }
+    require(b.size == rows && out.size == rows) { "solve requires vectors of size $rows" }
+    if (out !== b) b.copyInto(out)
+    trsv(out, lower = true)
+    trsv(out, lower = true, transpose = true)
+    return out
+}
 
-private fun referenceCholesky(kernels: F64Kernels, a: F64DenseMatrix, policy: CholeskyPolicy): CholeskyFactor =
-    referenceCholeskyInto(
-        kernels,
-        a,
-        CholeskyFactor(F64DenseMatrix.zero(a.rows, a.rows)),
-        policy,
-    )
+internal fun F64DenseMatrix.choleskyInverse(workspace: Workspace? = null): F64DenseMatrix =
+    choleskyInvertInto(F64DenseMatrix.zero(rows, cols), workspace)
 
-private fun referenceCholeskyInto(
-    kernels: F64Kernels,
-    a: F64DenseMatrix,
-    out: CholeskyFactor,
-    policy: CholeskyPolicy,
-): CholeskyFactor {
-    require(a.rows == a.cols) { "cholesky requires a square matrix" }
-    require(out.n == a.rows) { "choleskyInto: out is ${out.n}x${out.n}, expected ${a.rows}x${a.rows}" }
-    val n = a.rows
-    val ld = out.l.data
+internal fun F64DenseMatrix.choleskyInvertInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix {
+    require(rows == cols) { "cholesky factor must be square" }
+    require(out.rows == rows && out.cols == rows) { "inverse destination must be ${rows}x$rows" }
+    require(out.data !== data) { "inverse destination must not share the factor's storage" }
+    val n = rows
+    val ld = data
+    val kernels = koblas.kernels
+    val invd = out.data
+    workspace.borrow(n) { y ->
+        for (j in 0 until n) {
+            y.fill(0.0, j, n)
+            y[j] = 1.0
+            for (c in j until n) {
+                val base = c + c * n
+                val yc = y[c] / ld[base]
+                y[c] = yc
+                if (yc != 0.0) kernels.axpy(y, c + 1, -yc, ld, base + 1, n - c - 1)
+            }
+            for (i in n - 1 downTo j) {
+                val base = i + i * n
+                y[i] = (y[i] - kernels.dot(ld, base + 1, y, i + 1, n - i - 1)) / ld[base]
+            }
+            for (i in j until n) {
+                invd[i + j * n] = y[i]
+                invd[j + i * n] = y[i]
+            }
+        }
+    }
+    return out
+}
+
+internal fun F64DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): F64DenseMatrix =
+    choleskyInto(F64DenseMatrix.zero(rows, cols), policy)
+
+internal fun F64DenseMatrix.choleskyInto(
+    out: F64DenseMatrix,
+    policy: CholeskyPolicy = CholeskyPolicy.Strict,
+): F64DenseMatrix {
+    require(rows == cols) { "cholesky requires a square matrix" }
+    require(out.rows == rows && out.cols == rows) { "cholesky destination must be ${rows}x$rows" }
+    val n = rows
+    val kernels = koblas.kernels
+    val ld = out.data
     // A reused destination arrives holding the previous factor where a fresh one arrives zeroed, so the
     // strict upper triangle is cleared rather than inherited.
     for (j in 0 until n) {
         ld.fill(0.0, j * n, j * n + j)
-        a.data.copyInto(ld, j + j * n, j + j * n, (j + 1) * n)
+        if (data !== ld) data.copyInto(ld, j + j * n, j + j * n, (j + 1) * n)
     }
     // Left-looking blocked Cholesky. Each block column first takes what every earlier block owes it as one
     // level-3 product, then finishes column by column against the few columns inside the block. Gathering
@@ -100,7 +133,6 @@ private fun referenceCholeskyInto(
     // One pack buffer for the whole factorization rather than one per block column. The seam takes no
     // workspace, and a matrix that fits in a single block never gathers at all.
     val packed = if (n > CHOLESKY_BLOCK) DoubleArray(CHOLESKY_BLOCK * n) else null
-    out.regularizations = 0
     var blockStart = 0
     while (blockStart < n) {
         val width = min(CHOLESKY_BLOCK, n - blockStart)
@@ -108,7 +140,7 @@ private fun referenceCholeskyInto(
         if (blockStart > 0) {
             gatherEarlierBlocks(kernels, ld, n, blockStart, width, height, packed!!)
         }
-        out.regularizations += factorBlockColumn(kernels, ld, n, blockStart, width, policy)
+        factorBlockColumn(kernels, ld, n, blockStart, width, policy)
         blockStart += width
     }
     return out
@@ -166,8 +198,7 @@ private fun factorBlockColumn(
     start: Int,
     width: Int,
     policy: CholeskyPolicy,
-): Int {
-    var regularized = 0
+) {
     for (j in start until start + width) {
         val base = j + j * n
         val len = n - j
@@ -194,14 +225,12 @@ private fun factorBlockColumn(
             ld[base] = sqrt(pivot)
         } else if (pivot < floor) {
             ld[base] = sqrt(regularizedPivot(ld, base, len, floor))
-            regularized++
         } else {
             ld[base] = sqrt(pivot)
         }
         val diag = ld[base]
         for (i in base + 1 until base + len) ld[i] = ld[i] / diag
     }
-    return regularized
 }
 
 // Bounding the column multipliers by one avoids amplifying the trailing matrix by 1/floor.
@@ -212,69 +241,4 @@ private fun regularizedPivot(ld: DoubleArray, base: Int, len: Int, floor: Double
         if (magnitude > largest) largest = magnitude
     }
     return maxOf(floor, largest * largest)
-}
-
-private fun referenceSpdInvert(
-    kernels: F64Kernels,
-    chol: CholeskyFactor,
-    out: F64DenseMatrix,
-    workspace: Workspace?,
-): F64DenseMatrix {
-    val n = chol.n
-    val ld = chol.l.data
-    val invd = out.data
-    workspace.borrow(n) { y ->
-        for (j in 0 until n) {
-            y.fill(0.0, j, n)
-            y[j] = 1.0
-            for (c in j until n) {
-                val base = c + c * n
-                val yc = y[c] / ld[base]
-                y[c] = yc
-                if (yc != 0.0) kernels.axpy(y, c + 1, -yc, ld, base + 1, n - c - 1)
-            }
-            for (i in n - 1 downTo j) {
-                val base = i + i * n
-                y[i] = (y[i] - kernels.dot(ld, base + 1, y, i + 1, n - i - 1)) / ld[base]
-            }
-            for (i in j until n) {
-                invd[i + j * n] = y[i]
-                invd[j + i * n] = y[i]
-            }
-        }
-    }
-    return out
-}
-
-private fun referenceCholeskyRankUpdate(
-    kernels: F64Kernels,
-    chol: CholeskyFactor,
-    v: DoubleArray,
-    sigma: Double,
-    workspace: Workspace?,
-): CholeskyFactor {
-    val n = chol.n
-    if (n == 0 || sigma == 0.0) return chol
-    val ld = chol.l.data
-    val scale = sqrt(sigma)
-    workspace.borrow(n) { x ->
-        v.copyInto(x)
-        if (scale != 1.0) kernels.scale(x, 0, scale, n)
-        for (k in 0 until n) {
-            val base = k + k * n
-            val diagonal = ld[base]
-            // Inline the rotation to avoid allocating a Givens object per coordinate. A positive
-            // hypot keeps the factor diagonal non-negative and avoids squaring overflow or underflow.
-            val entry = x[k]
-            val r = hypot(diagonal, entry)
-            if (r != 0.0) {
-                ld[base] = r
-                val len = n - k - 1
-                // Two divisions rather than a reciprocal and two multiplies: this rotation sets the
-                // factor's numerical quality, and an extra rounding per entry compounds across n of them.
-                if (len > 0) kernels.rot(ld, base + 1, x, k + 1, len, diagonal / r, entry / r)
-            }
-        }
-    }
-    return chol
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -1,0 +1,280 @@
+@file:Suppress("VariableNaming", "FunctionParameterNaming")
+
+package com.eignex.kumulant.math
+
+import com.eignex.koblas.Workspace
+import com.eignex.koblas.borrow
+import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.dense.F64Kernels
+import com.eignex.koblas.dense.trsv
+import com.eignex.koblas.koblas
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.min
+import kotlin.math.sqrt
+
+// Adapted from Eignex/koblas ReferenceCholesky.kt and ReferenceLevel3.kt at cfdef98439f7baff0febc7a0892f16734bf55315.
+// Apache-2.0; module-internal API and a Cholesky-only specialization of the blocked product.
+private const val CHOLESKY_BLOCK = 64
+private const val PRODUCT_ROWS = 256
+private const val PRODUCT_COLUMNS = 8
+private const val PRODUCT_DEPTH = 128
+
+internal sealed interface CholeskyPolicy {
+    data object Strict : CholeskyPolicy
+
+    data class Regularize(val minimumPivot: Double = 1e-10) : CholeskyPolicy {
+        init {
+            require(minimumPivot > 0.0 && minimumPivot.isFinite()) {
+                "minimumPivot must be positive and finite, got $minimumPivot"
+            }
+        }
+    }
+}
+
+internal class NotPositiveDefinite(val pivotIndex: Int, val pivot: Double, message: String) :
+    IllegalArgumentException(message)
+
+internal class CholeskyFactor(val l: F64DenseMatrix) {
+    init {
+        require(l.rows == l.cols) { "cholesky factor must be square" }
+    }
+
+    val n: Int get() = l.rows
+    var regularizations: Int = 0
+
+    fun rankUpdate(v: DoubleArray, sigma: Double, workspace: Workspace? = null): CholeskyFactor {
+        require(v.size == n) { "update vector has ${v.size} entries, expected $n" }
+        require(sigma >= 0.0 && sigma.isFinite()) { "sigma must be non-negative and finite, got $sigma" }
+        return referenceCholeskyRankUpdate(koblas.kernels, this, v, sigma, workspace)
+    }
+
+    fun solveInto(b: DoubleArray, out: DoubleArray): DoubleArray {
+        require(b.size == n && out.size == n) { "solve requires vectors of size $n" }
+        if (out !== b) b.copyInto(out)
+        l.trsv(out, lower = true)
+        l.trsv(out, lower = true, transpose = true)
+        return out
+    }
+
+    fun invert(workspace: Workspace? = null): F64DenseMatrix = invertInto(F64DenseMatrix.zero(n, n), workspace)
+
+    fun invertInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix {
+        require(out.rows == n && out.cols == n) { "inverse destination must be ${n}x$n" }
+        require(out.data !== l.data) { "inverse destination must not share the factor's storage" }
+        return referenceSpdInvert(koblas.kernels, this, out, workspace)
+    }
+}
+
+internal fun F64DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): CholeskyFactor =
+    referenceCholesky(koblas.kernels, this, policy)
+
+private fun referenceCholesky(kernels: F64Kernels, a: F64DenseMatrix, policy: CholeskyPolicy): CholeskyFactor =
+    referenceCholeskyInto(
+        kernels,
+        a,
+        CholeskyFactor(F64DenseMatrix.zero(a.rows, a.rows)),
+        policy,
+    )
+
+private fun referenceCholeskyInto(
+    kernels: F64Kernels,
+    a: F64DenseMatrix,
+    out: CholeskyFactor,
+    policy: CholeskyPolicy,
+): CholeskyFactor {
+    require(a.rows == a.cols) { "cholesky requires a square matrix" }
+    require(out.n == a.rows) { "choleskyInto: out is ${out.n}x${out.n}, expected ${a.rows}x${a.rows}" }
+    val n = a.rows
+    val ld = out.l.data
+    // A reused destination arrives holding the previous factor where a fresh one arrives zeroed, so the
+    // strict upper triangle is cleared rather than inherited.
+    for (j in 0 until n) {
+        ld.fill(0.0, j * n, j * n + j)
+        a.data.copyInto(ld, j + j * n, j + j * n, (j + 1) * n)
+    }
+    // Left-looking blocked Cholesky. Each block column first takes what every earlier block owes it as one
+    // level-3 product, then finishes column by column against the few columns inside the block. Gathering
+    // one column at a time instead is a level-1 axpy per (column, earlier column) pair, which streams
+    // n^3/6 doubles for n^3/3 flops and leaves the factorization bandwidth-bound.
+    // One pack buffer for the whole factorization rather than one per block column. The seam takes no
+    // workspace, and a matrix that fits in a single block never gathers at all.
+    val packed = if (n > CHOLESKY_BLOCK) DoubleArray(CHOLESKY_BLOCK * n) else null
+    out.regularizations = 0
+    var blockStart = 0
+    while (blockStart < n) {
+        val width = min(CHOLESKY_BLOCK, n - blockStart)
+        val height = n - blockStart
+        if (blockStart > 0) {
+            gatherEarlierBlocks(kernels, ld, n, blockStart, width, height, packed!!)
+        }
+        out.regularizations += factorBlockColumn(kernels, ld, n, blockStart, width, policy)
+        blockStart += width
+    }
+    return out
+}
+
+@Suppress("LongParameterList") // the factor, its shape, the block being gathered into, and scratch
+private fun gatherEarlierBlocks(
+    kernels: F64Kernels,
+    ld: DoubleArray,
+    n: Int,
+    start: Int,
+    width: Int,
+    height: Int,
+    packed: DoubleArray,
+) {
+    for (t in 0 until width) {
+        for (p in 0 until start) packed[p + t * start] = ld[start + t + p * n]
+    }
+    var column = 0
+    while (column < width) {
+        val columnEnd = min(column + PRODUCT_COLUMNS, width)
+        var inner = 0
+        while (inner < start) {
+            val innerEnd = min(inner + PRODUCT_DEPTH, start)
+            var row = 0
+            while (row < height) {
+                val length = min(row + PRODUCT_ROWS, height) - row
+                for (p in inner until innerEnd) {
+                    val source = start + row + p * n
+                    for (j in column until columnEnd) {
+                        val value = packed[p + j * start]
+                        if (value != 0.0) {
+                            kernels.axpy(ld, start + start * n + row + j * n, -value, ld, source, length)
+                        }
+                    }
+                }
+                row += length
+            }
+            inner = innerEnd
+        }
+        column = columnEnd
+    }
+    // The product covers the whole diagonal block, including the strict upper half of it that the column
+    // sweep neither writes nor reads. Left there it would surface as a nonzero above the factor's diagonal.
+    for (t in 1 until width) {
+        val column = start + t
+        ld.fill(0.0, start + column * n, column + column * n)
+    }
+}
+
+private fun factorBlockColumn(
+    kernels: F64Kernels,
+    ld: DoubleArray,
+    n: Int,
+    start: Int,
+    width: Int,
+    policy: CholeskyPolicy,
+): Int {
+    var regularized = 0
+    for (j in start until start + width) {
+        val base = j + j * n
+        val len = n - j
+        for (p in start until j) {
+            val f = ld[j + p * n]
+            if (f != 0.0) kernels.axpy(ld, base, -f, ld, j + p * n, len)
+        }
+        val pivot = ld[base]
+        // A NaN is corrupt input, not indefiniteness, and no floor repairs it: the tail stays NaN while the
+        // diagonal reads clean, so a finite diagonal would conceal the corruption. Refused under every policy.
+        if (pivot.isNaN()) {
+            throw NotPositiveDefinite(j, pivot, "matrix has a NaN pivot at $j, so it cannot be factored")
+        }
+        val floor = (policy as? CholeskyPolicy.Regularize)?.minimumPivot
+        if (floor == null) {
+            if (pivot <= 0.0) {
+                throw NotPositiveDefinite(
+                    j,
+                    pivot,
+                    "matrix is not positive-definite at pivot $j (diagonal=$pivot); pass " +
+                        "CholeskyPolicy.Regularize to factor a nearby matrix instead",
+                )
+            }
+            ld[base] = sqrt(pivot)
+        } else if (pivot < floor) {
+            ld[base] = sqrt(regularizedPivot(ld, base, len, floor))
+            regularized++
+        } else {
+            ld[base] = sqrt(pivot)
+        }
+        val diag = ld[base]
+        for (i in base + 1 until base + len) ld[i] = ld[i] / diag
+    }
+    return regularized
+}
+
+// Bounding the column multipliers by one avoids amplifying the trailing matrix by 1/floor.
+private fun regularizedPivot(ld: DoubleArray, base: Int, len: Int, floor: Double): Double {
+    var largest = 0.0
+    for (i in base + 1 until base + len) {
+        val magnitude = abs(ld[i])
+        if (magnitude > largest) largest = magnitude
+    }
+    return maxOf(floor, largest * largest)
+}
+
+private fun referenceSpdInvert(
+    kernels: F64Kernels,
+    chol: CholeskyFactor,
+    out: F64DenseMatrix,
+    workspace: Workspace?,
+): F64DenseMatrix {
+    val n = chol.n
+    val ld = chol.l.data
+    val invd = out.data
+    workspace.borrow(n) { y ->
+        for (j in 0 until n) {
+            y.fill(0.0, j, n)
+            y[j] = 1.0
+            for (c in j until n) {
+                val base = c + c * n
+                val yc = y[c] / ld[base]
+                y[c] = yc
+                if (yc != 0.0) kernels.axpy(y, c + 1, -yc, ld, base + 1, n - c - 1)
+            }
+            for (i in n - 1 downTo j) {
+                val base = i + i * n
+                y[i] = (y[i] - kernels.dot(ld, base + 1, y, i + 1, n - i - 1)) / ld[base]
+            }
+            for (i in j until n) {
+                invd[i + j * n] = y[i]
+                invd[j + i * n] = y[i]
+            }
+        }
+    }
+    return out
+}
+
+private fun referenceCholeskyRankUpdate(
+    kernels: F64Kernels,
+    chol: CholeskyFactor,
+    v: DoubleArray,
+    sigma: Double,
+    workspace: Workspace?,
+): CholeskyFactor {
+    val n = chol.n
+    if (n == 0 || sigma == 0.0) return chol
+    val ld = chol.l.data
+    val scale = sqrt(sigma)
+    workspace.borrow(n) { x ->
+        v.copyInto(x)
+        if (scale != 1.0) kernels.scale(x, 0, scale, n)
+        for (k in 0 until n) {
+            val base = k + k * n
+            val diagonal = ld[base]
+            // Inline the rotation to avoid allocating a Givens object per coordinate. A positive
+            // hypot keeps the factor diagonal non-negative and avoids squaring overflow or underflow.
+            val entry = x[k]
+            val r = hypot(diagonal, entry)
+            if (r != 0.0) {
+                ld[base] = r
+                val len = n - k - 1
+                // Two divisions rather than a reciprocal and two multiplies: this rotation sets the
+                // factor's numerical quality, and an extra rounding per entry compounds across n of them.
+                if (len > 0) kernels.rot(ld, base + 1, x, k + 1, len, diagonal / r, entry / r)
+            }
+        }
+    }
+    return chol
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -4,7 +4,6 @@
 
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.NotPositiveDefinite
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.axpy
 import com.eignex.koblas.borrow
@@ -13,11 +12,6 @@ import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64MatrixLike
 import com.eignex.koblas.core.F64VectorLike
-import com.eignex.koblas.dense.CholeskyPolicy
-import com.eignex.koblas.dense.F64CholeskyDecomposition
-import com.eignex.koblas.dense.cholesky
-import com.eignex.koblas.dense.invert
-import com.eignex.koblas.dense.rankUpdate
 import com.eignex.koblas.dense.trmv
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.dot
@@ -30,6 +24,10 @@ import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requireMergeFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
+import com.eignex.kumulant.math.CholeskyFactor
+import com.eignex.kumulant.math.CholeskyPolicy
+import com.eignex.kumulant.math.NotPositiveDefinite
+import com.eignex.kumulant.math.cholesky
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
@@ -150,7 +148,7 @@ class BayesianRegressionStat(
     // The rank-1 update takes a decomposition rather than a bare factor. It wraps `precisionL`
     // without copying and every write goes through that same matrix, so one wrapper serves the
     // life of the stat and no update allocates to build one.
-    private val precisionFactor = F64CholeskyDecomposition(precisionL)
+    private val precisionFactor = CholeskyFactor(precisionL)
     private var bias: Double = 0.0
     private var biasPrecision: Double = 1.0 / priorVariance
     private var totalWeights: Double = 0.0
@@ -278,7 +276,7 @@ class BayesianRegressionStat(
 
                 // Solve H_new * mu_new = b via chol(H_new); that factor is the merged state.
                 val hChol = hNew.cholesky(CholeskyPolicy.Regularize())
-                koblas.solveInto(hChol, b, b)
+                hChol.solveInto(b, b)
                 val lNew = hChol.l.also { it.zeroStrictUpper() }
 
                 for (i in 0 until n) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -13,21 +13,22 @@ import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64MatrixLike
 import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dense.trmv
-import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.dot
 import com.eignex.koblas.koblas
 import com.eignex.koblas.syr
-import com.eignex.koblas.zeroStrictUpper
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
 import com.eignex.kumulant.core.requireFeatureSize
 import com.eignex.kumulant.core.requireMergeFeatureSize
 import com.eignex.kumulant.core.requirePositiveFeatureSize
-import com.eignex.kumulant.math.CholeskyFactor
 import com.eignex.kumulant.math.CholeskyPolicy
 import com.eignex.kumulant.math.NotPositiveDefinite
 import com.eignex.kumulant.math.cholesky
+import com.eignex.kumulant.math.choleskyInto
+import com.eignex.kumulant.math.choleskyInverse
+import com.eignex.kumulant.math.choleskyRankUpdate
+import com.eignex.kumulant.math.choleskySolveInto
 import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
@@ -129,8 +130,8 @@ class BayesianRegressionStat(
         // Both factorizations are strict: a caller prior that cannot be inverted has to fail at
         // construction, not silently become a regularised neighbour of itself.
         try {
-            priorPrecisionMatrix = initialCovariance.cholesky(CholeskyPolicy.Strict).invert()
-            initialPrecisionL = priorPrecisionMatrix.cholesky(CholeskyPolicy.Strict).l.also { it.zeroStrictUpper() }
+            priorPrecisionMatrix = initialCovariance.cholesky(CholeskyPolicy.Strict).choleskyInverse()
+            initialPrecisionL = priorPrecisionMatrix.cholesky(CholeskyPolicy.Strict)
         } catch (error: NotPositiveDefinite) {
             throw IllegalArgumentException("priorCovariance must be positive definite", error)
         }
@@ -145,10 +146,6 @@ class BayesianRegressionStat(
     private val weights = F64DenseVector.wrap(initialWeights.copyOf())
     private val precisionL = F64DenseMatrix.wrap(featureSize, featureSize, initialPrecisionL.data.copyOf())
 
-    // The rank-1 update takes a decomposition rather than a bare factor. It wraps `precisionL`
-    // without copying and every write goes through that same matrix, so one wrapper serves the
-    // life of the stat and no update allocates to build one.
-    private val precisionFactor = CholeskyFactor(precisionL)
     private var bias: Double = 0.0
     private var biasPrecision: Double = 1.0 / priorVariance
     private var totalWeights: Double = 0.0
@@ -194,12 +191,11 @@ class BayesianRegressionStat(
                 copy(x, solved)
 
                 // H <- H + w_c * x xT, as a rank-1 update of its factor; a zero w_c leaves it alone.
-                if (wc > 0.0) precisionFactor.rankUpdate(hx, wc, workspace)
+                if (wc > 0.0) precisionL.choleskyRankUpdate(hx, wc, workspace)
 
                 // Posterior mean update: w += (weight * residual) * H_new^-1 * x, solved against
                 // the factor just updated rather than through a materialised covariance.
-                precisionL.trsv(hx, lower = true)
-                precisionL.trsv(hx, lower = true, transpose = true)
+                precisionL.choleskySolveInto(hx, hx)
                 weights.axpy(weight * residual, solved)
 
                 biasPrecision += wc
@@ -252,8 +248,8 @@ class BayesianRegressionStat(
 
             // H_new = H_self + H_other - H_prior, accumulated in the lower triangle, which is the
             // only one the Cholesky below reads. `syrk` takes each factor as a general matrix, so
-            // it depends on the strict upper triangle being zero, which is what `precisionL`
-            // promises and what `zeroStrictUpper` keeps true on every write to it.
+            // it depends on the strict upper triangle being zero. Factorization clears it, and
+            // rank-1 updates preserve it.
             val hNew = F64DenseMatrix.zero(n, n)
             koblas.syrk(1.0, precisionL, transpose = false, 0.0, hNew, lower = true, workspace = workspace)
             koblas.syrk(1.0, values.precisionL, transpose = false, 1.0, hNew, lower = true, workspace = workspace)
@@ -275,13 +271,12 @@ class BayesianRegressionStat(
                 }
 
                 // Solve H_new * mu_new = b via chol(H_new); that factor is the merged state.
-                val hChol = hNew.cholesky(CholeskyPolicy.Regularize())
-                hChol.solveInto(b, b)
-                val lNew = hChol.l.also { it.zeroStrictUpper() }
+                hNew.choleskyInto(hNew, CholeskyPolicy.Regularize())
+                hNew.choleskySolveInto(b, b)
 
                 for (i in 0 until n) {
                     weights[i] = b[i]
-                    for (j in 0 until n) precisionL[i, j] = lNew[i, j]
+                    for (j in 0 until n) precisionL[i, j] = hNew[i, j]
                 }
             }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -9,7 +9,8 @@ import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.requireFeatureSize
-import com.eignex.kumulant.math.CholeskyFactor
+import com.eignex.kumulant.math.choleskyInverse
+import com.eignex.kumulant.math.choleskyInvertInto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -133,7 +134,7 @@ data class PrecisionRegressionResult(
      * matrix per call, so it belongs in reporting and prior fitting; scoring paths should stay on
      * the factor.
      */
-    fun covariance(workspace: Workspace? = null): F64DenseMatrix = CholeskyFactor(precisionL).invert(workspace)
+    fun covariance(workspace: Workspace? = null): F64DenseMatrix = precisionL.choleskyInverse(workspace)
 
     /**
      * Posterior covariance into [out], which is returned. Every entry is written, so a buffer
@@ -141,5 +142,5 @@ data class PrecisionRegressionResult(
      * rather than the work. [out] must not be [precisionL] itself.
      */
     fun covarianceInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix =
-        CholeskyFactor(precisionL).invertInto(out, workspace)
+        precisionL.choleskyInvertInto(out, workspace)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -1,19 +1,15 @@
-@file:OptIn(com.eignex.koblas.UnsafeKoblasApi::class)
-
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.core.F64DenseMatrix
 import com.eignex.koblas.core.F64DenseVector
 import com.eignex.koblas.core.F64VectorLike
-import com.eignex.koblas.dense.F64CholeskyDecomposition
-import com.eignex.koblas.dense.invert
-import com.eignex.koblas.dense.invertInto
 import com.eignex.koblas.dot
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.requireFeatureSize
+import com.eignex.kumulant.math.CholeskyFactor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -137,8 +133,7 @@ data class PrecisionRegressionResult(
      * matrix per call, so it belongs in reporting and prior fitting; scoring paths should stay on
      * the factor.
      */
-    fun covariance(workspace: Workspace? = null): F64DenseMatrix =
-        F64CholeskyDecomposition(precisionL).invert(workspace)
+    fun covariance(workspace: Workspace? = null): F64DenseMatrix = CholeskyFactor(precisionL).invert(workspace)
 
     /**
      * Posterior covariance into [out], which is returned. Every entry is written, so a buffer
@@ -146,5 +141,5 @@ data class PrecisionRegressionResult(
      * rather than the work. [out] must not be [precisionL] itself.
      */
     fun covarianceInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix =
-        F64CholeskyDecomposition(precisionL).invertInto(out, workspace)
+        CholeskyFactor(precisionL).invertInto(out, workspace)
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,0 +1,164 @@
+package com.eignex.kumulant.math
+
+import com.eignex.koblas.Workspace
+import com.eignex.koblas.core.F64DenseMatrix
+import kotlin.math.abs
+import kotlin.math.min
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CholeskyTest {
+    @Test
+    fun `factorization recovers a known factor across block boundaries`() {
+        for (n in listOf(0, 1, 63, 64, 65, 129, 193, 321)) {
+            val tail = 1.0 / (n + 1)
+            val a = F64DenseMatrix.wrap(
+                n, n,
+                DoubleArray(n * n) { index ->
+                val i = index % n
+                val j = index / n
+                if (i < j) Double.NaN else min(i, j) * tail * tail + if (i == j) 4.0 else 2.0 * tail
+            }
+            )
+            val original = a.data.copyOf()
+
+            val factor = a.cholesky()
+
+            var maxError = 0.0
+            for (j in 0 until n) {
+                for (i in 0 until n) {
+                    val expected = if (i < j) 0.0 else if (i == j) {
+                        2.0
+                    } else {
+                        tail
+                    }
+                    maxError = maxOf(maxError, abs(expected - factor.l[i, j]))
+                }
+            }
+            assertTrue(maxError < 1e-12, "n=$n factor error=$maxError")
+            assertContentEquals(original, a.data)
+        }
+    }
+
+    @Test
+    fun `strict factorization rejects the first non-positive pivot`() {
+        for (diagonal in listOf(0.0, -1.0)) {
+            val a = F64DenseMatrix.wrap(2, 2, doubleArrayOf(1.0, 0.0, 0.0, diagonal))
+
+            val error = assertFailsWith<NotPositiveDefinite> { a.cholesky() }
+
+            assertEquals(1, error.pivotIndex)
+            assertEquals(diagonal, error.pivot)
+        }
+    }
+
+    @Test
+    fun `every policy rejects NaN pivots`() {
+        for (policy in listOf(CholeskyPolicy.Strict, CholeskyPolicy.Regularize())) {
+            val a = F64DenseMatrix.wrap(1, 1, doubleArrayOf(Double.NaN))
+
+            assertFailsWith<NotPositiveDefinite> { a.cholesky(policy) }
+        }
+    }
+
+    @Test
+    fun `regularization bounds the column below a small pivot`() {
+        for (pivot in listOf(-1.0, 0.0, 1e-12)) {
+            val a = F64DenseMatrix.wrap(2, 2, doubleArrayOf(pivot, 3.0, 3.0, 2.0))
+
+            val factor = a.cholesky(CholeskyPolicy.Regularize())
+
+            assertContentEquals(doubleArrayOf(3.0, 1.0, 0.0, 1.0), factor.l.data)
+            assertEquals(1, factor.regularizations)
+        }
+    }
+
+    @Test
+    fun `regularization floors a small uncoupled pivot`() {
+        val a = F64DenseMatrix.wrap(1, 1, doubleArrayOf(1e-12))
+
+        val factor = a.cholesky(CholeskyPolicy.Regularize())
+
+        assertEquals(sqrt(1e-10), factor.l[0, 0])
+    }
+
+    @Test
+    fun `rank one update represents the weighted outer product without changing its input`() {
+        for (workspace in listOf(null, Workspace().apply { reserve(3, 2) })) {
+            val factor = F64DenseMatrix.diagonal(3, 2.0).cholesky()
+            val v = doubleArrayOf(1.0, -2.0, 3.0)
+
+            factor.rankUpdate(v, 4.0, workspace)
+
+            for (i in 0 until 3) {
+                for (j in 0 until 3) {
+                    var actual = 0.0
+                    for (k in 0 until 3) actual += factor.l[i, k] * factor.l[j, k]
+                    val expected = (if (i == j) 2.0 else 0.0) + 4.0 * v[i] * v[j]
+                    assertEquals(expected, actual, 1e-12)
+                }
+            }
+            assertContentEquals(doubleArrayOf(1.0, -2.0, 3.0), v)
+        }
+    }
+
+    @Test
+    fun `zero rank update leaves the factor untouched`() {
+        val factor = F64DenseMatrix.diagonal(2, 2.0).cholesky()
+        val original = factor.l.data.copyOf()
+
+        factor.rankUpdate(doubleArrayOf(Double.NaN, Double.NaN), 0.0)
+
+        assertContentEquals(original, factor.l.data)
+    }
+
+    @Test
+    fun `rank update avoids squaring overflow and underflow`() {
+        for (magnitude in listOf(1e-200, 1e200)) {
+            val factor = CholeskyFactor(F64DenseMatrix.wrap(1, 1, doubleArrayOf(magnitude)))
+
+            factor.rankUpdate(doubleArrayOf(-magnitude), 1.0)
+
+            assertTrue(factor.l[0, 0].isFinite())
+            assertEquals(sqrt(2.0), factor.l[0, 0] / magnitude, 1e-14)
+        }
+    }
+
+    @Test
+    fun `solve allows the destination to be the right hand side`() {
+        val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+        val b = doubleArrayOf(8.0, 12.0)
+
+        factor.solveInto(b, b)
+
+        assertContentEquals(doubleArrayOf(1.0, 2.0), b)
+    }
+
+    @Test
+    fun `inverse overwrites both triangles and preserves the factor with reused scratch`() {
+        for (workspace in listOf(null, Workspace().apply { reserve(2, 1) })) {
+            val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+            val original = factor.l.data.copyOf()
+            val out = F64DenseMatrix.wrap(2, 2, DoubleArray(4) { Double.NaN })
+
+            repeat(2) { factor.invertInto(out, workspace) }
+
+            assertContentEquals(doubleArrayOf(0.3125, -0.125, -0.125, 0.25), out.data)
+            assertContentEquals(original, factor.l.data)
+        }
+    }
+
+    @Test
+    fun `inverse rejects a destination sharing factor storage`() {
+        val factor = F64DenseMatrix.diagonal(2, 1.0).cholesky()
+        val alias = F64DenseMatrix.wrap(2, 2, factor.l.data)
+
+        assertFailsWith<IllegalArgumentException> { factor.invertInto(alias) }
+
+        assertContentEquals(doubleArrayOf(1.0, 0.0, 0.0, 1.0), factor.l.data)
+    }
+}

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class CholeskyTest {
@@ -17,12 +18,13 @@ class CholeskyTest {
         for (n in listOf(0, 1, 63, 64, 65, 129, 193, 321)) {
             val tail = 1.0 / (n + 1)
             val a = F64DenseMatrix.wrap(
-                n, n,
+                n,
+                n,
                 DoubleArray(n * n) { index ->
-                val i = index % n
-                val j = index / n
-                if (i < j) Double.NaN else min(i, j) * tail * tail + if (i == j) 4.0 else 2.0 * tail
-            }
+                    val i = index % n
+                    val j = index / n
+                    if (i < j) Double.NaN else min(i, j) * tail * tail + if (i == j) 4.0 else 2.0 * tail
+                },
             )
             val original = a.data.copyOf()
 
@@ -31,16 +33,69 @@ class CholeskyTest {
             var maxError = 0.0
             for (j in 0 until n) {
                 for (i in 0 until n) {
-                    val expected = if (i < j) 0.0 else if (i == j) {
+                    val expected = if (i < j) {
+                        0.0
+                    } else if (i == j) {
                         2.0
                     } else {
                         tail
                     }
-                    maxError = maxOf(maxError, abs(expected - factor.l[i, j]))
+                    maxError = maxOf(maxError, abs(expected - factor[i, j]))
                 }
             }
             assertTrue(maxError < 1e-12, "n=$n factor error=$maxError")
             assertContentEquals(original, a.data)
+        }
+    }
+
+    @Test
+    fun `factorization overwrites a reused destination without changing its input`() {
+        val a = F64DenseMatrix.diagonal(65, 4.0)
+        a[64, 0] = 2.0
+        a[64, 64] = 5.0
+        val original = a.data.copyOf()
+        val out = F64DenseMatrix.wrap(65, 65, DoubleArray(65 * 65) { Double.NaN })
+
+        repeat(2) {
+            val factor = a.choleskyInto(out)
+
+            assertSame(out, factor)
+            for (j in 0 until 65) {
+                for (i in 0 until 65) {
+                    val expected = if (i == j) 2.0 else if (i == 64 && j == 0) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                    assertEquals(expected, out[i, j])
+                }
+            }
+            assertContentEquals(original, a.data)
+        }
+    }
+
+    @Test
+    fun `factorization allows the destination to share input storage`() {
+        for (sameMatrix in listOf(true, false)) {
+            val a = F64DenseMatrix.diagonal(65, 4.0)
+            a[64, 0] = 2.0
+            a[64, 64] = 5.0
+            for (j in 0 until 65) for (i in 0 until j) a[i, j] = Double.NaN
+            val out = if (sameMatrix) a else F64DenseMatrix.wrap(65, 65, a.data)
+
+            val factor = a.choleskyInto(out)
+
+            assertSame(out, factor)
+            for (j in 0 until 65) {
+                for (i in 0 until 65) {
+                    val expected = if (i == j) 2.0 else if (i == 64 && j == 0) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                    assertEquals(expected, factor[i, j])
+                }
+            }
         }
     }
 
@@ -72,8 +127,7 @@ class CholeskyTest {
 
             val factor = a.cholesky(CholeskyPolicy.Regularize())
 
-            assertContentEquals(doubleArrayOf(3.0, 1.0, 0.0, 1.0), factor.l.data)
-            assertEquals(1, factor.regularizations)
+            assertContentEquals(doubleArrayOf(3.0, 1.0, 0.0, 1.0), factor.data)
         }
     }
 
@@ -83,7 +137,7 @@ class CholeskyTest {
 
         val factor = a.cholesky(CholeskyPolicy.Regularize())
 
-        assertEquals(sqrt(1e-10), factor.l[0, 0])
+        assertEquals(sqrt(1e-10), factor[0, 0])
     }
 
     @Test
@@ -92,12 +146,12 @@ class CholeskyTest {
             val factor = F64DenseMatrix.diagonal(3, 2.0).cholesky()
             val v = doubleArrayOf(1.0, -2.0, 3.0)
 
-            factor.rankUpdate(v, 4.0, workspace)
+            factor.choleskyRankUpdate(v, 4.0, workspace)
 
             for (i in 0 until 3) {
                 for (j in 0 until 3) {
                     var actual = 0.0
-                    for (k in 0 until 3) actual += factor.l[i, k] * factor.l[j, k]
+                    for (k in 0 until 3) actual += factor[i, k] * factor[j, k]
                     val expected = (if (i == j) 2.0 else 0.0) + 4.0 * v[i] * v[j]
                     assertEquals(expected, actual, 1e-12)
                 }
@@ -109,22 +163,22 @@ class CholeskyTest {
     @Test
     fun `zero rank update leaves the factor untouched`() {
         val factor = F64DenseMatrix.diagonal(2, 2.0).cholesky()
-        val original = factor.l.data.copyOf()
+        val original = factor.data.copyOf()
 
-        factor.rankUpdate(doubleArrayOf(Double.NaN, Double.NaN), 0.0)
+        factor.choleskyRankUpdate(doubleArrayOf(Double.NaN, Double.NaN), 0.0)
 
-        assertContentEquals(original, factor.l.data)
+        assertContentEquals(original, factor.data)
     }
 
     @Test
     fun `rank update avoids squaring overflow and underflow`() {
         for (magnitude in listOf(1e-200, 1e200)) {
-            val factor = CholeskyFactor(F64DenseMatrix.wrap(1, 1, doubleArrayOf(magnitude)))
+            val factor = F64DenseMatrix.wrap(1, 1, doubleArrayOf(magnitude))
 
-            factor.rankUpdate(doubleArrayOf(-magnitude), 1.0)
+            factor.choleskyRankUpdate(doubleArrayOf(-magnitude), 1.0)
 
-            assertTrue(factor.l[0, 0].isFinite())
-            assertEquals(sqrt(2.0), factor.l[0, 0] / magnitude, 1e-14)
+            assertTrue(factor[0, 0].isFinite())
+            assertEquals(sqrt(2.0), factor[0, 0] / magnitude, 1e-14)
         }
     }
 
@@ -133,32 +187,45 @@ class CholeskyTest {
         val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
         val b = doubleArrayOf(8.0, 12.0)
 
-        factor.solveInto(b, b)
+        factor.choleskySolveInto(b, b)
 
         assertContentEquals(doubleArrayOf(1.0, 2.0), b)
+    }
+
+    @Test
+    fun `solve into a separate destination preserves the right hand side`() {
+        val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+        val b = doubleArrayOf(8.0, 12.0)
+        val out = doubleArrayOf(Double.NaN, Double.NaN)
+
+        val solution = factor.choleskySolveInto(b, out)
+
+        assertSame(out, solution)
+        assertContentEquals(doubleArrayOf(1.0, 2.0), out)
+        assertContentEquals(doubleArrayOf(8.0, 12.0), b)
     }
 
     @Test
     fun `inverse overwrites both triangles and preserves the factor with reused scratch`() {
         for (workspace in listOf(null, Workspace().apply { reserve(2, 1) })) {
             val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
-            val original = factor.l.data.copyOf()
+            val original = factor.data.copyOf()
             val out = F64DenseMatrix.wrap(2, 2, DoubleArray(4) { Double.NaN })
 
-            repeat(2) { factor.invertInto(out, workspace) }
+            repeat(2) { factor.choleskyInvertInto(out, workspace) }
 
             assertContentEquals(doubleArrayOf(0.3125, -0.125, -0.125, 0.25), out.data)
-            assertContentEquals(original, factor.l.data)
+            assertContentEquals(original, factor.data)
         }
     }
 
     @Test
     fun `inverse rejects a destination sharing factor storage`() {
         val factor = F64DenseMatrix.diagonal(2, 1.0).cholesky()
-        val alias = F64DenseMatrix.wrap(2, 2, factor.l.data)
+        val alias = F64DenseMatrix.wrap(2, 2, factor.data)
 
-        assertFailsWith<IllegalArgumentException> { factor.invertInto(alias) }
+        assertFailsWith<IllegalArgumentException> { factor.choleskyInvertInto(alias) }
 
-        assertContentEquals(doubleArrayOf(1.0, 0.0, 0.0, 1.0), factor.l.data)
+        assertContentEquals(doubleArrayOf(1.0, 0.0, 0.0, 1.0), factor.data)
     }
 }


### PR DESCRIPTION
## What changed

- Move portable Cholesky factorization, regularization, rank-one updates, solves, and SPD inversion into module-internal kumulant functions operating directly on factor matrices.
- Switch Bayesian regression and covariance materialization to these functions while retaining koblas BLAS kernels. Remove the decomposition wrapper and unused regularization count.
- Factor the temporary merged precision matrix in place, eliminating an additional matrix allocation and copy.
- Cover block boundaries, invalid pivots, regularization, extreme magnitudes, reused destinations and workspaces, input/output aliasing, and input preservation.

## Why

Koblas will remove its decomposition APIs. Bayesian regression uses Cholesky during prior initialization, every observation update, posterior merging, and covariance reporting. Owning the portable routines removes those dependencies while preserving public signatures and serialized snapshots. The callers already own their factor matrices, so the private functions use that storage directly. This change establishes the portable implementation before the LAPACK-guided performance follow-up.

## Testing

`./gradlew check lintDocs --rerun-tasks` passed, including API compatibility, linting, documentation generation, 2,024 JVM tests, and 1,965 Linux Native tests. All 14 Cholesky tests passed; the slowest took 146 ms on the JVM.
