### PR TITLE
refactor: use koblas precision aliases

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BanditSpecs.kt
@@ -7,7 +7,7 @@ import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
 import com.eignex.kumulant.bandit.univariate.UCB1
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.MultivariateGaussian
 import com.eignex.kumulant.stat.regression.glm.PointPosterior
@@ -100,14 +100,14 @@ fun contextualBanditSpec(
     build = build,
     cycle = { bandit, oracle ->
         val ctx = sampleContext(oracle)
-        val x = F64DenseVector.of(ctx)
+        val x = DenseVector.of(ctx)
         val i = bandit.choose(x)
         val r = sampleReward(i, ctx, oracle)
         bandit.update(i, x, r)
     },
     regretCycle = { bandit, oracle, ref ->
         val ctx = sampleContext(oracle)
-        val x = F64DenseVector.of(ctx)
+        val x = DenseVector.of(ctx)
         val i = bandit.choose(x)
         val r = sampleReward(i, ctx, oracle)
         bandit.update(i, x, r)

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BayesianWorkspaceBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BayesianWorkspaceBenchmark.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bench
 
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult
 import kotlinx.benchmark.Benchmark
@@ -16,14 +16,14 @@ open class BayesianWorkspaceBenchmark {
     @Param("8", "32", "128", "512")
     var featureSize: Int = 8
 
-    private lateinit var x: F64DenseVector
+    private lateinit var x: DenseVector
     private lateinit var workspace: Workspace
     private lateinit var stat: BayesianRegressionStat
     private lateinit var mergeValue: PrecisionRegressionResult
 
     @Setup
     fun setup() {
-        x = F64DenseVector.of(DoubleArray(featureSize) { (it % 7 - 3) * 0.125 })
+        x = DenseVector.of(DoubleArray(featureSize) { (it % 7 - 3) * 0.125 })
         workspace = Workspace().apply { reserve(featureSize, count = 3) }
         stat = BayesianRegressionStat(featureSize)
         val other = BayesianRegressionStat(featureSize)

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Exp4MixingBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Exp4MixingBenchmark.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bench
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import kotlinx.benchmark.Benchmark
@@ -19,7 +19,7 @@ open class Exp4MixingBenchmark {
     lateinit var advice: String
 
     private lateinit var bandit: Exp4Bandit
-    private lateinit var x: F64DenseVector
+    private lateinit var x: DenseVector
     private lateinit var out: DoubleArray
     private var arm: Int = 0
 
@@ -31,7 +31,7 @@ open class Exp4MixingBenchmark {
             Exp4Expert { _, _ -> if (advice == "reusable") value else value.copyOf() }
         }
         bandit = Exp4Bandit(arms, expertPool, gamma = 0.1)
-        x = F64DenseVector.of(doubleArrayOf(1.0))
+        x = DenseVector.of(doubleArrayOf(1.0))
         out = DoubleArray(arms)
     }
 

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/Harness.kt
@@ -6,7 +6,7 @@ import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.SeriesStat
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.random.Random
 
 /** Single observation passed to a stat under test. */
@@ -119,7 +119,7 @@ fun <R : Result> regressionStatSpec(
             var y = bias
             var i = 0
             while (i < featureSize) { y += trueWeights[i] * x[i]; i++ }
-            s.update(F64DenseVector.of(x), y, u.timestampNanos, u.weight)
+            s.update(DenseVector.of(x), y, u.timestampNanos, u.weight)
         },
         readSnapshot = { s, ts -> s.read(ts) },
         merge = { s, r -> s.merge(r) },

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/OwnedStorageBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/OwnedStorageBenchmark.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bench
 
-import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
@@ -24,7 +24,7 @@ open class OwnedStorageBenchmark {
     private lateinit var diagonal: DiagonalRegressionStat
     private lateinit var bayesian: BayesianRegressionStat
     private lateinit var naiveBayes: GaussianNaiveBayesStat
-    private lateinit var sparse: F64SparseVector
+    private lateinit var sparse: SparseVector
     private lateinit var knn: KnnContextualBandit
 
     @Setup
@@ -35,7 +35,7 @@ open class OwnedStorageBenchmark {
         bayesian = BayesianRegressionStat(featureSize).also { it.update(x, 1.0) }
         naiveBayes = GaussianNaiveBayesStat(featureSize, 4).also { it.update(x, 0.0) }
         val nnz = (featureSize * densityPercent / 100).coerceAtLeast(1)
-        sparse = F64SparseVector.of(
+        sparse = SparseVector.of(
             featureSize,
             IntArray(nnz) { it * featureSize / nnz },
             DoubleArray(nnz) { it.toDouble() },

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.bench
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionResult
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
@@ -29,7 +29,7 @@ open class PredictionKernelBenchmark {
     @Param("1", "10", "100")
     var densityPercent: Int = 1
 
-    private lateinit var x: F64VectorLike
+    private lateinit var x: VectorLike
     private lateinit var linear: StochasticRegressionResult
     private lateinit var softmax: SoftmaxRegressionResult
     private lateinit var posterior: PrecisionRegressionResult
@@ -42,27 +42,27 @@ open class PredictionKernelBenchmark {
     fun setup() {
         val values = DoubleArray(featureSize) { i -> (i % 11 - 5) * 0.125 }
         val count = maxOf(1, featureSize * densityPercent / 100)
-        x = if (densityPercent == 100) F64DenseVector.of(values) else F64SparseVector.of(
+        x = if (densityPercent == 100) DenseVector.of(values) else SparseVector.of(
             featureSize,
             IntArray(count) { it * featureSize / count },
             DoubleArray(count) { values[it * featureSize / count] },
         )
-        val weights = F64DenseVector.of(DoubleArray(featureSize) { i -> (i % 7 - 3) * 0.2 })
+        val weights = DenseVector.of(DoubleArray(featureSize) { i -> (i % 7 - 3) * 0.2 })
         linear = StochasticRegressionResult(weights, 0.25, 0.0, 0L, Link.Identity)
         softmax = SoftmaxRegressionResult(
             featureSize,
             4,
-            F64DenseMatrix.of(Array(4) { k -> DoubleArray(featureSize) { i -> (k - i % 5) * 0.1 } }),
-            F64DenseVector.of(doubleArrayOf(-0.2, 0.0, 0.1, 0.3)),
+            DenseMatrix.of(Array(4) { k -> DoubleArray(featureSize) { i -> (k - i % 5) * 0.1 } }),
+            DenseVector.of(doubleArrayOf(-0.2, 0.0, 0.1, 0.3)),
             0.0,
             0L,
             0.0,
         )
-        val identity = F64DenseMatrix.diagonal(featureSize, 1.0)
+        val identity = DenseMatrix.diagonal(featureSize, 1.0)
         posterior = PrecisionRegressionResult(weights, 0.25, 1.0, 0.0, 0L, identity)
         val naiveBayes = GaussianNaiveBayesStat(featureSize, 4)
         repeat(16) { sample ->
-            naiveBayes.update(F64DenseVector.of(DoubleArray(featureSize) { i -> (sample - i % 7) * 0.1 }), (sample % 4).toDouble())
+            naiveBayes.update(DenseVector.of(DoubleArray(featureSize) { i -> (sample - i % 7) * 0.1 }), (sample % 4).toDouble())
         }
         gaussianNaiveBayes = naiveBayes.read()
         knn = KnnContextualBandit(nbrArms = 4, k = 8, exploration = 0.0)
@@ -105,7 +105,7 @@ open class PredictionKernelBenchmark {
     fun knnChooseWorkspace(): Int = knn.choose(x, workspace)
 
     @Benchmark
-    fun multivariateSample(): F64VectorLike = MultivariateGaussian.sample(posterior, Random(1234), 1.0)
+    fun multivariateSample(): VectorLike = MultivariateGaussian.sample(posterior, Random(1234), 1.0)
 
     @Benchmark
     fun multivariateEvaluate(): Double = MultivariateGaussian.evaluate(posterior, x, Random(1234), 1.0)
@@ -117,7 +117,7 @@ open class PredictionKernelBenchmark {
     @Benchmark
     fun bayesianPrior(): PrecisionRegressionResult = BayesianRegressionStat(
         featureSize = featureSize,
-        priorMean = F64DenseVector.of(DoubleArray(featureSize) { it * 0.01 }),
+        priorMean = DenseVector.of(DoubleArray(featureSize) { it * 0.01 }),
     ).read()
 
     @Benchmark

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.bench
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64StridedVectorView
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.expr.VFoldOp
@@ -30,7 +30,7 @@ open class VectorExprBenchmark {
     @Param("dense", "sparse", "strided", "custom")
     lateinit var representation: String
 
-    private lateinit var input: F64VectorLike
+    private lateinit var input: VectorLike
     private val scalar = V(0) + V(1)
     private val predicate = V(0) gt 0.0
     private val vector = vectorOf(V(0), V(1))
@@ -45,12 +45,12 @@ open class VectorExprBenchmark {
     fun setup() {
         val values = DoubleArray(featureSize) { if (it % 3 == 0) 1.0 else 0.0 }
         input = when (representation) {
-            "dense" -> F64DenseVector.of(values)
+            "dense" -> DenseVector.of(values)
             "sparse" -> {
                 val nnz = (featureSize * densityPercent / 100).coerceAtLeast(1)
-                F64SparseVector.of(featureSize, IntArray(nnz) { it * featureSize / nnz }, DoubleArray(nnz) { 1.0 })
+                SparseVector.of(featureSize, IntArray(nnz) { it * featureSize / nnz }, DoubleArray(nnz) { 1.0 })
             }
-            "strided" -> F64StridedVectorView(DoubleArray(featureSize * 2) { values[it / 2] }, 0, featureSize, 2)
+            "strided" -> StridedVectorView(DoubleArray(featureSize * 2) { values[it / 2] }, 0, featureSize, 2)
             else -> Vector(values)
         }
         dot = vDot(List(featureSize) { if (it % 2 == 0) 1.0 else -1.0 })
@@ -69,7 +69,7 @@ open class VectorExprBenchmark {
     @Benchmark fun materializedPredicate(): Boolean = predicate.eval(0.0, 0.0, input.toDoubleArray())
     @Benchmark fun materializedVector(): DoubleArray = vector.eval(0.0, 0.0, input.toDoubleArray())
 
-    private class Vector(private val values: DoubleArray) : F64VectorLike {
+    private class Vector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 
@@ -109,7 +109,7 @@ interface UnivariateBandit : Bandit {
  *
  * The standard contextual lifecycle:
  *
- * 1. Caller observes `x: F64VectorLike` (e.g. a user feature vector).
+ * 1. Caller observes `x: VectorLike` (e.g. a user feature vector).
  * 2. Caller calls [choose] with `x`; the bandit picks an arm by combining
  *    the per-arm model with the context.
  * 3. Caller plays the arm and observes a reward.
@@ -133,14 +133,14 @@ interface ContextualBandit : Bandit {
      * configurable [com.eignex.kumulant.stat.regression.RegressionPosterior]
      * (or analogue) and returns the argmax / sampled choice.
      */
-    fun choose(x: F64VectorLike, workspace: Workspace? = null): Int
+    fun choose(x: VectorLike, workspace: Workspace? = null): Int
 
     /**
      * Fold a single `(x, reward)` observation into the arm at [armIndex].
      * The `weight` is the same observation-weight running through the
      * library; typically `1.0`, occasionally importance-weighted.
      */
-    fun update(armIndex: Int, x: F64VectorLike, reward: Double, weight: Double = 1.0, workspace: Workspace? = null)
+    fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double = 1.0, workspace: Workspace? = null)
 }
 
 /**
@@ -242,5 +242,5 @@ interface Scorable {
  */
 interface ContextualScorable {
     /** Score the arm at [armIndex] under the current state and context [x]. */
-    fun evaluate(armIndex: Int, x: F64VectorLike, workspace: Workspace? = null): Double
+    fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace? = null): Double
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec
@@ -183,7 +183,7 @@ fun RegressionContextualSpec.materialize(
 }
 
 /** Resolve a wire-named distance metric to the function that computes it. */
-private fun KnnDistance.resolve(): (F64VectorLike, F64VectorLike) -> Double = when (this) {
+private fun KnnDistance.resolve(): (VectorLike, VectorLike) -> Double = when (this) {
     KnnDistance.SquaredL2 -> KnnContextualBandit.Companion::squaredL2
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -89,7 +89,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
         @Suppress("UNCHECKED_CAST")
         (updateArmRewardTemplate?.create(null) as PairedStat<Result>?)
 
-    override fun choose(x: F64VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
+    override fun choose(x: VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
         x.requireFeatureSize(contextFeatureSize)
         val i = inner.choose(x, workspace)
         chooseStat?.update(x, i.toDouble(), nowNanos(), 1.0, workspace)
@@ -98,7 +98,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
 
     override fun update(
         armIndex: Int,
-        x: F64VectorLike,
+        x: VectorLike,
         reward: Double,
         weight: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -110,7 +110,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
             val joint = DoubleArray(contextFeatureSize + 1)
             joint[0] = armIndex.toDouble()
             for (j in 0 until contextFeatureSize) joint[j + 1] = x[j]
-            updateJointStat.update(F64DenseVector.of(joint), reward, ts, weight, workspace)
+            updateJointStat.update(DenseVector.of(joint), reward, ts, weight, workspace)
         }
         updateMarginalStat?.update(x, reward, ts, weight, workspace)
         updateArmRewardStat?.update(armIndex.toDouble(), reward, ts, weight)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable
@@ -44,7 +44,7 @@ data class Exp4State(
  */
 fun interface Exp4Expert {
     /** Distribution over arms for [x]. Result must sum to 1 and have length `nbrArms`. */
-    fun advise(x: F64VectorLike, nbrArms: Int): DoubleArray
+    fun advise(x: VectorLike, nbrArms: Int): DoubleArray
 }
 
 /**
@@ -128,7 +128,7 @@ class Exp4Bandit(
     private val pendingPulls = IntArray(nbrArms)
 
     /** Build the round's play distribution and sample an arm. */
-    override fun choose(x: F64VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
+    override fun choose(x: VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
         playDistributionInto(x, lastDistribution)
         val chosen = random.sampleFromDistribution(lastDistribution)
         pendingPropensity[chosen] = lastDistribution[chosen]
@@ -138,7 +138,7 @@ class Exp4Bandit(
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with
      *  uniform exploration via [gamma]. */
-    fun playDistribution(x: F64VectorLike): DoubleArray = DoubleArray(nbrArms).also {
+    fun playDistribution(x: VectorLike): DoubleArray = DoubleArray(nbrArms).also {
         playDistributionInto(x, it)
     }
 
@@ -149,7 +149,7 @@ class Exp4Bandit(
      *
      * The destination is caller-owned. It is not retained after this method returns.
      */
-    fun playDistributionInto(x: F64VectorLike, out: DoubleArray) {
+    fun playDistributionInto(x: VectorLike, out: DoubleArray) {
         require(out.size == nbrArms) { "out has ${out.size} probs, expected $nbrArms" }
         var wSum = 0.0
         for (i in experts.indices) {
@@ -178,7 +178,7 @@ class Exp4Bandit(
     /** Fold a `(context, reward)` observation back into the expert weights. */
     override fun update(
         armIndex: Int,
-        x: F64VectorLike,
+        x: VectorLike,
         reward: Double,
         weight: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -207,7 +207,7 @@ class Exp4Bandit(
      * Falls back to the distribution at [x] when the caller updates an arm it never chose, which is
      * the best available estimate and what an off-policy caller implicitly asks for.
      */
-    private fun propensityOf(armIndex: Int, x: F64VectorLike): Double {
+    private fun propensityOf(armIndex: Int, x: VectorLike): Double {
         if (pendingPulls[armIndex] <= 0) {
             playDistributionInto(x, lastDistribution)
             return lastDistribution[armIndex]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -1,10 +1,10 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorLike
+import com.eignex.koblas.VectorStorage
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorLike
-import com.eignex.koblas.core.F64VectorStorage
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.koblas
 import com.eignex.kumulant.bandit.ContextualBandit
@@ -34,7 +34,7 @@ import kotlin.random.Random
 @Serializable
 @SerialName("KnnArmResult")
 data class KnnArmResult(
-    /** Retained contexts (each a copy of the submitted [F64VectorLike]). */
+    /** Retained contexts (each a copy of the submitted [VectorLike]). */
     val contexts: List<DoubleArray>,
     /** Per-sample rewards, parallel to [contexts]. */
     val rewards: DoubleArray,
@@ -132,7 +132,7 @@ class KnnContextualBandit(
     /** UCB-style exploration scale on `sqrt(ln(totalSteps) / armWeight)`; `0.0` disables. */
     val exploration: Double = 1.0,
     /** Pairwise distance between context vectors; defaults to squared L2. */
-    val distance: (F64VectorLike, F64VectorLike) -> Double = ::squaredL2,
+    val distance: (VectorLike, VectorLike) -> Double = ::squaredL2,
     /** Single source of randomness; used only for tie-breaking, currently deterministic. */
     override val random: Random = Random.Default,
 ) : ContextualBandit,
@@ -179,7 +179,7 @@ class KnnContextualBandit(
      * there is no scratch left to borrow.
      */
     @Suppress("UnusedParameter")
-    override fun choose(x: F64VectorLike, workspace: Workspace?): Int {
+    override fun choose(x: VectorLike, workspace: Workspace?): Int {
         requireFeatureSize(x.size)
         val bestIdx = argmaxArm(nbrArms) { armIndex -> score(armIndex, x) }
         step++
@@ -192,14 +192,14 @@ class KnnContextualBandit(
      * [workspace] is accepted for interface uniformity and ignored, as in [choose].
      */
     @Suppress("UnusedParameter")
-    override fun evaluate(armIndex: Int, x: F64VectorLike, workspace: Workspace?): Double {
+    override fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace?): Double {
         requireArmIndex(armIndex, nbrArms)
         requireFeatureSize(x.size)
         return score(armIndex, x)
     }
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
-    override fun update(armIndex: Int, x: F64VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
+    override fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
         requireArmIndex(armIndex, nbrArms)
         // An inert observation must not consume a history slot; the eviction below would drop real data.
         // A negative weight drops for the same reason rather than downdating: a bounded history has no
@@ -239,7 +239,7 @@ class KnnContextualBandit(
         for (a in 0 until nbrArms) {
             val arm = other[a]
             for (i in arm.contexts.indices) {
-                update(a, F64DenseVector.of(arm.contexts[i]), arm.rewards[i], arm.weights[i])
+                update(a, DenseVector.of(arm.contexts[i]), arm.rewards[i], arm.weights[i])
             }
         }
     }
@@ -266,12 +266,12 @@ class KnnContextualBandit(
         return exploration * sqrt(ln(t) / w)
     }
 
-    private fun score(armIndex: Int, x: F64VectorLike): Double {
+    private fun score(armIndex: Int, x: VectorLike): Double {
         if (histories[armIndex].size < k) return coldStartScore + ucbBonus(armIndex)
         return knnMean(armIndex, x) + ucbBonus(armIndex)
     }
 
-    private fun knnMean(armIndex: Int, x: F64VectorLike): Double {
+    private fun knnMean(armIndex: Int, x: VectorLike): Double {
         val history = histories[armIndex]
         // Linear scan holding the k nearest seen so far. For typical maxHistoryPerArm values
         // (<= a few thousand) this is faster than maintaining a KD-tree under reweights.
@@ -325,21 +325,21 @@ class KnnContextualBandit(
          * stored entries and accumulates dense-only contributions via a baseline
          * pass; sparse/sparse iterates the union of stored indices on both sides.
          */
-        fun squaredL2(a: F64VectorLike, b: F64VectorLike): Double {
+        fun squaredL2(a: VectorLike, b: VectorLike): Double {
             require(a.size == b.size) { "size mismatch: ${a.size} vs ${b.size}" }
             return when {
-                a is F64DenseVector && b is F64DenseVector -> denseSquaredL2(a, b)
-                a is F64SparseVector && b is F64SparseVector -> sparseSquaredL2(a, b)
-                a is F64SparseVector -> mixedSquaredL2(a, b)
-                b is F64SparseVector -> mixedSquaredL2(b, a)
+                a is DenseVector && b is DenseVector -> denseSquaredL2(a, b)
+                a is SparseVector && b is SparseVector -> sparseSquaredL2(a, b)
+                a is SparseVector -> mixedSquaredL2(a, b)
+                b is SparseVector -> mixedSquaredL2(b, a)
                 else -> genericSquaredL2(a, b)
             }
         }
 
-        private fun denseSquaredL2(a: F64DenseVector, b: F64DenseVector): Double =
+        private fun denseSquaredL2(a: DenseVector, b: DenseVector): Double =
             koblas.kernels.ssqd(a.data, 0, b.data, 0, a.size)
 
-        private fun genericSquaredL2(a: F64VectorLike, b: F64VectorLike): Double {
+        private fun genericSquaredL2(a: VectorLike, b: VectorLike): Double {
             var s = 0.0
             for (i in 0 until a.size) {
                 val d = a[i] - b[i]
@@ -348,7 +348,7 @@ class KnnContextualBandit(
             return s
         }
 
-        private fun mixedSquaredL2(sparse: F64SparseVector, dense: F64VectorLike): Double {
+        private fun mixedSquaredL2(sparse: SparseVector, dense: VectorLike): Double {
             // Start from the dense side's full squared norm, then correct the sparse-indexed
             // entries to use (sparse_v - dense_v)^2 instead of dense_v^2.
             var s = 0.0
@@ -365,7 +365,7 @@ class KnnContextualBandit(
         }
 
         @OptIn(com.eignex.koblas.UnsafeKoblasApi::class)
-        private fun sparseSquaredL2(a: F64SparseVector, b: F64SparseVector): Double {
+        private fun sparseSquaredL2(a: SparseVector, b: SparseVector): Double {
             // Both index arrays are strictly ascending, so one merge walk reaches every coordinate
             // either side stores without a search. Reading the other side positionally would binary
             // search per entry, and testing membership against an IntArray scans it, which makes the
@@ -421,7 +421,7 @@ class KnnContextualBandit(
 //
 // Contexts stay in koblas storages rather than one flat buffer because koblas has no dense vector
 // over an (array, offset, length) slice: a window type declared here would be a third implementation
-// of F64VectorLike, which drops the scan out of squaredL2's dense/dense branch onto its generic one
+// of VectorLike, which drops the scan out of squaredL2's dense/dense branch onto its generic one
 // and costs more per choose than the flat layout saves per update.
 private class ArmHistory(private val capacity: Int) {
     var size: Int = 0
@@ -429,7 +429,7 @@ private class ArmHistory(private val capacity: Int) {
 
     private val rewards = DoubleArray(capacity)
     private val weights = DoubleArray(capacity)
-    private val contexts = arrayOfNulls<F64VectorStorage>(capacity)
+    private val contexts = arrayOfNulls<VectorStorage>(capacity)
 
     private var head = 0
 
@@ -438,13 +438,13 @@ private class ArmHistory(private val capacity: Int) {
     fun weight(age: Int): Double = weights[slotOf(age)]
 
     /** The stored context at [age], oldest first. */
-    fun context(age: Int): F64VectorLike = contexts[slotOf(age)]!!
+    fun context(age: Int): VectorLike = contexts[slotOf(age)]!!
 
     /** The stored context at [age], densified into an array that outlives the slot. */
     fun contextCopy(age: Int): DoubleArray = contexts[slotOf(age)]!!.toDoubleArray()
 
     /** Admits `(x, reward, weight)` and returns the weight of the sample it evicted, `0.0` if none. */
-    fun add(x: F64VectorLike, reward: Double, weight: Double): Double {
+    fun add(x: VectorLike, reward: Double, weight: Double): Double {
         val slot: Int
         var dropped = 0.0
         if (size == capacity) {
@@ -476,15 +476,15 @@ private class ArmHistory(private val capacity: Int) {
 // The copy of x an arm keeps, reusing the dense buffer already in the slot when the widths agree so a
 // saturated arm evicts without allocating. A sparse sample always takes a fresh copy: its stored
 // length tracks the sample rather than the feature width, and the caller keeps arrays it may mutate.
-private fun retain(slot: F64VectorStorage?, x: F64VectorLike): F64VectorStorage {
-    if (x is F64SparseVector) return F64SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
-    if (slot is F64DenseVector && slot.size == x.size) {
-        if (x is F64DenseVector) {
+private fun retain(slot: VectorStorage?, x: VectorLike): VectorStorage {
+    if (x is SparseVector) return SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
+    if (slot is DenseVector && slot.size == x.size) {
+        if (x is DenseVector) {
             x.data.copyInto(slot.data)
         } else {
             for (i in 0 until x.size) slot.data[i] = x[i]
         }
         return slot
     }
-    return F64DenseVector.wrap(x.toDoubleArray())
+    return DenseVector.wrap(x.toDoubleArray())
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.bandit.PerArmBandit
@@ -101,22 +101,22 @@ class RegressionContextualBandit<R : Result>(
     private val arms: Array<RegressionStat<R>> = Array(nbrArms) { template.create(null) }
     private val global: RegressionStat<R>? = globalTemplate?.create(null)
 
-    private fun globalMean(x: F64VectorLike, workspace: Workspace?): Double =
+    private fun globalMean(x: VectorLike, workspace: Workspace?): Double =
         global?.let { posterior.evaluate(it.read(0L), x, random, 0.0, workspace) } ?: 0.0
 
-    override fun choose(x: F64VectorLike, workspace: Workspace?): Int {
+    override fun choose(x: VectorLike, workspace: Workspace?): Int {
         val gMean = globalMean(x, workspace)
         return argmaxArm(
             nbrArms,
         ) { i -> gMean + posterior.evaluate(arms[i].read(0L), x, random, exploration, workspace) }
     }
 
-    override fun evaluate(armIndex: Int, x: F64VectorLike, workspace: Workspace?): Double {
+    override fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace?): Double {
         requireArmIndex(armIndex, nbrArms)
         return globalMean(x, workspace) + posterior.evaluate(arms[armIndex].read(0L), x, random, exploration, workspace)
     }
 
-    override fun update(armIndex: Int, x: F64VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
+    override fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
         requireArmIndex(armIndex, nbrArms)
         val g = global
         if (g == null) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.dot
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -217,7 +217,7 @@ interface HasShapeMoments : HasSampleVariance {
  */
 interface HasLinearModel : Result {
     /** Fitted weight per feature, indexed by the same `i` as the input `x[i]`. */
-    val weights: F64VectorLike
+    val weights: VectorLike
 
     /** Fitted bias / intercept term. */
     val bias: Double
@@ -230,7 +230,7 @@ interface HasLinearModel : Result {
      * For Gaussian regression this is the prediction; for non-identity GLMs
      * this is the linear predictor pre-link.
      */
-    fun predict(x: F64VectorLike): Double {
+    fun predict(x: VectorLike): Double {
         x.requireFeatureSize(weights.size)
         return bias + (x dot weights)
     }
@@ -251,7 +251,7 @@ interface HasSlope : HasLinearModel {
     /** Fitted intercept `c`. */
     val intercept: Double
 
-    override val weights: F64VectorLike get() = F64DenseVector.of(doubleArrayOf(slope))
+    override val weights: VectorLike get() = DenseVector.of(doubleArrayOf(slope))
     override val bias: Double get() = intercept
     override val featureSize: Int get() = 1
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.core
 
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.stream.currentTimeNanos
 
 /**
@@ -285,10 +285,10 @@ interface PairedStat<R : Result> : Stat<R> {
  * ([DecisionTreeRegressionStat][com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat]).
  * They share the update shape and differ in what they expose on [read].
  *
- * Inputs are passed as [F64VectorLike] so callers can submit sparse feature
+ * Inputs are passed as [VectorLike] so callers can submit sparse feature
  * vectors without materialising them into dense arrays first. The
- * [DoubleArray] convenience overloads wrap the array in a [F64DenseVector]; the
- * sparse path goes through [com.eignex.koblas.core.F64SparseVector].
+ * [DoubleArray] convenience overloads wrap the array in a [DenseVector]; the
+ * sparse path goes through [com.eignex.koblas.SparseVector].
  *
  * The K-way classifiers
  * ([SoftmaxRegressionStat][com.eignex.kumulant.stat.regression.SoftmaxRegressionStat],
@@ -300,19 +300,19 @@ interface RegressionStat<R : Result> : Stat<R> {
     val featureSize: Int
 
     /** Record an `(x, y)` observation with the given [weight] at the current time. */
-    fun update(x: F64VectorLike, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
+    fun update(x: VectorLike, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
         update(x, y, currentTimeNanos(), weight, workspace)
 
     /** Record an `(x, y)` observation at [timestampNanos] with the given [weight]. */
-    fun update(x: F64VectorLike, y: Double, timestampNanos: Long, weight: Double = 1.0, workspace: Workspace? = null)
+    fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double = 1.0, workspace: Workspace? = null)
 
-    /** Convenience overload that wraps `x` as a [F64DenseVector]. */
+    /** Convenience overload that wraps `x` as a [DenseVector]. */
     fun update(x: DoubleArray, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
-        update(F64DenseVector.of(x), y, currentTimeNanos(), weight, workspace)
+        update(DenseVector.of(x), y, currentTimeNanos(), weight, workspace)
 
-    /** Timestamped convenience overload that wraps `x` as a [F64DenseVector]. */
+    /** Timestamped convenience overload that wraps `x` as a [DenseVector]. */
     fun update(x: DoubleArray, y: Double, timestampNanos: Long, weight: Double = 1.0, workspace: Workspace? = null) =
-        update(F64DenseVector.of(x), y, timestampNanos, weight, workspace)
+        update(DenseVector.of(x), y, timestampNanos, weight, workspace)
 
     override fun create(concurrency: Concurrency?): RegressionStat<R>
 }
@@ -325,27 +325,27 @@ interface RegressionStat<R : Result> : Stat<R> {
  * detector
  * ([HalfSpaceTreesStat][com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat]).
  *
- * Like [RegressionStat], inputs are passed as [F64VectorLike] so sparse callers
+ * Like [RegressionStat], inputs are passed as [VectorLike] so sparse callers
  * don't pay for dense materialisation. The [DoubleArray] convenience
- * overloads wrap the array in a [F64DenseVector].
+ * overloads wrap the array in a [DenseVector].
  */
 interface VectorStat<R : Result> : Stat<R> {
     /** Record a [vector] observation with the given [weight] at the current time. */
-    fun update(vector: F64VectorLike, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
+    fun update(vector: VectorLike, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
 
     /** Record a [vector] observation at [timestampNanos] with the given [weight]. */
-    fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double = 1.0)
+    fun update(vector: VectorLike, timestampNanos: Long, weight: Double = 1.0)
 
-    /** Convenience overload that wraps [vector] as a [F64DenseVector]. */
+    /** Convenience overload that wraps [vector] as a [DenseVector]. */
     fun update(vector: DoubleArray, weight: Double = 1.0) = update(
-        F64DenseVector.of(vector),
+        DenseVector.of(vector),
         currentTimeNanos(),
         weight,
     )
 
-    /** Timestamped convenience overload that wraps [vector] as a [F64DenseVector]. */
+    /** Timestamped convenience overload that wraps [vector] as a [DenseVector]. */
     fun update(vector: DoubleArray, timestampNanos: Long, weight: Double = 1.0) =
-        update(F64DenseVector.of(vector), timestampNanos, weight)
+        update(DenseVector.of(vector), timestampNanos, weight)
 
     override fun create(concurrency: Concurrency?): VectorStat<R>
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 
 /**
  * Reject a context vector whose arity does not match the model's.
@@ -13,10 +13,10 @@ import com.eignex.koblas.core.F64VectorLike
  * spells its own check out instead, because its receiver is named `vector` and its message says so.
  *
  * @param expected the model's feature count.
- * @throws IllegalArgumentException if [F64VectorLike.size] differs from [expected].
+ * @throws IllegalArgumentException if the [VectorLike] size differs from [expected].
  */
 @Suppress("NOTHING_TO_INLINE") // as with the weight predicates; the non-JVM targets pay for the call
-internal inline fun F64VectorLike.requireFeatureSize(expected: Int) {
+internal inline fun VectorLike.requireFeatureSize(expected: Int) {
     require(size == expected) { "x.size=$size, expected $expected" }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
@@ -28,11 +28,11 @@ silently drop the stamp. Stats that care about it (rates, windowed
 wrappers, decaying accumulators) treat it as the ordering signal; pass a
 monotonic stamp when replaying a log.
 
-[VectorStat] and [RegressionStat] both accept an `F64VectorLike`
-([com.eignex.koblas.core.F64VectorLike]) so sparse callers can feed
+[VectorStat] and [RegressionStat] both accept a `VectorLike`
+([com.eignex.koblas.VectorLike]) so sparse callers can feed
 sparse vectors without materialising them. Each also exposes a
 `DoubleArray` convenience overload that wraps the array in an
-`F64DenseVector` before forwarding.
+`DenseVector` before forwarding.
 
 ### Snapshots
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -4,8 +4,8 @@ package com.eignex.kumulant.math
 
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.dense.F64Kernels
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.dense.Kernels
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.koblas
 import kotlin.math.abs
@@ -35,7 +35,7 @@ internal sealed interface CholeskyPolicy {
 internal class NotPositiveDefinite(val pivotIndex: Int, val pivot: Double, message: String) :
     IllegalArgumentException(message)
 
-internal fun F64DenseMatrix.choleskyRankUpdate(v: DoubleArray, sigma: Double, workspace: Workspace? = null) {
+internal fun DenseMatrix.choleskyRankUpdate(v: DoubleArray, sigma: Double, workspace: Workspace? = null) {
     require(rows == cols) { "cholesky factor must be square" }
     require(v.size == rows) { "update vector has ${v.size} entries, expected $rows" }
     require(sigma >= 0.0 && sigma.isFinite()) { "sigma must be non-negative and finite, got $sigma" }
@@ -65,7 +65,7 @@ internal fun F64DenseMatrix.choleskyRankUpdate(v: DoubleArray, sigma: Double, wo
     }
 }
 
-internal fun F64DenseMatrix.choleskySolveInto(b: DoubleArray, out: DoubleArray): DoubleArray {
+internal fun DenseMatrix.choleskySolveInto(b: DoubleArray, out: DoubleArray): DoubleArray {
     require(rows == cols) { "cholesky factor must be square" }
     require(b.size == rows && out.size == rows) { "solve requires vectors of size $rows" }
     if (out !== b) b.copyInto(out)
@@ -74,10 +74,10 @@ internal fun F64DenseMatrix.choleskySolveInto(b: DoubleArray, out: DoubleArray):
     return out
 }
 
-internal fun F64DenseMatrix.choleskyInverse(workspace: Workspace? = null): F64DenseMatrix =
-    choleskyInvertInto(F64DenseMatrix.zero(rows, cols), workspace)
+internal fun DenseMatrix.choleskyInverse(workspace: Workspace? = null): DenseMatrix =
+    choleskyInvertInto(DenseMatrix.zero(rows, cols), workspace)
 
-internal fun F64DenseMatrix.choleskyInvertInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix {
+internal fun DenseMatrix.choleskyInvertInto(out: DenseMatrix, workspace: Workspace? = null): DenseMatrix {
     require(rows == cols) { "cholesky factor must be square" }
     require(out.rows == rows && out.cols == rows) { "inverse destination must be ${rows}x$rows" }
     require(out.data !== data) { "inverse destination must not share the factor's storage" }
@@ -108,13 +108,13 @@ internal fun F64DenseMatrix.choleskyInvertInto(out: F64DenseMatrix, workspace: W
     return out
 }
 
-internal fun F64DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): F64DenseMatrix =
-    choleskyInto(F64DenseMatrix.zero(rows, cols), policy)
+internal fun DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): DenseMatrix =
+    choleskyInto(DenseMatrix.zero(rows, cols), policy)
 
-internal fun F64DenseMatrix.choleskyInto(
-    out: F64DenseMatrix,
+internal fun DenseMatrix.choleskyInto(
+    out: DenseMatrix,
     policy: CholeskyPolicy = CholeskyPolicy.Strict,
-): F64DenseMatrix {
+): DenseMatrix {
     require(rows == cols) { "cholesky requires a square matrix" }
     require(out.rows == rows && out.cols == rows) { "cholesky destination must be ${rows}x$rows" }
     val n = rows
@@ -148,7 +148,7 @@ internal fun F64DenseMatrix.choleskyInto(
 
 @Suppress("LongParameterList") // the factor, its shape, the block being gathered into, and scratch
 private fun gatherEarlierBlocks(
-    kernels: F64Kernels,
+    kernels: Kernels,
     ld: DoubleArray,
     n: Int,
     start: Int,
@@ -192,7 +192,7 @@ private fun gatherEarlierBlocks(
 }
 
 private fun factorBlockColumn(
-    kernels: F64Kernels,
+    kernels: Kernels,
     ld: DoubleArray,
     n: Int,
     start: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.core.PairedStat
@@ -91,7 +91,7 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
     WindowsInside<I, VectorStat<I>>,
     Stat<I> by inner {
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         primary.update(vector, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(vector.size) { i ->
@@ -133,7 +133,7 @@ internal class FeedbackRegressionStat<P : Result, R : Result>(
     override val featureSize: Int get() = inner.featureSize
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -43,10 +43,10 @@ internal class FilterPairedStat<R : Result>(
 internal class FilterVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val predicate: (DoubleArray) -> Boolean = { true },
-    private val vectorPredicate: ((F64VectorLike) -> Boolean)? = null,
+    private val vectorPredicate: ((VectorLike) -> Boolean)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         if (vectorPredicate?.invoke(vector) ?: predicate(vector.toDoubleArray())) {
             delegate.update(vector, timestampNanos, weight)
         }
@@ -55,7 +55,7 @@ internal class FilterVectorStat<R : Result>(
         FilterVectorStat(delegate.create(concurrency), predicate, vectorPredicate)
 
     companion object {
-        fun <R : Result> vector(delegate: VectorStat<R>, predicate: (F64VectorLike) -> Boolean): FilterVectorStat<R> =
+        fun <R : Result> vector(delegate: VectorStat<R>, predicate: (VectorLike) -> Boolean): FilterVectorStat<R> =
             FilterVectorStat(delegate, vectorPredicate = predicate)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -17,17 +17,17 @@ import com.eignex.kumulant.core.VectorStat
 internal class FoldVectorStat<R : Result>(
     private val delegate: SeriesStat<R>,
     private val transform: (DoubleArray) -> Double = { 0.0 },
-    private val vectorTransform: ((F64VectorLike) -> Double)? = null,
+    private val vectorTransform: ((VectorLike) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(vectorTransform?.invoke(vector) ?: transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
         FoldVectorStat(delegate.create(concurrency), transform, vectorTransform)
 
     companion object {
-        fun <R : Result> vector(delegate: SeriesStat<R>, transform: (F64VectorLike) -> Double): FoldVectorStat<R> =
+        fun <R : Result> vector(delegate: SeriesStat<R>, transform: (VectorLike) -> Double): FoldVectorStat<R> =
             FoldVectorStat(delegate, vectorTransform = transform)
     }
 }
@@ -48,11 +48,11 @@ internal class FoldVectorPairedStat<R : Result>(
     private val delegate: PairedStat<R>,
     private val foldX: (DoubleArray) -> Double = { 0.0 },
     private val foldY: (DoubleArray) -> Double = { 0.0 },
-    private val vectorFoldX: ((F64VectorLike) -> Double)? = null,
-    private val vectorFoldY: ((F64VectorLike) -> Double)? = null,
+    private val vectorFoldX: ((VectorLike) -> Double)? = null,
+    private val vectorFoldY: ((VectorLike) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         if (vectorFoldX != null && vectorFoldY != null) {
             delegate.update(vectorFoldX(vector), vectorFoldY(vector), timestampNanos, weight)
         } else {
@@ -66,8 +66,8 @@ internal class FoldVectorPairedStat<R : Result>(
     companion object {
         fun <R : Result> vector(
             delegate: PairedStat<R>,
-            foldX: (F64VectorLike) -> Double,
-            foldY: (F64VectorLike) -> Double,
+            foldX: (VectorLike) -> Double,
+            foldY: (VectorLike) -> Double,
         ): FoldVectorPairedStat<R> = FoldVectorPairedStat(delegate, vectorFoldX = foldX, vectorFoldY = foldY)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -89,7 +89,7 @@ internal class MapResultVectorStat<R1 : Result, R2 : Result>(
     private val reverse: (R2) -> R1,
 ) : VectorStat<R2>,
     Stat<R2> by MappedResultCore(delegate, forward, reverse) {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) =
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) =
         delegate.update(vector, timestampNanos, weight)
     override fun create(concurrency: Concurrency?): VectorStat<R2> =
         MapResultVectorStat(delegate.create(concurrency), forward, reverse)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -18,13 +18,12 @@ import com.eignex.kumulant.core.requirePositiveFeatureSize
 // `com.eignex.kumulant.schema.Operations.kt` materialise to these wrappers.
 
 /** Forward only updates that pass [predicate]; the predicate sees `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.filter(predicate: (F64VectorLike, Double) -> Boolean): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.filter(predicate: (VectorLike, Double) -> Boolean): RegressionStat<R> =
     FilterRegressionStat(this, predicate)
 
 /** Rewrite y before update via [transform]; x and weight pass through unchanged. */
-internal fun <R : Result> RegressionStat<R>.transformY(
-    transform: (F64VectorLike, Double) -> Double,
-): RegressionStat<R> = TransformYRegressionStat(this, transform)
+internal fun <R : Result> RegressionStat<R>.transformY(transform: (VectorLike, Double) -> Double): RegressionStat<R> =
+    TransformYRegressionStat(this, transform)
 
 /**
  * Rewrite x before update via [transform]; y and weight pass through unchanged.
@@ -34,7 +33,7 @@ internal fun <R : Result> RegressionStat<R>.transformY(
  */
 internal fun <R : Result> RegressionStat<R>.transformX(
     inputFeatureSize: Int? = null,
-    transform: (F64VectorLike, Double) -> DoubleArray,
+    transform: (VectorLike, Double) -> DoubleArray,
 ): RegressionStat<R> = TransformXRegressionStat(this, inputFeatureSize, transform)
 
 /**
@@ -47,7 +46,7 @@ internal fun <R : Result> RegressionStat<R>.withWeight(weight: Double): Regressi
     WithWeightRegressionStat(this, weight)
 
 /** Multiply each update's caller-supplied weight by [weighter] over `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (F64VectorLike, Double) -> Double): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (VectorLike, Double) -> Double): RegressionStat<R> =
     WeightByRegressionStat(this, weighter)
 
 /** Forward only every [every]th update; drop the rest. */
@@ -71,17 +70,17 @@ internal fun <R : Result> RegressionStat<R>.sample(rate: Double, seed: Long): Re
  */
 internal fun <R : Result> SeriesStat<R>.foldRegression(
     featureSize: Int,
-    project: (F64VectorLike, Double) -> Double,
+    project: (VectorLike, Double) -> Double,
 ): RegressionStat<R> = FoldRegressionStat(this, featureSize, project)
 
 internal class FilterRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val predicate: (F64VectorLike, Double) -> Boolean,
+    private val predicate: (VectorLike, Double) -> Boolean,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -95,12 +94,12 @@ internal class FilterRegressionStat<R : Result>(
 
 internal class TransformYRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val transform: (F64VectorLike, Double) -> Double,
+    private val transform: (VectorLike, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -115,7 +114,7 @@ internal class TransformYRegressionStat<R : Result>(
 internal class TransformXRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
     private val inputFeatureSize: Int?,
-    private val transform: (F64VectorLike, Double) -> DoubleArray,
+    private val transform: (VectorLike, Double) -> DoubleArray,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     // The width expected in `x`, which is what RegressionStat.featureSize means - not the inner
@@ -125,14 +124,14 @@ internal class TransformXRegressionStat<R : Result>(
     override val featureSize: Int = inputFeatureSize ?: delegate.featureSize
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
         workspace: com.eignex.koblas.Workspace?,
     ) {
         x.requireFeatureSize(featureSize)
-        delegate.update(F64DenseVector.of(transform(x, y)), y, timestampNanos, weight, workspace)
+        delegate.update(DenseVector.of(transform(x, y)), y, timestampNanos, weight, workspace)
     }
 
     override fun create(concurrency: Concurrency?): RegressionStat<R> =
@@ -146,7 +145,7 @@ internal class WithWeightRegressionStat<R : Result>(
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -162,12 +161,12 @@ internal class WithWeightRegressionStat<R : Result>(
 
 internal class WeightByRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val weighter: (F64VectorLike, Double) -> Double,
+    private val weighter: (VectorLike, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -185,7 +184,7 @@ internal class ThrottleRegressionStat<R : Result>(private val delegate: Regressi
     override val featureSize: Int = delegate.featureSize
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -212,7 +211,7 @@ internal class SampleRegressionStat<R : Result>(
     private val gate = SampleGate(rate, seed, delegate.concurrency)
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -234,14 +233,14 @@ internal class SampleRegressionStat<R : Result>(
 internal class FoldRegressionStat<R : Result>(
     private val delegate: SeriesStat<R>,
     override val featureSize: Int,
-    private val project: (F64VectorLike, Double) -> Double,
+    private val project: (VectorLike, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     init {
         requirePositiveFeatureSize(featureSize)
     }
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -109,7 +109,7 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
     WindowsInside<R, VectorStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
@@ -195,7 +195,7 @@ internal class SampleVectorStat<R : Result>(
 ) : VectorStat<R>,
     Stat<R> by delegate {
     private val gate = SampleGate(rate, seed, delegate.concurrency)
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -31,7 +31,7 @@ internal class AtYStat<R : Result>(private val delegate: SeriesStat<R>) :
 internal class AtIndexStat<R : Result>(private val delegate: SeriesStat<R>, private val index: Int) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(vector[index], timestampNanos, weight)
     }
 
@@ -44,7 +44,7 @@ internal class AtIndicesStat<R : Result>(
     private val indexY: Int,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(vector[indexX], vector[indexY], timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -50,10 +50,10 @@ internal class TransformPairStat<R : Result>(
 internal class TransformVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val transform: (DoubleArray) -> DoubleArray = { it },
-    private val vectorTransform: ((F64VectorLike) -> DoubleArray)? = null,
+    private val vectorTransform: ((VectorLike) -> DoubleArray)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(vectorTransform?.invoke(vector) ?: transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
@@ -62,7 +62,7 @@ internal class TransformVectorStat<R : Result>(
     companion object {
         fun <R : Result> vector(
             delegate: VectorStat<R>,
-            transform: (F64VectorLike) -> DoubleArray,
+            transform: (VectorLike) -> DoubleArray,
         ): TransformVectorStat<R> = TransformVectorStat(delegate, vectorTransform = transform)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
@@ -17,7 +17,7 @@ import com.eignex.kumulant.core.requireFeatureSize
  * entries; incoming vectors must match [dimensions] exactly.
  *
  * When [skipZeros] is `true`, only the stored entries of the input vector are
- * forwarded to their per-dimension stats. For a [com.eignex.koblas.core.F64SparseVector]
+ * forwarded to their per-dimension stats. For a [com.eignex.koblas.SparseVector]
  * this turns the per-update cost from `O(dimensions)` into `O(nnz)`, and an
  * unobserved index is treated as "no update" rather than "update with 0.0".
  * Keep the default (`false`) for stats whose semantics distinguish zero from
@@ -35,7 +35,7 @@ internal class VectorizedStat<R : Result>(
 
     override val concurrency: Concurrency get() = template.concurrency
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         vector.requireFeatureSize(dimensions)
         if (skipZeros) {
             vector.forEachStored { i, v -> stats[i].update(v, timestampNanos, weight) }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -64,7 +64,7 @@ internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat
 internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat<R>, private val weight: Double) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(vector, timestampNanos, weight.orInert(this.weight))
     }
 
@@ -132,10 +132,10 @@ internal class WeightByPairedStat<R : Result>(
 internal class WeightByVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val weighter: (DoubleArray) -> Double = { 1.0 },
-    private val vectorWeighter: ((F64VectorLike) -> Double)? = null,
+    private val vectorWeighter: ((VectorLike) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         delegate.update(
             vector,
             timestampNanos,
@@ -146,7 +146,7 @@ internal class WeightByVectorStat<R : Result>(
         WeightByVectorStat(delegate.create(concurrency), weighter, vectorWeighter)
 
     companion object {
-        fun <R : Result> vector(delegate: VectorStat<R>, weighter: (F64VectorLike) -> Double): WeightByVectorStat<R> =
+        fun <R : Result> vector(delegate: VectorStat<R>, weighter: (VectorLike) -> Double): WeightByVectorStat<R> =
             WeightByVectorStat(delegate, vectorWeighter = weighter)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -164,7 +164,7 @@ internal class WindowedVectorStat<R : Result>(
     private val template = template.create(concurrency = this.concurrency)
     private val ring = SliceRing<R, VectorStat<R>>(windowDuration, slices, concurrency) { c -> this.template.create(c) }
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         ring.slotFor(timestampNanos)?.update(vector, timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.schema.expr
 
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.koblas
 import com.eignex.koblas.sum
@@ -838,8 +838,8 @@ sealed interface VectorExpr {
  * bits, and a snapshot carrying such a value is only equal to another that was fed the same storage.
  * Every other fold is order-independent and agrees exactly whatever the storage.
  */
-fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): Double {
-    if (v is F64SparseVector) {
+fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): Double {
+    if (v is SparseVector) {
         when (this) {
             is VFold -> when (op) {
                 VFoldOp.Min -> return sparseMin(v)
@@ -864,125 +864,124 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary:
     return evalVectorGeneric(x, y, v, primary)
 }
 
-private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: F64VectorLike, primary: Result?): Double =
-    when (this) {
-        X -> x
+private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: VectorLike, primary: Result?): Double = when (this) {
+    X -> x
 
-        Y -> y
+    Y -> y
 
-        Center -> primary.feedbackPrimary<HasCenterScale>("Center").center
+    Center -> primary.feedbackPrimary<HasCenterScale>("Center").center
 
-        Scale -> primary.feedbackPrimary<HasCenterScale>("Scale").scale
+    Scale -> primary.feedbackPrimary<HasCenterScale>("Scale").scale
 
-        Low -> primary.feedbackPrimary<HasMinMax>("Low").min
+    Low -> primary.feedbackPrimary<HasMinMax>("Low").min
 
-        High -> primary.feedbackPrimary<HasMinMax>("High").max
+    High -> primary.feedbackPrimary<HasMinMax>("High").max
 
-        VIndex -> {
-            check(
-                primary is IndexedResult,
-            ) { "VIndex requires an element-wise feedback context; got ${primary?.let { it::class.simpleName }}" }
-            primary.index.toDouble()
-        }
-
-        is V -> v[index]
-
-        is Const -> this.v
-
-        is Add -> l.eval(x, y, v, primary) + r.eval(x, y, v, primary)
-
-        is Sub -> l.eval(x, y, v, primary) - r.eval(x, y, v, primary)
-
-        is Mul -> l.eval(x, y, v, primary) * r.eval(x, y, v, primary)
-
-        is Div -> l.eval(x, y, v, primary) / r.eval(x, y, v, primary)
-
-        is Neg -> -a.eval(x, y, v, primary)
-
-        is Abs -> abs(a.eval(x, y, v, primary))
-
-        is Log -> ln(a.eval(x, y, v, primary))
-
-        is Exp -> exp(a.eval(x, y, v, primary))
-
-        is Sqrt -> sqrt(a.eval(x, y, v, primary))
-
-        is Pow -> a.eval(x, y, v, primary).pow(b.eval(x, y, v, primary))
-
-        is MinExpr -> min(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
-
-        is MaxExpr -> max(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
-
-        is IfExpr -> if (cond.eval(x, y, v, primary)) then.eval(x, y, v, primary) else otherwise.eval(x, y, v, primary)
-
-        is Switch -> {
-            val key = on.eval(x, y, v, primary)
-            cases.firstOrNull { it.value == key }?.then?.eval(x, y, v, primary) ?: otherwise.eval(x, y, v, primary)
-        }
-
-        Standardize -> {
-            val result = primary.feedbackPrimary<HasCenterScale>("Standardize")
-            if (result.scale > 0.0) (x - result.center) / result.scale else 0.0
-        }
-
-        is MinMax -> {
-            val result = primary.feedbackPrimary<HasMinMax>("MinMax")
-            val span = result.max - result.min
-            if (span > 0.0) targetLow + (x - result.min) / span * (targetHigh - targetLow) else targetLow
-        }
-
-        is VFold -> when (op) {
-            VFoldOp.Sum -> v.sum()
-
-            VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
-
-            VFoldOp.Mean -> {
-                require(
-                    v.size != 0,
-                ) { "VFold.Mean on empty vector" }
-                v.sum() / v.size
-            }
-
-            VFoldOp.Min -> {
-                require(
-                    v.size != 0,
-                ) { "VFold.Min on empty vector" }
-                var minimum = v[0]
-                for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
-                minimum
-            }
-
-            VFoldOp.Max -> {
-                require(
-                    v.size != 0,
-                ) { "VFold.Max on empty vector" }
-                var maximum = v[0]
-                for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
-                maximum
-            }
-
-            VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
-        }
-
-        is VDot -> {
-            require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
-            (0 until v.size).sumOf { weights[it] * v[it] }
-        }
+    VIndex -> {
+        check(
+            primary is IndexedResult,
+        ) { "VIndex requires an element-wise feedback context; got ${primary?.let { it::class.simpleName }}" }
+        primary.index.toDouble()
     }
 
-private fun sparseNorm2(v: F64SparseVector): Double {
+    is V -> v[index]
+
+    is Const -> this.v
+
+    is Add -> l.eval(x, y, v, primary) + r.eval(x, y, v, primary)
+
+    is Sub -> l.eval(x, y, v, primary) - r.eval(x, y, v, primary)
+
+    is Mul -> l.eval(x, y, v, primary) * r.eval(x, y, v, primary)
+
+    is Div -> l.eval(x, y, v, primary) / r.eval(x, y, v, primary)
+
+    is Neg -> -a.eval(x, y, v, primary)
+
+    is Abs -> abs(a.eval(x, y, v, primary))
+
+    is Log -> ln(a.eval(x, y, v, primary))
+
+    is Exp -> exp(a.eval(x, y, v, primary))
+
+    is Sqrt -> sqrt(a.eval(x, y, v, primary))
+
+    is Pow -> a.eval(x, y, v, primary).pow(b.eval(x, y, v, primary))
+
+    is MinExpr -> min(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
+
+    is MaxExpr -> max(l.eval(x, y, v, primary), r.eval(x, y, v, primary))
+
+    is IfExpr -> if (cond.eval(x, y, v, primary)) then.eval(x, y, v, primary) else otherwise.eval(x, y, v, primary)
+
+    is Switch -> {
+        val key = on.eval(x, y, v, primary)
+        cases.firstOrNull { it.value == key }?.then?.eval(x, y, v, primary) ?: otherwise.eval(x, y, v, primary)
+    }
+
+    Standardize -> {
+        val result = primary.feedbackPrimary<HasCenterScale>("Standardize")
+        if (result.scale > 0.0) (x - result.center) / result.scale else 0.0
+    }
+
+    is MinMax -> {
+        val result = primary.feedbackPrimary<HasMinMax>("MinMax")
+        val span = result.max - result.min
+        if (span > 0.0) targetLow + (x - result.min) / span * (targetHigh - targetLow) else targetLow
+    }
+
+    is VFold -> when (op) {
+        VFoldOp.Sum -> v.sum()
+
+        VFoldOp.Product -> (0 until v.size).fold(1.0) { product, i -> product * v[i] }
+
+        VFoldOp.Mean -> {
+            require(
+                v.size != 0,
+            ) { "VFold.Mean on empty vector" }
+            v.sum() / v.size
+        }
+
+        VFoldOp.Min -> {
+            require(
+                v.size != 0,
+            ) { "VFold.Min on empty vector" }
+            var minimum = v[0]
+            for (i in 1 until v.size) if (v[i] < minimum) minimum = v[i]
+            minimum
+        }
+
+        VFoldOp.Max -> {
+            require(
+                v.size != 0,
+            ) { "VFold.Max on empty vector" }
+            var maximum = v[0]
+            for (i in 1 until v.size) if (v[i] > maximum) maximum = v[i]
+            maximum
+        }
+
+        VFoldOp.Norm2 -> sqrt((0 until v.size).sumOf { v[it] * v[it] })
+    }
+
+    is VDot -> {
+        require(v.size == weights.size) { "VDot length mismatch: weights=${weights.size}, v=${v.size}" }
+        (0 until v.size).sumOf { weights[it] * v[it] }
+    }
+}
+
+private fun sparseNorm2(v: SparseVector): Double {
     var sum = 0.0
     v.forEachStored { _, value -> sum += value * value }
     return sqrt(sum)
 }
 
-private fun sparseDot(v: F64SparseVector, weights: List<Double>): Double {
+private fun sparseDot(v: SparseVector, weights: List<Double>): Double {
     var sum = 0.0
     v.forEachStored { index, value -> sum += weights[index] * value }
     return sum
 }
 
-private fun sparseMin(v: F64SparseVector): Double {
+private fun sparseMin(v: SparseVector): Double {
     require(v.size != 0) { "VFold.Min on empty vector" }
     var minimum = 0.0
     var first = true
@@ -1001,7 +1000,7 @@ private fun sparseMin(v: F64SparseVector): Double {
     return minimum
 }
 
-private fun sparseMax(v: F64SparseVector): Double {
+private fun sparseMax(v: SparseVector): Double {
     require(v.size != 0) { "VFold.Max on empty vector" }
     var maximum = 0.0
     var first = true
@@ -1021,7 +1020,7 @@ private fun sparseMax(v: F64SparseVector): Double {
 }
 
 /** Evaluate this boolean expression against a borrowed KoBLAS vector without materialising it. */
-fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): Boolean = when (this) {
+fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): Boolean = when (this) {
     is Gt -> l.eval(x, y, v, primary) > r.eval(x, y, v, primary)
 
     is Ge -> l.eval(x, y, v, primary) >= r.eval(x, y, v, primary)
@@ -1070,7 +1069,7 @@ fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: R
 }
 
 /** Evaluate this vector expression against a borrowed KoBLAS vector, allocating only its owned output. */
-fun VectorExpr.eval(x: Double = 0.0, y: Double = 0.0, v: F64VectorLike, primary: Result? = null): DoubleArray =
+fun VectorExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): DoubleArray =
     when (this) {
         is VElements -> DoubleArray(exprs.size) { i -> exprs[i].eval(x, y, v, primary) }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -159,7 +159,7 @@ internal class VectorListStats<R : Result>(
             concurrency = concurrency,
         )
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         for ((_, stat) in entries) stat.update(vector, timestampNanos, weight)
     }
 
@@ -245,7 +245,7 @@ internal class RegressionListStats<R : Result>(
     }
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -148,7 +148,7 @@ class VectorStatGroup(stats: List<BoundStat<*, out VectorStat<*>, *>>, concurren
     constructor(schema: StatSchema, concurrency: Concurrency = Concurrency.None) :
         this(stats = vectorSpecs(schema, concurrency), concurrency = concurrency)
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         for ((_, stat) in stats) stat.update(vector, timestampNanos, weight)
     }
 
@@ -197,7 +197,7 @@ class RegressionStatGroup(stats: List<BoundStat<*, out RegressionStat<*>, *>>, c
     }
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
@@ -86,7 +86,7 @@ data class HalfSpaceTreesResult(
      * means [x] falls into densely populated regions of the reference window;
      * i.e. it looks normal. Lower score flags an anomaly.
      */
-    fun score(x: F64VectorLike): Double {
+    fun score(x: VectorLike): Double {
         x.requireFeatureSize(featureSize)
         var total = 0.0
         val depthFactor = 1 shl height
@@ -204,7 +204,7 @@ class HalfSpaceTreesStat(
     private val windowCounter: StreamLong = counterMode.newLong(0L)
     private val totalWeightsCell = massMode.newDouble(0.0)
 
-    override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }
         if (weight.isNotPositiveWeight()) return
         for (t in 0 until numTrees) {
@@ -318,7 +318,7 @@ private fun routeToLeaf(
     height: Int,
     numInternal: Int,
     treeIdx: Int,
-    x: F64VectorLike,
+    x: VectorLike,
 ): Int {
     val treeOffset = treeIdx * numInternal
     var node = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/calibration/PlattCalibratorStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.calibration
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.PairedStat
@@ -70,7 +70,7 @@ class PlattCalibratorStat(
     )
 
     override fun update(x: Double, y: Double, timestampNanos: Long, weight: Double) {
-        inner.update(F64DenseVector.of(doubleArrayOf(x)), y, timestampNanos, weight)
+        inner.update(DenseVector.of(doubleArrayOf(x)), y, timestampNanos, weight)
     }
 
     override fun read(timestampNanos: Long): PlattCalibratorResult {
@@ -89,7 +89,7 @@ class PlattCalibratorStat(
      */
     override fun merge(values: PlattCalibratorResult, workspace: com.eignex.koblas.Workspace?) {
         val snapshot = StochasticRegressionResult(
-            weights = F64DenseVector.of(doubleArrayOf(values.slope)),
+            weights = DenseVector.of(doubleArrayOf(values.slope)),
             bias = values.intercept,
             totalWeights = values.totalWeights,
             step = 0L,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
@@ -42,11 +42,11 @@ data class GaussianNaiveBayesResult(
     /** Number of classes. */
     val numClasses: Int,
     /** K-by-p matrix of per-class running means; `means[c][i]` is the mean of feature `i` given class `c`. */
-    val means: F64DenseMatrix,
+    val means: DenseMatrix,
     /** K-by-p matrix of per-class running variances (population, weight-normalised). */
-    val variances: F64DenseMatrix,
+    val variances: DenseMatrix,
     /** Cumulative observation weight per class; length [numClasses]. */
-    val classWeights: F64DenseVector,
+    val classWeights: DenseVector,
     /** Total cumulative observation weight across all classes. */
     override val totalWeights: Double,
     /** Lower bound applied to per-class variances at predict time. */
@@ -70,7 +70,7 @@ data class GaussianNaiveBayesResult(
     fun prior(c: Int): Double = if (totalWeights > 0.0) classWeights[c] / totalWeights else 1.0 / numClasses
 
     /** Unnormalised log-posterior `log prior[c] + Sum_i log N(x_i | mu_c, var_c)`. */
-    fun logPosterior(x: F64VectorLike, c: Int): Double {
+    fun logPosterior(x: VectorLike, c: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = ln(prior(c).coerceAtLeast(SMALL_PROB))
         for (i in 0 until featureSize) {
@@ -83,7 +83,7 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Writes unnormalised log-posteriors for [x] into [destination]. */
-    fun logPosteriorsInto(x: F64VectorLike, destination: DoubleArray) {
+    fun logPosteriorsInto(x: VectorLike, destination: DoubleArray) {
         x.requireFeatureSize(featureSize)
         require(destination.size == numClasses) {
             "destination size ${destination.size} must match numClasses $numClasses"
@@ -92,16 +92,16 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Normalised class probabilities via log-sum-exp on the log-posterior. */
-    fun probabilities(x: F64VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
+    fun probabilities(x: VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
 
     /** Writes normalised class probabilities for [x] into [destination]. */
-    fun probabilitiesInto(x: F64VectorLike, destination: DoubleArray) {
+    fun probabilitiesInto(x: VectorLike, destination: DoubleArray) {
         logPosteriorsInto(x, destination)
         destination.softmaxInPlace()
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: F64VectorLike): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
+    fun predict(x: VectorLike): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
 
     private companion object {
         const val SMALL_PROB: Double = 1e-300
@@ -153,7 +153,7 @@ class GaussianNaiveBayesStat(
     private val totalWeightCell: StreamDouble = mode.newDouble(0.0)
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -196,9 +196,9 @@ class GaussianNaiveBayesStat(
         GaussianNaiveBayesResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            means = F64DenseMatrix.wrap(numClasses, featureSize, meansFlat),
-            variances = F64DenseMatrix.wrap(numClasses, featureSize, varsFlat),
-            classWeights = F64DenseVector.wrap(cw),
+            means = DenseMatrix.wrap(numClasses, featureSize, meansFlat),
+            variances = DenseMatrix.wrap(numClasses, featureSize, varsFlat),
+            classWeights = DenseVector.wrap(cw),
             totalWeights = totalWeightCell.load(),
             varianceFloor = varianceFloor,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
 
@@ -26,7 +26,7 @@ interface RegressionPosterior<R : Result> {
      */
     fun evaluate(
         snapshot: R,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double = 1.0,
         workspace: Workspace? = null,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -1,10 +1,10 @@
 package com.eignex.kumulant.stat.regression
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
@@ -44,9 +44,9 @@ data class SoftmaxRegressionResult(
     /** Number of classes (rows of [weights] and length of [biases]). */
     val numClasses: Int,
     /** K-by-p weight matrix; `weights[k][i]` is the coefficient on feature `i` for class `k`. */
-    val weights: F64DenseMatrix,
+    val weights: DenseMatrix,
     /** Per-class intercept; length [numClasses]. */
-    val biases: F64DenseVector,
+    val biases: DenseVector,
     /** Cumulative observation weight folded in. */
     override val totalWeights: Double,
     /** Number of `update` calls absorbed. */
@@ -62,7 +62,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Linear predictor for class [k]: `biases[k] + weights[k] . x`. */
-    fun logit(x: F64VectorLike, k: Int): Double {
+    fun logit(x: VectorLike, k: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = biases[k]
         // Walk what x stores rather than every feature index. Reading a sparse x position by
@@ -73,7 +73,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Writes the per-class logits for [x] into [destination]. */
-    fun logitsInto(x: F64VectorLike, destination: DoubleArray) {
+    fun logitsInto(x: VectorLike, destination: DoubleArray) {
         x.requireFeatureSize(featureSize)
         require(destination.size == numClasses) {
             "destination size ${destination.size} must match numClasses $numClasses"
@@ -83,10 +83,10 @@ data class SoftmaxRegressionResult(
     }
 
     /** Softmax probabilities across all classes for [x]; length [numClasses]. */
-    fun probabilities(x: F64VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
+    fun probabilities(x: VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
 
     /** Writes softmax probabilities for [x] into caller-owned [destination]. */
-    fun probabilitiesInto(x: F64VectorLike, destination: DoubleArray) {
+    fun probabilitiesInto(x: VectorLike, destination: DoubleArray) {
         logitsInto(x, destination)
         destination.softmaxInPlace()
     }
@@ -99,7 +99,7 @@ data class SoftmaxRegressionResult(
      * is a search through its stored indices. Without a [workspace] to borrow from, the single pass
      * costs one length-[numClasses] buffer, which is the cheaper side of that trade.
      */
-    fun predict(x: F64VectorLike, workspace: Workspace? = null): Int = workspace.borrow(numClasses) { logits ->
+    fun predict(x: VectorLike, workspace: Workspace? = null): Int = workspace.borrow(numClasses) { logits ->
         logitsInto(x, logits)
         argMaxOf(numClasses) { logits[it] }
     }
@@ -172,7 +172,7 @@ class SoftmaxRegressionStat(
     val crossEntropy: Double by crossEntropyCell
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -223,10 +223,10 @@ class SoftmaxRegressionStat(
         SoftmaxRegressionResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            weights = F64DenseMatrix.of(
+            weights = DenseMatrix.of(
                 Array(numClasses) { k -> w.copyOfRange(k * featureSize, (k + 1) * featureSize) },
             ),
-            biases = F64DenseVector.of(b),
+            biases = DenseVector.of(b),
             totalWeights = totalWeightsCell.load(),
             step = stepCell.load(),
             crossEntropy = crossEntropyCell.load(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -4,14 +4,14 @@
 
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.MatrixLike
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.axpy
 import com.eignex.koblas.borrow
 import com.eignex.koblas.copy
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64MatrixLike
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dense.trmv
 import com.eignex.koblas.dot
 import com.eignex.koblas.koblas
@@ -33,7 +33,7 @@ import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
 
-private fun F64MatrixLike.copyDenseMatrix(): F64DenseMatrix = F64DenseMatrix.wrap(
+private fun MatrixLike.copyDenseMatrix(): DenseMatrix = DenseMatrix.wrap(
     rows,
     cols,
     DoubleArray(rows * cols) { index -> this[index % rows, index / rows] },
@@ -96,8 +96,8 @@ class BayesianRegressionStat(
     /** Canonical GLM link function; [Link.Identity] is the strict closed-form Gaussian posterior. */
     val link: Link = Link.Identity,
     override val concurrency: Concurrency = Concurrency.None,
-    priorMean: F64VectorLike? = null,
-    priorCovariance: F64MatrixLike? = null,
+    priorMean: VectorLike? = null,
+    priorCovariance: MatrixLike? = null,
 ) : RegressionStat<PrecisionRegressionResult> {
 
     init {
@@ -117,14 +117,14 @@ class BayesianRegressionStat(
     // `initialCovariance` survives only so `create()` can hand a child the same prior it was
     // given, rather than a round-tripped inverse of the precision.
     private val initialWeights: DoubleArray = priorMean?.toDoubleArray() ?: DoubleArray(featureSize)
-    private val initialCovariance: F64DenseMatrix = priorCovariance
+    private val initialCovariance: DenseMatrix = priorCovariance
         ?.copyDenseMatrix()
-        ?: F64DenseMatrix.diagonal(featureSize, priorVariance)
+        ?: DenseMatrix.diagonal(featureSize, priorVariance)
 
     // Prior precision H_prior = Sigma_prior^-1, cached so merge() can subtract one prior factor,
     // and its factor, which is where every update starts.
-    private val priorPrecisionMatrix: F64DenseMatrix
-    private val initialPrecisionL: F64DenseMatrix
+    private val priorPrecisionMatrix: DenseMatrix
+    private val initialPrecisionL: DenseMatrix
 
     init {
         // Both factorizations are strict: a caller prior that cannot be inverted has to fail at
@@ -139,12 +139,12 @@ class BayesianRegressionStat(
 
     // priorInfo = H_prior * mu_prior, the natural-form contribution from the prior.
     private val priorInfo = DoubleArray(featureSize).also {
-        priorPrecisionMatrix.multiplyInto(F64DenseVector.wrap(initialWeights), it)
+        priorPrecisionMatrix.multiplyInto(DenseVector.wrap(initialWeights), it)
     }
 
     private val lock = concurrency.serializedLock()
-    private val weights = F64DenseVector.wrap(initialWeights.copyOf())
-    private val precisionL = F64DenseMatrix.wrap(featureSize, featureSize, initialPrecisionL.data.copyOf())
+    private val weights = DenseVector.wrap(initialWeights.copyOf())
+    private val precisionL = DenseMatrix.wrap(featureSize, featureSize, initialPrecisionL.data.copyOf())
 
     private var bias: Double = 0.0
     private var biasPrecision: Double = 1.0 / priorVariance
@@ -152,12 +152,12 @@ class BayesianRegressionStat(
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: F64VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) =
+    override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) =
         updateInternal(x, y, timestampNanos, weight, workspace)
 
     @Suppress("UnusedParameter")
     private fun updateInternal(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         _timestampNanos: Long,
         weight: Double,
@@ -187,7 +187,7 @@ class BayesianRegressionStat(
             // untouched, so the scattered x is still there for the solve afterwards; scattering
             // also spares the update a binary search per coordinate when x arrives sparse.
             workspace.borrow(featureSize) { hx ->
-                val solved = F64DenseVector.wrap(hx)
+                val solved = DenseVector.wrap(hx)
                 copy(x, solved)
 
                 // H <- H + w_c * x xT, as a rank-1 update of its factor; a zero w_c leaves it alone.
@@ -207,12 +207,12 @@ class BayesianRegressionStat(
 
     override fun read(timestampNanos: Long): PrecisionRegressionResult = lock.guarded {
         PrecisionRegressionResult(
-            weights = F64DenseVector.wrap(weights.data.copyOf()),
+            weights = DenseVector.wrap(weights.data.copyOf()),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            precisionL = F64DenseMatrix.wrap(featureSize, featureSize, precisionL.data.copyOf()),
+            precisionL = DenseMatrix.wrap(featureSize, featureSize, precisionL.data.copyOf()),
             link = link,
             sse = sse,
         )
@@ -250,7 +250,7 @@ class BayesianRegressionStat(
             // only one the Cholesky below reads. `syrk` takes each factor as a general matrix, so
             // it depends on the strict upper triangle being zero. Factorization clears it, and
             // rank-1 updates preserve it.
-            val hNew = F64DenseMatrix.zero(n, n)
+            val hNew = DenseMatrix.zero(n, n)
             koblas.syrk(1.0, precisionL, transpose = false, 0.0, hNew, lower = true, workspace = workspace)
             koblas.syrk(1.0, values.precisionL, transpose = false, 1.0, hNew, lower = true, workspace = workspace)
             for (j in 0 until n) {
@@ -310,8 +310,8 @@ class BayesianRegressionStat(
         priorVariance = priorVariance,
         link = link,
         concurrency = concurrency ?: this.concurrency,
-        priorMean = F64DenseVector.wrap(initialWeights.copyOf()),
-        priorCovariance = F64DenseMatrix.wrap(featureSize, featureSize, initialCovariance.data.copyOf()),
+        priorMean = DenseVector.wrap(initialWeights.copyOf()),
+        priorCovariance = DenseMatrix.wrap(featureSize, featureSize, initialCovariance.data.copyOf()),
     )
 
     /** Empirical-Bayes / hierarchical helpers that operate on populations of fitted snapshots. */
@@ -358,16 +358,16 @@ class BayesianRegressionStat(
             for (i in 0 until n) muPop[i] /= wTotal
 
             // Sigma_pop = weighted mean of Sigma_i + weighted covariance of (mu_i - mu_pop).
-            val sigmaPop = F64DenseMatrix.zero(n, n)
+            val sigmaPop = DenseMatrix.zero(n, n)
             // One buffer for every snapshot's covariance: the inversion writes each entry, so it
             // never sees what the previous instance left behind.
-            val cov = F64DenseMatrix.zero(n, n)
+            val cov = DenseMatrix.zero(n, n)
             // Both matrices are square, n by n, and column-major, so their flat backings line up
             // entry for entry and the matrix add is a level-1 axpy over the whole of them.
-            val sigmaFlat = F64DenseVector.wrap(sigmaPop.data)
-            val covFlat = F64DenseVector.wrap(cov.data)
+            val sigmaFlat = DenseVector.wrap(sigmaPop.data)
+            val covFlat = DenseVector.wrap(cov.data)
             val deviation = DoubleArray(n)
-            val deviationVector = F64DenseVector.wrap(deviation)
+            val deviationVector = DenseVector.wrap(deviation)
             for (s in snapshots.indices) {
                 val wi = weights[s] / wTotal
                 snapshots[s].covarianceInto(cov)
@@ -384,7 +384,7 @@ class BayesianRegressionStat(
             }
 
             return PopulationPrior(
-                mean = F64DenseVector.of(muPop),
+                mean = DenseVector.of(muPop),
                 covariance = sigmaPop,
                 instanceCount = snapshots.size,
             )
@@ -400,9 +400,9 @@ class BayesianRegressionStat(
 @Serializable
 data class PopulationPrior(
     /** Population mean of the per-instance posterior means. */
-    val mean: F64DenseVector,
+    val mean: DenseVector,
     /** Population covariance: within-instance posterior + between-instance mean spread. */
-    val covariance: F64DenseMatrix,
+    val covariance: DenseMatrix,
     /** Number of per-instance posteriors that contributed to this prior. */
     val instanceCount: Int,
 )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
@@ -86,7 +86,7 @@ class DiagonalRegressionStat(
     private var sse: Double = 0.0
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -98,7 +98,7 @@ class DiagonalRegressionStat(
             step++
             val eta = learningRate.eval(step.toDouble())
 
-            val etaPred = bias + (x dot F64DenseVector.wrap(weights))
+            val etaPred = bias + (x dot DenseVector.wrap(weights))
             val mu = link.invMean(etaPred)
             val negResidual = mu - y
             val curvature = link.curvature(etaPred)
@@ -132,12 +132,12 @@ class DiagonalRegressionStat(
 
     override fun read(timestampNanos: Long): DiagonalRegressionResult = lock.guarded {
         DiagonalRegressionResult(
-            weights = F64DenseVector.wrap(weights.copyOf()),
+            weights = DenseVector.wrap(weights.copyOf()),
             bias = bias,
             biasPrecision = biasPrecision,
             totalWeights = totalWeights,
             step = step,
-            precision = F64DenseVector.wrap(precision.copyOf()),
+            precision = DenseVector.wrap(precision.copyOf()),
             link = link,
             sse = sse,
         )

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.requirePositiveFeatureSize
 
@@ -37,8 +37,8 @@ class HierarchicalBayesianRegression(
     /** Concurrency level forwarded to each instance. */
     val concurrency: Concurrency = Concurrency.None,
     initialPriorVariance: Double = 1.0,
-    initialPriorMean: F64DenseVector? = null,
-    initialPriorCovariance: F64DenseMatrix? = null,
+    initialPriorMean: DenseVector? = null,
+    initialPriorCovariance: DenseMatrix? = null,
 ) {
     init {
         requirePositiveFeatureSize(featureSize)
@@ -52,8 +52,8 @@ class HierarchicalBayesianRegression(
      * call [refit] to update it from the current per-instance posteriors.
      */
     var populationPrior: PopulationPrior = PopulationPrior(
-        mean = initialPriorMean ?: F64DenseVector.zero(featureSize),
-        covariance = initialPriorCovariance ?: F64DenseMatrix.diagonal(featureSize, initialPriorVariance),
+        mean = initialPriorMean ?: DenseVector.zero(featureSize),
+        covariance = initialPriorCovariance ?: DenseMatrix.diagonal(featureSize, initialPriorVariance),
         instanceCount = 0,
     )
         private set

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.axpy
 import com.eignex.koblas.borrow
 import com.eignex.koblas.copy
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
@@ -36,7 +36,7 @@ import kotlin.random.Random
 sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosterior<R> {
     /** Draw a weight vector from the posterior at `exploration` variance scale.
      *  `exploration = 0.0` collapses to the point estimate; `1.0` is the calibrated posterior. */
-    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): F64VectorLike
+    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): VectorLike
 
     /** Writes an owned posterior draw into [destination]. */
     fun sampleInto(snapshot: R, rng: Random, destination: DoubleArray, exploration: Double = 1.0) {
@@ -62,7 +62,7 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
      */
     override fun evaluate(
         snapshot: R,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -77,9 +77,9 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
 @Serializable
 @SerialName("PointPosterior")
 data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
-    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): F64VectorLike {
+    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): VectorLike {
         if (exploration <= 0.0) return snapshot.weights
-        return F64DenseVector.wrap(
+        return DenseVector.wrap(
             DoubleArray(snapshot.weights.size).also { destination ->
                 sampleInto(snapshot, rng, destination, exploration)
             },
@@ -107,7 +107,7 @@ data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
      *  are iid; one Gaussian draw instead of one per coordinate. */
     override fun evaluate(
         snapshot: StochasticRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -126,8 +126,8 @@ data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
 @Serializable
 @SerialName("FactorisedGaussian")
 data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
-    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): F64VectorLike =
-        F64DenseVector.wrap(
+    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): VectorLike =
+        DenseVector.wrap(
             DoubleArray(snapshot.weights.size).also { destination ->
                 sampleInto(snapshot, rng, destination, exploration)
             },
@@ -153,7 +153,7 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
     /** Sum of independent normals: `invMean(eta(x) + sqrt(exploration * Sum x_i^2 / precision[i]) * N(0,1))`. */
     override fun evaluate(
         snapshot: DiagonalRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -170,11 +170,11 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
  * `sqrt(xT * Sigma * x) = ||L^-1 x||` for the precision factor `L` with `Sigma = (L * LT)^-1`.
  * One forward substitution, so the covariance is never formed.
  */
-private fun PrecisionRegressionResult.predictiveDeviation(x: F64VectorLike, workspace: Workspace?): Double =
+private fun PrecisionRegressionResult.predictiveDeviation(x: VectorLike, workspace: Workspace?): Double =
     workspace.borrow(featureSize) { v ->
-        copy(x, F64DenseVector.wrap(v))
+        copy(x, DenseVector.wrap(v))
         precisionL.trsv(v, lower = true)
-        F64DenseVector.wrap(v).norm2()
+        DenseVector.wrap(v).norm2()
     }
 
 /**
@@ -189,12 +189,12 @@ private fun PrecisionRegressionResult.predictiveDeviation(x: F64VectorLike, work
 @Serializable
 @SerialName("MultivariateGaussian")
 data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
-    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): F64VectorLike {
+    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): VectorLike {
         val n = snapshot.weights.size
         val sd = sqrt(exploration)
         val u = DoubleArray(n) { rng.nextNormal(0.0, sd) }
         snapshot.precisionL.trsv(u, lower = true, transpose = true)
-        return F64DenseVector.wrap(u).also { it.axpy(1.0, snapshot.weights) }
+        return DenseVector.wrap(u).also { it.axpy(1.0, snapshot.weights) }
     }
 
     override fun sampleInto(
@@ -216,7 +216,7 @@ data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
      *  solve instead of sampling the full weight vector. */
     override fun evaluate(
         snapshot: PrecisionRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -238,7 +238,7 @@ data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
 @Serializable
 @SerialName("LinUcb")
 data object LinUcb : LinearPosterior<PrecisionRegressionResult> {
-    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): F64VectorLike =
+    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): VectorLike =
         snapshot.weights
 
     override fun sampleInto(
@@ -255,7 +255,7 @@ data object LinUcb : LinearPosterior<PrecisionRegressionResult> {
 
     override fun evaluate(
         snapshot: PrecisionRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.koblas.dot
 import com.eignex.kumulant.core.HasLinearModel
 import com.eignex.kumulant.core.HasRegression
@@ -22,8 +22,8 @@ import kotlinx.serialization.Serializable
  *  - [DiagonalRegressionResult]: per-coefficient precision (factorised posterior).
  *  - [PrecisionRegressionResult]: full posterior as the Cholesky factor of its precision.
  *
- * Sealed + `@Serializable`. Concrete weights round-trip as [F64DenseVector] today;
- * the public field is typed [F64VectorLike] so a sparse variant can swap in without
+ * Sealed + `@Serializable`. Concrete weights round-trip as [DenseVector] today;
+ * the public field is typed [VectorLike] so a sparse variant can swap in without
  * breaking callers. Regression error metrics from [HasRegression] become
  * meaningful once [sse] is tracked; implementations that don't accumulate it
  * return `0.0`.
@@ -33,7 +33,7 @@ sealed interface LinearRegressionResult :
     Result,
     HasLinearModel,
     HasRegression {
-    override val weights: F64VectorLike
+    override val weights: VectorLike
 
     override val bias: Double
 
@@ -49,14 +49,14 @@ sealed interface LinearRegressionResult :
     val link: Link
 
     /** Linear predictor `eta = bias + x . weights`, before the inverse link. */
-    fun linearPredictor(x: F64VectorLike): Double {
+    fun linearPredictor(x: VectorLike): Double {
         x.requireFeatureSize(weights.size)
         return bias + (x dot weights)
     }
 
     /** Mean response: `link.invMean(linearPredictor(x))`. For [Link.Identity] this is
      *  the linear predictor itself, matching plain linear regression. */
-    override fun predict(x: F64VectorLike): Double = link.invMean(linearPredictor(x))
+    override fun predict(x: VectorLike): Double = link.invMean(linearPredictor(x))
 }
 
 /** SGD weight estimates with no posterior. Cheap, no uncertainty quantification.
@@ -67,14 +67,14 @@ sealed interface LinearRegressionResult :
 @Serializable
 @SerialName("StochasticRegressionResult")
 data class StochasticRegressionResult(
-    override val weights: F64DenseVector,
+    override val weights: DenseVector,
     override val bias: Double,
     override val totalWeights: Double,
     override val step: Long,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
     /** Per-optimiser auxiliary state (e.g. Adam's `m`/`v`); empty for plain SGD. */
-    val updaterState: List<F64VectorLike> = emptyList(),
+    val updaterState: List<VectorLike> = emptyList(),
 ) : LinearRegressionResult
 
 /**
@@ -85,14 +85,14 @@ data class StochasticRegressionResult(
 @Serializable
 @SerialName("DiagonalRegressionResult")
 data class DiagonalRegressionResult(
-    override val weights: F64DenseVector,
+    override val weights: DenseVector,
     override val bias: Double,
     /** Posterior precision (inverse variance) on the bias term. */
     val biasPrecision: Double,
     override val totalWeights: Double,
     override val step: Long,
     /** Per-coefficient precision (inverse variance). Same length as [weights]. */
-    val precision: F64DenseVector,
+    val precision: DenseVector,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
 ) : LinearRegressionResult
@@ -109,7 +109,7 @@ data class DiagonalRegressionResult(
 @Serializable
 @SerialName("PrecisionRegressionResult")
 data class PrecisionRegressionResult(
-    override val weights: F64DenseVector,
+    override val weights: DenseVector,
     override val bias: Double,
     /** Posterior precision (inverse variance) on the bias term. */
     val biasPrecision: Double,
@@ -117,7 +117,7 @@ data class PrecisionRegressionResult(
     override val step: Long,
     /** Cholesky factor of the posterior precision over [weights]: `H = L·Lᵀ`, covariance `S = H⁻¹`.
      *  Only the lower triangle is meaningful, matching koblas's factor convention. */
-    val precisionL: F64DenseMatrix,
+    val precisionL: DenseMatrix,
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
 ) : LinearRegressionResult {
@@ -134,13 +134,13 @@ data class PrecisionRegressionResult(
      * matrix per call, so it belongs in reporting and prior fitting; scoring paths should stay on
      * the factor.
      */
-    fun covariance(workspace: Workspace? = null): F64DenseMatrix = precisionL.choleskyInverse(workspace)
+    fun covariance(workspace: Workspace? = null): DenseMatrix = precisionL.choleskyInverse(workspace)
 
     /**
      * Posterior covariance into [out], which is returned. Every entry is written, so a buffer
      * carried across calls needs no clearing; still O(n³) each time, so this saves the allocation
      * rather than the work. [out] must not be [precisionL] itself.
      */
-    fun covarianceInto(out: F64DenseMatrix, workspace: Workspace? = null): F64DenseMatrix =
+    fun covarianceInto(out: DenseMatrix, workspace: Workspace? = null): DenseMatrix =
         precisionL.choleskyInvertInto(out, workspace)
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/MatrixVector.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/MatrixVector.kt
@@ -1,16 +1,16 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.koblas
 
 /** Writes `matrix * x` to [destination] without materialising a vector for sparse or generic [x]. */
-internal fun F64DenseMatrix.multiplyInto(x: F64VectorLike, destination: DoubleArray) {
+internal fun DenseMatrix.multiplyInto(x: VectorLike, destination: DoubleArray) {
     require(x.size == cols) { "x size ${x.size} must match matrix columns $cols" }
     require(destination.size == rows) { "destination size ${destination.size} must match matrix rows $rows" }
-    if (x is F64DenseVector) {
+    if (x is DenseVector) {
         koblas.gemv(1.0, this, x.data, 0.0, destination)
         return
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -125,7 +125,7 @@ class StochasticRegressionStat(
     private fun requireSgdBiasRate(): ScalarExpr = sgdBiasRate ?: error("Sgd bias rate required")
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -238,7 +238,7 @@ class StochasticRegressionStat(
             }
         }
         StochasticRegressionResult(
-            weights = F64DenseVector.wrap(materialised),
+            weights = DenseVector.wrap(materialised),
             bias = biasCell.load(),
             totalWeights = totalWeightsCell.load(),
             step = stepCell.load(),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/package.md
@@ -49,7 +49,7 @@ per-feature-set; per-coordinate aux state honours the stat's
 
 [RegressionPosterior] is the scoring interface shared by every
 regression family. A posterior projects a [com.eignex.kumulant.core.Result]
-and a query [com.eignex.koblas.core.F64VectorLike] to a scalar score,
+and a query [com.eignex.koblas.VectorLike] to a scalar score,
 parametrised by an `exploration` knob and a `Random`. The contextual
 bandits ([com.eignex.kumulant.bandit.contextual.RegressionContextualBandit])
 consume posteriors at choose time.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
@@ -17,7 +17,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /** The classification instantiation of the node-shape SPI. */
 internal typealias ClassificationShapeSpi = TreeShape<
-    F64VectorLike,
+    VectorLike,
     SerializableSplit,
     ClassificationNode,
     ClassificationSplitNode,
@@ -57,22 +57,22 @@ class ClassificationTree(
     )
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: F64VectorLike): ClassificationLeafNode = growth.root.findLeaf(row)
+    fun findLeaf(row: VectorLike): ClassificationLeafNode = growth.root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
     fun rootNode(): ClassificationNode = growth.root
 
     /** Argmax class at the leaf [row] resolves to. */
-    fun predict(row: F64VectorLike): Int = findLeaf(row).arm.read(0L).predict()
+    fun predict(row: VectorLike): Int = findLeaf(row).arm.read(0L).predict()
 
     /** Probabilities at the leaf [row] resolves to. */
-    fun probabilities(row: F64VectorLike): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
+    fun probabilities(row: VectorLike): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
 
     /** Number of internal + leaf nodes currently in the tree. */
     val nodeCount: Int get() = growth.nbrNodes.load()
 
     /** Fold an observation `(row, classLabel)` into the tree, possibly growing it. */
-    fun update(row: F64VectorLike, classLabel: Int, weight: Double = 1.0) {
+    fun update(row: VectorLike, classLabel: Int, weight: Double = 1.0) {
         if (classLabel !in 0 until numClasses) return
         growth.update(row, classLabel.toDouble(), weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicLong
@@ -14,7 +14,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  */
 sealed interface ClassificationNode {
     /** Walk to the leaf this row resolves to. */
-    fun findLeaf(row: F64VectorLike): ClassificationLeafNode
+    fun findLeaf(row: VectorLike): ClassificationLeafNode
 }
 
 /** Split mirror; predicate routes to [pos] or [neg]; [carryover] absorbs orphan
@@ -35,7 +35,7 @@ class ClassificationSplitNode(
     @Volatile
     var carryover: SeriesStat<ClassCountsResult>? = carryover
 
-    override fun findLeaf(row: F64VectorLike): ClassificationLeafNode =
+    override fun findLeaf(row: VectorLike): ClassificationLeafNode =
         if (split.direction(row)) pos.findLeaf(row) else neg.findLeaf(row)
 }
 
@@ -43,7 +43,7 @@ class ClassificationSplitNode(
 sealed class ClassificationLeafNode : ClassificationNode {
     /** The leaf's class-count accumulator. */
     abstract val arm: SeriesStat<ClassCountsResult>
-    final override fun findLeaf(row: F64VectorLike): ClassificationLeafNode = this
+    final override fun findLeaf(row: VectorLike): ClassificationLeafNode = this
 }
 
 /** Frozen leaf; no further splits considered. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -85,7 +85,7 @@ class DecisionTreeClassifierStat(
     )
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -77,9 +77,9 @@ class DecisionTreeRegressionStat(
     // path and rewritten by reset, so without it a concurrent updater can go on writing into the
     // pre-reset tree indefinitely, never observing the replacement.
     @Volatile
-    private var tree: RegressionTree<F64VectorLike> = newTree()
+    private var tree: RegressionTree<VectorLike> = newTree()
 
-    private fun newTree(): RegressionTree<F64VectorLike> = RegressionTree(
+    private fun newTree(): RegressionTree<VectorLike> = RegressionTree(
         splitCandidates,
         config,
         concurrency,
@@ -88,7 +88,7 @@ class DecisionTreeRegressionStat(
     )
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -127,5 +127,5 @@ class DecisionTreeRegressionStat(
     )
 
     /** Live underlying tree. Use for inspection / pretty-printing. */
-    fun tree(): RegressionTree<F64VectorLike> = tree
+    fun tree(): RegressionTree<VectorLike> = tree
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -96,7 +96,7 @@ class RandomForestClassifierStat(
     )
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -179,7 +179,7 @@ data class ForestClassificationResult(
     }
 
     /** Average per-class probability across trees for the leaf each tree routes [x] to. */
-    fun probabilities(x: F64VectorLike): DoubleArray {
+    fun probabilities(x: VectorLike): DoubleArray {
         val acc = DoubleArray(numClasses)
         for (t in trees) {
             val p = t.probabilities(x)
@@ -191,7 +191,7 @@ data class ForestClassificationResult(
     }
 
     /** Argmax over [probabilities]. */
-    fun predict(x: F64VectorLike): Int {
+    fun predict(x: VectorLike): Int {
         val p = probabilities(x)
         return argMaxOf(numClasses) { k -> p[k] }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -81,9 +81,9 @@ class RandomForestRegressionStat(
     // path and rewritten by reset, so without it a concurrent updater can go on writing into the
     // pre-reset tree indefinitely, never observing the replacement.
     @Volatile
-    private var trees: Array<RegressionTree<F64VectorLike>> = Array(nbrTrees) { newTree() }
+    private var trees: Array<RegressionTree<VectorLike>> = Array(nbrTrees) { newTree() }
 
-    private fun newTree(): RegressionTree<F64VectorLike> = RegressionTree(
+    private fun newTree(): RegressionTree<VectorLike> = RegressionTree(
         splitCandidates,
         this.config,
         concurrency,
@@ -92,7 +92,7 @@ class RandomForestRegressionStat(
     )
 
     override fun update(
-        x: F64VectorLike,
+        x: VectorLike,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -150,7 +150,7 @@ class RandomForestRegressionStat(
     )
 
     /** Live underlying trees. Use for inspection. */
-    fun trees(): List<RegressionTree<F64VectorLike>> = trees.toList()
+    fun trees(): List<RegressionTree<VectorLike>> = trees.toList()
 }
 
 /** Snapshot of a [RandomForestRegressionStat]: per-tree immutable snapshots. */
@@ -166,7 +166,7 @@ data class ForestRegressionResult(
 
     /** Merge the leaves that [x] routes to across every tree into a single weighted-
      *  variance aggregate. Useful for ensembled scoring. */
-    fun findLeafMerged(x: F64VectorLike): WeightedVarianceResult {
+    fun findLeafMerged(x: VectorLike): WeightedVarianceResult {
         // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, which short-circuits only
         // on an exactly-zero weight: a leaf left with negative total weight by an over-reaching
         // downdate would otherwise be folded in, and against a positive sibling of equal magnitude the
@@ -181,7 +181,7 @@ data class ForestRegressionResult(
     }
 
     /** Mean of [findLeafMerged]. */
-    fun predict(x: F64VectorLike): Double = findLeafMerged(x).mean
+    fun predict(x: VectorLike): Double = findLeafMerged(x).mean
 
     /** Sum of per-tree root totalWeights; `nbrTrees * underlyingWeight` under bagging. */
     val totalWeights: Double get() = trees.sumOf { it.totalWeights }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -34,9 +34,9 @@ internal typealias RegressionShapeSpi<Row> = TreeShape<
  *
  * The engine is **generic over the feature representation**: it only ever inspects a row
  * by calling [Split.direction], so any feature type can drive growth by supplying its own
- * [Split]s (e.g. a dense [com.eignex.koblas.core.F64VectorLike] for the built-in stats, or
+ * [Split]s (e.g. a dense [com.eignex.koblas.VectorLike] for the built-in stats, or
  * a typed/constraint-coupled row from a downstream library). Wire-portable serialization
- * of a snapshot is only meaningful for the [com.eignex.koblas.core.F64VectorLike] case and
+ * of a snapshot is only meaningful for the [com.eignex.koblas.VectorLike] case and
  * lives in `TreeRegressionResult.kt` as `VectorLike`-constrained extensions.
  *
  * Internal split nodes hold no live arm; subtree aggregates (`rootSnapshot`, the `value`

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.schema.expr.BoolExpr
 import com.eignex.kumulant.schema.expr.eval
 import kotlinx.serialization.SerialName
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  *
  * The interface is intentionally **open and non-serializable**: it is the in-memory SPI
  * for growing trees over arbitrary features. Wire-portable splits over a dense
- * [F64VectorLike] context live under the [SerializableSplit] hierarchy, which the
+ * [VectorLike] context live under the [SerializableSplit] hierarchy, which the
  * serializable tree snapshots ([TreeNodeResult]) embed.
  */
 interface Split<in Row> {
@@ -23,13 +23,13 @@ interface Split<in Row> {
 }
 
 /**
- * Wire-portable [Split] over a dense [F64VectorLike] context. Sealed + serializable so tree
+ * Wire-portable [Split] over a dense [VectorLike] context. Sealed + serializable so tree
  * snapshots round-trip cleanly through `kotlinx.serialization`. Built-in implementations:
  * [ThresholdSplit] (numeric `x[i] <= t`) and [ExprSplit] (wrapping a [BoolExpr]); callers
  * needing custom predicates compose them as [BoolExpr] AST nodes and wrap in [ExprSplit].
  */
 @Serializable
-sealed interface SerializableSplit : Split<F64VectorLike>
+sealed interface SerializableSplit : Split<VectorLike>
 
 /** Route by `row[featureIndex] <= threshold`. Threshold is inclusive on the "pos" side. */
 @Serializable
@@ -40,7 +40,7 @@ data class ThresholdSplit(
     /** Inclusive threshold separating pos (<=) from neg (>). */
     val threshold: Double,
 ) : SerializableSplit {
-    override fun direction(row: F64VectorLike): Boolean = row[featureIndex] <= threshold
+    override fun direction(row: VectorLike): Boolean = row[featureIndex] <= threshold
     override fun toString(): String = "x[$featureIndex] <= $threshold"
 }
 
@@ -56,7 +56,7 @@ data class ExprSplit(
     /** Predicate expression over the context vector. */
     val expr: BoolExpr,
 ) : SerializableSplit {
-    override fun direction(row: F64VectorLike): Boolean {
+    override fun direction(row: VectorLike): Boolean {
         val x = if (row.size >= 1) row[0] else 0.0
         val y = if (row.size >= 2) row[1] else 0.0
         return expr.eval(x, y, row)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,13 +13,13 @@ data class TreeClassificationResult(
     val root: TreeClassificationNodeResult,
 ) : Result {
     /** Walk to the leaf the context [x] resolves to and return its class-count snapshot. */
-    fun findLeaf(x: F64VectorLike): ClassCountsResult = root.findLeaf(x)
+    fun findLeaf(x: VectorLike): ClassCountsResult = root.findLeaf(x)
 
     /** Class probabilities at the leaf [x] resolves to. */
-    fun probabilities(x: F64VectorLike): DoubleArray = findLeaf(x).probabilities()
+    fun probabilities(x: VectorLike): DoubleArray = findLeaf(x).probabilities()
 
     /** Argmax class index at the leaf [x] resolves to. */
-    fun predict(x: F64VectorLike): Int = findLeaf(x).predict()
+    fun predict(x: VectorLike): Int = findLeaf(x).predict()
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -35,7 +35,7 @@ sealed interface TreeClassificationNodeResult {
     val value: ClassCountsResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: F64VectorLike): ClassCountsResult
+    fun findLeaf(x: VectorLike): ClassCountsResult
 }
 
 /** Immutable classification split-node snapshot. */
@@ -50,7 +50,7 @@ data class TreeClassificationSplitResult(
     val neg: TreeClassificationNodeResult,
     override val value: ClassCountsResult,
 ) : TreeClassificationNodeResult {
-    override fun findLeaf(x: F64VectorLike): ClassCountsResult =
+    override fun findLeaf(x: VectorLike): ClassCountsResult =
         if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
@@ -58,7 +58,7 @@ data class TreeClassificationSplitResult(
 @Serializable
 @SerialName("TreeClassificationLeafResult")
 data class TreeClassificationLeafResult(override val value: ClassCountsResult) : TreeClassificationNodeResult {
-    override fun findLeaf(x: F64VectorLike): ClassCountsResult = value
+    override fun findLeaf(x: VectorLike): ClassCountsResult = value
 }
 
 /** Freeze a live classification-tree node into an immutable snapshot. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -27,7 +27,7 @@ sealed interface TreePosterior : RegressionPosterior<TreeRegressionResult>
 data object MeanTreePosterior : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -77,7 +77,7 @@ data class ThompsonTreePosterior(
 ) : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -103,7 +103,7 @@ data class UcbTreePosterior(
 ) : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -123,7 +123,7 @@ sealed interface ForestPosterior : RegressionPosterior<ForestRegressionResult>
 data object MeanForestPosterior : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -139,7 +139,7 @@ data class ThompsonForestPosterior(
 ) : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -160,7 +160,7 @@ data class UcbForestPosterior(
 ) : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: F64VectorLike,
+        x: VectorLike,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,18 +1,18 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [F64VectorLike]
+ * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorLike]
  * context. Carries the tree structure ([SerializableSplit] predicates + per-node
  * weighted-variance aggregates) so callers can route a context vector to its leaf without
  * reaching back into the live stat.
  *
- * Serialization is only meaningful for the [F64VectorLike] feature representation (the splits
+ * Serialization is only meaningful for the [VectorLike] feature representation (the splits
  * must be wire-portable); trees grown over other [Split] row types use the live
  * [RegressionTree] directly and are not snapshotted to this type.
  *
@@ -26,10 +26,10 @@ data class TreeRegressionResult(
     val root: TreeNodeResult,
 ) : Result {
     /** Walk to the leaf the context resolves to. */
-    fun findLeaf(x: F64VectorLike): WeightedVarianceResult = root.findLeaf(x)
+    fun findLeaf(x: VectorLike): WeightedVarianceResult = root.findLeaf(x)
 
     /** Mean of the leaf the context resolves to. */
-    fun predict(x: F64VectorLike): Double = findLeaf(x).mean
+    fun predict(x: VectorLike): Double = findLeaf(x).mean
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -45,7 +45,7 @@ sealed interface TreeNodeResult {
     val value: WeightedVarianceResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: F64VectorLike): WeightedVarianceResult
+    fun findLeaf(x: VectorLike): WeightedVarianceResult
 }
 
 /** Immutable split-node snapshot. */
@@ -60,7 +60,7 @@ data class TreeSplitResult(
     val neg: TreeNodeResult,
     override val value: WeightedVarianceResult,
 ) : TreeNodeResult {
-    override fun findLeaf(x: F64VectorLike): WeightedVarianceResult =
+    override fun findLeaf(x: VectorLike): WeightedVarianceResult =
         if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
@@ -68,19 +68,19 @@ data class TreeSplitResult(
 @Serializable
 @SerialName("TreeLeafResult")
 data class TreeLeafResult(override val value: WeightedVarianceResult) : TreeNodeResult {
-    override fun findLeaf(x: F64VectorLike): WeightedVarianceResult = value
+    override fun findLeaf(x: VectorLike): WeightedVarianceResult = value
 }
 
 /**
- * Freeze a live [F64VectorLike] tree node into an immutable, serializable snapshot. Internal
+ * Freeze a live [VectorLike] tree node into an immutable, serializable snapshot. Internal
  * split aggregates are derived from the snapshotted children so the wire format stays
  * stable even though live splits hold no arm.
  *
- * Snapshotting is `F64VectorLike`-only because the wire format requires [SerializableSplit];
- * a `F64VectorLike` tree is always grown from [SerializableSplit] candidates, so the cast on
+ * Snapshotting is `VectorLike`-only because the wire format requires [SerializableSplit];
+ * a `VectorLike` tree is always grown from [SerializableSplit] candidates, so the cast on
  * each split is safe by construction.
  */
-fun RegressionNode<F64VectorLike>.snapshot(): TreeNodeResult = when (this) {
+fun RegressionNode<VectorLike>.snapshot(): TreeNodeResult = when (this) {
     is RegressionSplitNode -> {
         val p = pos.snapshot()
         val n = neg.snapshot()
@@ -95,22 +95,22 @@ fun RegressionNode<F64VectorLike>.snapshot(): TreeNodeResult = when (this) {
 
 /**
  * Snapshot merge using only the immutable result. Mirrors [RegressionTree.merge] but the
- * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `F64VectorLike`
+ * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `VectorLike`
  * only, for the same reason [snapshot] is.
  *
- * An extension rather than a member because it exists only at `Row = F64VectorLike`, which a member of a
+ * An extension rather than a member because it exists only at `Row = VectorLike`, which a member of a
  * generic class cannot be constrained to. The algorithm is [TreeGrowth.mergeSnapshot].
  */
-fun RegressionTree<F64VectorLike>.mergeSnapshot(other: TreeNodeResult, workspace: com.eignex.koblas.Workspace? = null) {
+fun RegressionTree<VectorLike>.mergeSnapshot(other: TreeNodeResult, workspace: com.eignex.koblas.Workspace? = null) {
     growth.mergeSnapshot(other, RegressionResultShape, workspace)
 }
 
 /** Reads the immutable regression snapshot hierarchy on the growth engine's behalf. */
 private object RegressionResultShape :
-    TreeResultShape<Split<F64VectorLike>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
+    TreeResultShape<Split<VectorLike>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
     override fun asSplitResult(node: TreeNodeResult): TreeSplitResult? = node as? TreeSplitResult
 
-    override fun splitOf(node: TreeSplitResult): Split<F64VectorLike> = node.split
+    override fun splitOf(node: TreeSplitResult): Split<VectorLike> = node.split
 
     override fun posOf(node: TreeSplitResult): TreeNodeResult = node.pos
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/TestVectors.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 
 /**
  * A feature vector, for the tests that need one.
  *
- * One call site for `F64DenseVector.of` across the suite: koblas moved its dense storage to column-major
+ * One call site for `DenseVector.of` across the suite: koblas moved its dense storage to column-major
  * after `v0.1.0`, a change no compiler catches, so the next one should be a single edit.
  */
-internal fun feat(vararg xs: Double): F64DenseVector = F64DenseVector.of(xs)
+internal fun feat(vararg xs: Double): DenseVector = DenseVector.of(xs)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BernoulliArm
@@ -26,7 +26,7 @@ class ArmIndexContractSweepTest {
 
     private class Probe(val name: String, val calls: List<Pair<String, (Int) -> Any?>>)
 
-    private val x: F64VectorLike = feat(1.0, 1.0)
+    private val x: VectorLike = feat(1.0, 1.0)
 
     private fun probes(): List<Probe> {
         val multiArmed = MultiArmedBandit(ARMS, ThompsonSampling(BernoulliArm(), BetaPosterior), Random(0))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditInterfaceTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
 import com.eignex.kumulant.bandit.univariate.MultiArmedBandit
@@ -100,7 +100,7 @@ class BanditInterfaceTest {
             posterior = MultivariateGaussian,
             random = Random(5),
         )
-        val x = F64DenseVector.of(doubleArrayOf(1.0, 0.0))
+        val x = DenseVector.of(doubleArrayOf(1.0, 0.0))
         cb.update(1, x, 2.0)
         val asBandit: PerArmBandit<*> = cb
         assertEquals(asBandit.snapshot()[1], asBandit.armResult(1))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.univariate.Exp3ArmResult
@@ -48,7 +48,7 @@ class BanditTuningTest {
         val alwaysFirst = Exp4Expert { _, k -> DoubleArray(k) { if (it == 0) 1.0 else 0.0 } }
         val alwaysSecond = Exp4Expert { _, k -> DoubleArray(k) { if (it == 1) 1.0 else 0.0 } }
         val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(alwaysFirst, alwaysSecond), random = Random(3))
-        val x: F64VectorLike = F64DenseVector.of(doubleArrayOf(1.0))
+        val x: VectorLike = DenseVector.of(doubleArrayOf(1.0))
 
         repeat(500) {
             bandit.update(0, x, 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
@@ -73,7 +73,7 @@ class StandaloneBanditExtraTest {
     fun `Exp4 expertWeights sum to 1`() {
         val experts: List<Exp4Expert> = listOf(
             Exp4Expert { _, n -> DoubleArray(n) { 1.0 / n } },
-            Exp4Expert { _: F64VectorLike, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
+            Exp4Expert { _: VectorLike, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
         )
         val b = Exp4Bandit(nbrArms = 3, experts = experts, random = Random(1))
         repeat(20) { b.update(b.choose(feat(0.0)), feat(0.0), 1.0) }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.bandit
 
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BetaBernoulliTS
@@ -33,7 +33,7 @@ class TrackedBanditTest {
     private class RecordingRegressionStat(private val recorder: WorkspaceRecorder) : RegressionStat<SumResult> {
         override val concurrency = Concurrency.None
         override val featureSize = 1
-        override fun update(x: F64VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
+        override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
             recorder.workspace = workspace
         }
 
@@ -62,7 +62,7 @@ class TrackedBanditTest {
         )
         val workspace = Workspace()
 
-        tracked.choose(F64DenseVector.of(doubleArrayOf(0.5)), workspace)
+        tracked.choose(DenseVector.of(doubleArrayOf(0.5)), workspace)
 
         assertSame(workspace, recorder.workspace)
     }
@@ -83,7 +83,7 @@ class TrackedBanditTest {
             updateMarginalTemplate = BayesianRegressionStat(featureSize = 1),
             updateArmRewardTemplate = CovarianceStat(),
         )
-        val x = F64DenseVector.of(doubleArrayOf(0.3))
+        val x = DenseVector.of(doubleArrayOf(0.3))
         tracked.update(0, x, reward = 1.0)
         tracked.update(0, x, reward = 0.5)
         tracked.update(1, x, reward = 0.0)
@@ -126,7 +126,7 @@ class TrackedBanditTest {
             random = Random(7),
         )
         val tracked = TrackedContextualBandit(inner = inner, contextFeatureSize = 1)
-        val x = F64DenseVector.of(doubleArrayOf(0.1))
+        val x = DenseVector.of(doubleArrayOf(0.1))
         tracked.update(0, x, reward = 1.0)
         tracked.choose(x)
         assertNull(tracked.chooseResult())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random
@@ -179,10 +179,10 @@ class Exp4BanditTest {
     @Test
     fun `context-aware experts win on context-dependent rewards`() {
         // Expert "left" picks arm 0 when x<0, arm 1 when x>=0; opposite for "right".
-        val left = Exp4Expert { x: F64VectorLike, n: Int ->
+        val left = Exp4Expert { x: VectorLike, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 0 else 1] = 1.0 }
         }
-        val right = Exp4Expert { x: F64VectorLike, n: Int ->
+        val right = Exp4Expert { x: VectorLike, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 1 else 0] = 1.0 }
         }
         val rng = Random(5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit.Companion.squaredL2
 import com.eignex.kumulant.feat
 import kotlin.random.Random
@@ -111,7 +111,7 @@ class KnnContextualBanditTest {
         val bandit = KnnContextualBandit(nbrArms = 1, k = 1, maxHistoryPerArm = 2, exploration = 0.0)
         bandit.update(0, feat(1.0, 0.0), 1.0)
         bandit.update(0, feat(0.0, 2.0), 2.0)
-        bandit.update(0, F64SparseVector.of(2, intArrayOf(1), doubleArrayOf(3.0)), 3.0)
+        bandit.update(0, SparseVector.of(2, intArrayOf(1), doubleArrayOf(3.0)), 3.0)
         bandit.update(0, feat(4.0, 0.0), 4.0)
 
         val contexts = bandit.snapshot()[0].contexts
@@ -142,14 +142,14 @@ class KnnContextualBanditTest {
 
     @Test
     fun `squaredL2 dense and sparse agree across storage combinations`() {
-        val aDense = F64DenseVector.of(doubleArrayOf(1.0, 0.0, -2.0, 3.0, 0.0))
-        val bDense = F64DenseVector.of(doubleArrayOf(0.0, 4.0, -2.0, 1.0, 5.0))
-        val aSparse = F64SparseVector.of(
+        val aDense = DenseVector.of(doubleArrayOf(1.0, 0.0, -2.0, 3.0, 0.0))
+        val bDense = DenseVector.of(doubleArrayOf(0.0, 4.0, -2.0, 1.0, 5.0))
+        val aSparse = SparseVector.of(
             size = 5,
             indices = intArrayOf(0, 2, 3),
             values = doubleArrayOf(1.0, -2.0, 3.0),
         )
-        val bSparse = F64SparseVector.of(
+        val bSparse = SparseVector.of(
             size = 5,
             indices = intArrayOf(1, 2, 3, 4),
             values = doubleArrayOf(4.0, -2.0, 1.0, 5.0),
@@ -171,9 +171,9 @@ class KnnContextualBanditTest {
             intArrayOf(0, 3) to intArrayOf(),
         )
         for ((ai, bi) in shapes) {
-            val a = F64SparseVector.of(4, ai, DoubleArray(ai.size) { it + 1.5 })
-            val b = F64SparseVector.of(4, bi, DoubleArray(bi.size) { -(it + 0.5) })
-            val reference = squaredL2(F64DenseVector.of(a.toDoubleArray()), F64DenseVector.of(b.toDoubleArray()))
+            val a = SparseVector.of(4, ai, DoubleArray(ai.size) { it + 1.5 })
+            val b = SparseVector.of(4, bi, DoubleArray(bi.size) { -(it + 0.5) })
+            val reference = squaredL2(DenseVector.of(a.toDoubleArray()), DenseVector.of(b.toDoubleArray()))
 
             assertEquals(reference, squaredL2(a, b), 1e-12, "a=${ai.toList()} b=${bi.toList()}")
         }
@@ -189,11 +189,11 @@ class KnnContextualBanditTest {
             doubleArrayOf(0.5, 0.0, 0.0, 1.5) to 1.0,
         )
         for ((x, r) in rows) {
-            denseInput.update(0, F64DenseVector.of(x), r)
+            denseInput.update(0, DenseVector.of(x), r)
             val nz = x.withIndex().filter { it.value != 0.0 }
             sparseInput.update(
                 0,
-                F64SparseVector.of(
+                SparseVector.of(
                     size = x.size,
                     indices = nz.map { it.index }.toIntArray(),
                     values = nz.map { it.value }.toDoubleArray(),
@@ -201,7 +201,7 @@ class KnnContextualBanditTest {
                 r,
             )
         }
-        val q = F64DenseVector.of(doubleArrayOf(0.5, 0.0, 0.0, 1.5))
+        val q = DenseVector.of(doubleArrayOf(0.5, 0.0, 0.0, 1.5))
         assertEquals(denseInput.evaluate(0, q), sparseInput.evaluate(0, q), 1e-12)
     }
 
@@ -210,7 +210,7 @@ class KnnContextualBanditTest {
         val indices = intArrayOf(0, 2)
         val values = doubleArrayOf(1.0, 0.0)
         val bandit = KnnContextualBandit(nbrArms = 1, k = 1, exploration = 0.0)
-        bandit.update(0, F64SparseVector.wrap(3, indices, values), 4.0)
+        bandit.update(0, SparseVector.wrap(3, indices, values), 4.0)
 
         indices[0] = 1
         values[0] = 99.0
@@ -220,7 +220,7 @@ class KnnContextualBanditTest {
     @Test
     fun `update retains an empty sparse snapshot`() {
         val bandit = KnnContextualBandit(nbrArms = 1, k = 1, exploration = 0.0)
-        bandit.update(0, F64SparseVector.wrap(3, IntArray(0), DoubleArray(0)), 4.0)
+        bandit.update(0, SparseVector.wrap(3, IntArray(0), DoubleArray(0)), 4.0)
 
         assertEquals(4.0, bandit.evaluate(0, feat(0.0, 0.0, 0.0)), 1e-12)
     }
@@ -237,8 +237,8 @@ class KnnContextualBanditTest {
 
     @Test
     fun `squaredL2 counts a stored zero once`() {
-        val a = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
-        val b = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
+        val a = SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.0))
+        val b = SparseVector.of(2, intArrayOf(0), doubleArrayOf(3.0))
         assertEquals(9.0, squaredL2(a, b))
     }
 
@@ -247,16 +247,16 @@ class KnnContextualBanditTest {
         val allocating = KnnContextualBandit(nbrArms = 2, k = 2, exploration = 0.0)
         val reused = KnnContextualBandit(nbrArms = 2, k = 2, exploration = 0.0)
         val samples = listOf(
-            Triple(0, F64SparseVector.of(3, intArrayOf(0), doubleArrayOf(1.0)), 0.5),
-            Triple(0, F64SparseVector.of(3, intArrayOf(1), doubleArrayOf(-2.0)), -1.0),
-            Triple(1, F64SparseVector.of(3, intArrayOf(2), doubleArrayOf(3.0)), 1.5),
-            Triple(1, F64SparseVector.of(3, intArrayOf(0, 2), doubleArrayOf(-1.0, 1.0)), 0.25),
+            Triple(0, SparseVector.of(3, intArrayOf(0), doubleArrayOf(1.0)), 0.5),
+            Triple(0, SparseVector.of(3, intArrayOf(1), doubleArrayOf(-2.0)), -1.0),
+            Triple(1, SparseVector.of(3, intArrayOf(2), doubleArrayOf(3.0)), 1.5),
+            Triple(1, SparseVector.of(3, intArrayOf(0, 2), doubleArrayOf(-1.0, 1.0)), 0.25),
         )
         for ((arm, x, reward) in samples) {
             allocating.update(arm, x, reward)
             reused.update(arm, x, reward)
         }
-        val x = F64SparseVector.of(3, intArrayOf(0), doubleArrayOf(0.5))
+        val x = SparseVector.of(3, intArrayOf(0), doubleArrayOf(0.5))
         val workspace = Workspace().apply { reserve(6, 1) }
 
         for (arm in 0 until 2) assertEquals(allocating.evaluate(arm, x), reused.evaluate(arm, x, workspace), 1e-12)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.DenseVector
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
 import com.eignex.kumulant.feat
@@ -49,7 +49,7 @@ class RegressionContextualBanditTest {
 
         repeat(3000) {
             val x = doubleArrayOf(rng.nextDouble() * 2 - 1, rng.nextDouble() * 2 - 1)
-            val xv = F64DenseVector.of(x)
+            val xv = DenseVector.of(x)
             val arm = bandit.choose(xv)
             val reward = trueWeights[arm][0] * x[0] + trueWeights[arm][1] * x[1] +
                 rng.nextDouble() * 0.1 - 0.05
@@ -249,7 +249,7 @@ class RegressionContextualBanditTest {
         // while the global picks up the signal.
         repeat(500) {
             val x = doubleArrayOf(rng.nextDouble(), rng.nextDouble())
-            val xv = F64DenseVector.of(x)
+            val xv = DenseVector.of(x)
             val reward = 2.0 * x[0] + 0.5 * x[1]
             pooled.update(0, xv, reward)
             pooled.update(1, xv, reward)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/core/ClassLabelAdmissionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionStat
@@ -19,7 +19,7 @@ class ClassLabelAdmissionTest {
     private class Probe(val name: String, val update: (Double, Double) -> Unit, val snapshot: () -> String)
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
-    private val x = F64DenseVector.of(DoubleArray(2) { 1.0 })
+    private val x = DenseVector.of(DoubleArray(2) { 1.0 })
 
     // Fresh instances per test. Every snapshot reads the learned numbers out explicitly rather than
     // stringifying the result: ClassCountsResult has no toString override, so on the JVM a stringified

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.math
 
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseMatrix
+import com.eignex.koblas.DenseMatrix
 import kotlin.math.abs
 import kotlin.math.min
 import kotlin.math.sqrt
@@ -17,7 +17,7 @@ class CholeskyTest {
     fun `factorization recovers a known factor across block boundaries`() {
         for (n in listOf(0, 1, 63, 64, 65, 129, 193, 321)) {
             val tail = 1.0 / (n + 1)
-            val a = F64DenseMatrix.wrap(
+            val a = DenseMatrix.wrap(
                 n,
                 n,
                 DoubleArray(n * n) { index ->
@@ -50,11 +50,11 @@ class CholeskyTest {
 
     @Test
     fun `factorization overwrites a reused destination without changing its input`() {
-        val a = F64DenseMatrix.diagonal(65, 4.0)
+        val a = DenseMatrix.diagonal(65, 4.0)
         a[64, 0] = 2.0
         a[64, 64] = 5.0
         val original = a.data.copyOf()
-        val out = F64DenseMatrix.wrap(65, 65, DoubleArray(65 * 65) { Double.NaN })
+        val out = DenseMatrix.wrap(65, 65, DoubleArray(65 * 65) { Double.NaN })
 
         repeat(2) {
             val factor = a.choleskyInto(out)
@@ -77,11 +77,11 @@ class CholeskyTest {
     @Test
     fun `factorization allows the destination to share input storage`() {
         for (sameMatrix in listOf(true, false)) {
-            val a = F64DenseMatrix.diagonal(65, 4.0)
+            val a = DenseMatrix.diagonal(65, 4.0)
             a[64, 0] = 2.0
             a[64, 64] = 5.0
             for (j in 0 until 65) for (i in 0 until j) a[i, j] = Double.NaN
-            val out = if (sameMatrix) a else F64DenseMatrix.wrap(65, 65, a.data)
+            val out = if (sameMatrix) a else DenseMatrix.wrap(65, 65, a.data)
 
             val factor = a.choleskyInto(out)
 
@@ -102,7 +102,7 @@ class CholeskyTest {
     @Test
     fun `strict factorization rejects the first non-positive pivot`() {
         for (diagonal in listOf(0.0, -1.0)) {
-            val a = F64DenseMatrix.wrap(2, 2, doubleArrayOf(1.0, 0.0, 0.0, diagonal))
+            val a = DenseMatrix.wrap(2, 2, doubleArrayOf(1.0, 0.0, 0.0, diagonal))
 
             val error = assertFailsWith<NotPositiveDefinite> { a.cholesky() }
 
@@ -114,7 +114,7 @@ class CholeskyTest {
     @Test
     fun `every policy rejects NaN pivots`() {
         for (policy in listOf(CholeskyPolicy.Strict, CholeskyPolicy.Regularize())) {
-            val a = F64DenseMatrix.wrap(1, 1, doubleArrayOf(Double.NaN))
+            val a = DenseMatrix.wrap(1, 1, doubleArrayOf(Double.NaN))
 
             assertFailsWith<NotPositiveDefinite> { a.cholesky(policy) }
         }
@@ -123,7 +123,7 @@ class CholeskyTest {
     @Test
     fun `regularization bounds the column below a small pivot`() {
         for (pivot in listOf(-1.0, 0.0, 1e-12)) {
-            val a = F64DenseMatrix.wrap(2, 2, doubleArrayOf(pivot, 3.0, 3.0, 2.0))
+            val a = DenseMatrix.wrap(2, 2, doubleArrayOf(pivot, 3.0, 3.0, 2.0))
 
             val factor = a.cholesky(CholeskyPolicy.Regularize())
 
@@ -133,7 +133,7 @@ class CholeskyTest {
 
     @Test
     fun `regularization floors a small uncoupled pivot`() {
-        val a = F64DenseMatrix.wrap(1, 1, doubleArrayOf(1e-12))
+        val a = DenseMatrix.wrap(1, 1, doubleArrayOf(1e-12))
 
         val factor = a.cholesky(CholeskyPolicy.Regularize())
 
@@ -143,7 +143,7 @@ class CholeskyTest {
     @Test
     fun `rank one update represents the weighted outer product without changing its input`() {
         for (workspace in listOf(null, Workspace().apply { reserve(3, 2) })) {
-            val factor = F64DenseMatrix.diagonal(3, 2.0).cholesky()
+            val factor = DenseMatrix.diagonal(3, 2.0).cholesky()
             val v = doubleArrayOf(1.0, -2.0, 3.0)
 
             factor.choleskyRankUpdate(v, 4.0, workspace)
@@ -162,7 +162,7 @@ class CholeskyTest {
 
     @Test
     fun `zero rank update leaves the factor untouched`() {
-        val factor = F64DenseMatrix.diagonal(2, 2.0).cholesky()
+        val factor = DenseMatrix.diagonal(2, 2.0).cholesky()
         val original = factor.data.copyOf()
 
         factor.choleskyRankUpdate(doubleArrayOf(Double.NaN, Double.NaN), 0.0)
@@ -173,7 +173,7 @@ class CholeskyTest {
     @Test
     fun `rank update avoids squaring overflow and underflow`() {
         for (magnitude in listOf(1e-200, 1e200)) {
-            val factor = F64DenseMatrix.wrap(1, 1, doubleArrayOf(magnitude))
+            val factor = DenseMatrix.wrap(1, 1, doubleArrayOf(magnitude))
 
             factor.choleskyRankUpdate(doubleArrayOf(-magnitude), 1.0)
 
@@ -184,7 +184,7 @@ class CholeskyTest {
 
     @Test
     fun `solve allows the destination to be the right hand side`() {
-        val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+        val factor = DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
         val b = doubleArrayOf(8.0, 12.0)
 
         factor.choleskySolveInto(b, b)
@@ -194,7 +194,7 @@ class CholeskyTest {
 
     @Test
     fun `solve into a separate destination preserves the right hand side`() {
-        val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+        val factor = DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
         val b = doubleArrayOf(8.0, 12.0)
         val out = doubleArrayOf(Double.NaN, Double.NaN)
 
@@ -208,9 +208,9 @@ class CholeskyTest {
     @Test
     fun `inverse overwrites both triangles and preserves the factor with reused scratch`() {
         for (workspace in listOf(null, Workspace().apply { reserve(2, 1) })) {
-            val factor = F64DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
+            val factor = DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
             val original = factor.data.copyOf()
-            val out = F64DenseMatrix.wrap(2, 2, DoubleArray(4) { Double.NaN })
+            val out = DenseMatrix.wrap(2, 2, DoubleArray(4) { Double.NaN })
 
             repeat(2) { factor.choleskyInvertInto(out, workspace) }
 
@@ -221,8 +221,8 @@ class CholeskyTest {
 
     @Test
     fun `inverse rejects a destination sharing factor storage`() {
-        val factor = F64DenseMatrix.diagonal(2, 1.0).cholesky()
-        val alias = F64DenseMatrix.wrap(2, 2, factor.data)
+        val factor = DenseMatrix.diagonal(2, 1.0).cholesky()
+        val alias = DenseMatrix.wrap(2, 2, factor.data)
 
         assertFailsWith<IllegalArgumentException> { factor.choleskyInvertInto(alias) }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/SamplingTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.CovarianceStat
@@ -69,7 +69,7 @@ class SamplingTest {
     @Test
     fun `vector throttle forwards every Nth update`() {
         val stat = VectorizedStat(2, SumStat()).throttle(every = 2)
-        repeat(6) { stat.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0))) }
+        repeat(6) { stat.update(DenseVector.of(doubleArrayOf(1.0, 1.0))) }
         assertEquals(3.0, stat.read().results[0].sum, DELTA)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/VectorizedStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.SparseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.summary.CountStat
@@ -81,8 +81,8 @@ class VectorizedStatTest {
     @Test
     fun `skipZeros with sparse input only touches stored entries`() {
         val stat = VectorizedStat(dimensions = 5, template = CountStat(), skipZeros = true)
-        stat.update(F64SparseVector.of(size = 5, indices = intArrayOf(1, 3), values = doubleArrayOf(2.5, 7.0)))
-        stat.update(F64SparseVector.of(size = 5, indices = intArrayOf(3), values = doubleArrayOf(1.0)))
+        stat.update(SparseVector.of(size = 5, indices = intArrayOf(1, 3), values = doubleArrayOf(2.5, 7.0)))
+        stat.update(SparseVector.of(size = 5, indices = intArrayOf(3), values = doubleArrayOf(1.0)))
         val r = stat.read()
         assertEquals(0.0, r.results[0].sum, DELTA)
         assertEquals(1.0, r.results[1].sum, DELTA)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/operation/WeightsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.stat.cardinality.HyperLogLogStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
@@ -96,7 +96,7 @@ class WeightsTest {
             assertEquals(0.0, discrete.read().estimate, "discrete moved on weight $inert")
 
             val regression = StochasticRegressionStat(featureSize = 2).withWeight(2.0)
-            regression.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0)), 1.0, weight = inert)
+            regression.update(DenseVector.of(doubleArrayOf(1.0, 1.0)), 1.0, weight = inert)
             assertEquals(0.0, regression.read().totalWeights, DELTA, "regression moved on weight $inert")
         }
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprKotlinConstructionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.BoolExpr
 import com.eignex.kumulant.schema.expr.Const
@@ -168,14 +168,14 @@ class ExprKotlinConstructionTest {
         // Materialising and driving one proves the whole path works, not just that the type exists.
         val reordered = Vectorized(dimensions = 3, template = Sum).transformVector(vectorOf(V(2), V(0), V(1)))
         val stat = reordered.materialize()
-        stat.update(F64DenseVector.of(doubleArrayOf(1.0, 2.0, 3.0)))
+        stat.update(DenseVector.of(doubleArrayOf(1.0, 2.0, 3.0)))
 
         // Coordinate 0 of the output is input coordinate 2.
         assertEquals(3.0, stat.read().results[0].let { (it as com.eignex.kumulant.stat.summary.SumResult).sum }, DELTA)
 
         val regression = StochasticRegression(featureSize = 3).transformX(vectorOf(V(0), V(1), V(2)))
         val model = regression.materialize()
-        model.update(F64DenseVector.of(doubleArrayOf(1.0, 1.0, 1.0)), 1.0)
+        model.update(DenseVector.of(doubleArrayOf(1.0, 1.0, 1.0)), 1.0)
         assertEquals(1.0, model.read().totalWeights, DELTA, "the regression transform did not accept an update")
     }
 }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64StridedVectorView
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.ResultList
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
 
 class ExprTest {
 
-    private class NoMaterializeVector(private val values: DoubleArray) : F64VectorLike {
+    private class NoMaterializeVector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("expression materialised its vector input")
@@ -51,15 +51,15 @@ class ExprTest {
     }
 
     @Test fun `vector aware expressions agree across vector representations`() {
-        val dense = F64DenseVector.of(doubleArrayOf(2.0, 0.0, -3.0))
-        val sparse = F64SparseVector.of(3, intArrayOf(0, 2), doubleArrayOf(2.0, -3.0))
-        val strided = F64StridedVectorView(doubleArrayOf(2.0, 9.0, 0.0, 9.0, -3.0, 9.0), 0, 3, 2)
+        val dense = DenseVector.of(doubleArrayOf(2.0, 0.0, -3.0))
+        val sparse = SparseVector.of(3, intArrayOf(0, 2), doubleArrayOf(2.0, -3.0))
+        val strided = StridedVectorView(doubleArrayOf(2.0, 9.0, 0.0, 9.0, -3.0, 9.0), 0, 3, 2)
         val custom = NoMaterializeVector(doubleArrayOf(2.0, 0.0, -3.0))
         val scalar = V(0) * V(2) + VFold(VFoldOp.Sum)
         val predicate = (V(0) gt 0.0) and (V(2) lt 0.0)
         val vector = VElements(listOf(V(2), V(0) + V(1)))
 
-        for (input in listOf<F64VectorLike>(dense, sparse, strided, custom)) {
+        for (input in listOf<VectorLike>(dense, sparse, strided, custom)) {
             assertEquals(-7.0, scalar.eval(v = input), DELTA)
             assertTrue(predicate.eval(v = input))
             assertTrue(vector.eval(v = input).contentEquals(doubleArrayOf(-3.0, 2.0)))
@@ -68,11 +68,11 @@ class ExprTest {
     }
 
     @Test fun `all finite checks stored non finite values and sparse zeroes`() {
-        assertTrue(allFinite().eval(v = F64SparseVector.of(3, intArrayOf(1), doubleArrayOf(0.0))))
-        assertEquals(false, allFinite().eval(v = F64SparseVector.of(3, intArrayOf(1), doubleArrayOf(Double.NaN))))
+        assertTrue(allFinite().eval(v = SparseVector.of(3, intArrayOf(1), doubleArrayOf(0.0))))
+        assertEquals(false, allFinite().eval(v = SparseVector.of(3, intArrayOf(1), doubleArrayOf(Double.NaN))))
         assertEquals(
             false,
-            allFinite().eval(v = F64SparseVector.of(3, intArrayOf(1), doubleArrayOf(Double.POSITIVE_INFINITY))),
+            allFinite().eval(v = SparseVector.of(3, intArrayOf(1), doubleArrayOf(Double.POSITIVE_INFINITY))),
         )
         assertTrue(allFinite().eval(v = NoMaterializeVector(doubleArrayOf())))
     }
@@ -419,10 +419,10 @@ class ExprTest {
         val folds = VFoldOp.entries.map(::VFold)
 
         for (array in values) {
-            val representations = listOf<F64VectorLike>(
-                F64DenseVector.of(array),
+            val representations = listOf<VectorLike>(
+                DenseVector.of(array),
                 sparse(array),
-                F64StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
+                StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
                 NoMaterializeVector(array),
             )
             for (fold in folds) {
@@ -465,10 +465,10 @@ class ExprTest {
         for ((array, weights) in cases.zip(weightSets)) {
             val expr = VDot(weights)
             val expected = expr.eval(0.0, 0.0, array)
-            for (input in listOf<F64VectorLike>(
-                F64DenseVector.of(array),
+            for (input in listOf<VectorLike>(
+                DenseVector.of(array),
                 sparse(array),
-                F64StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
+                StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
                 NoMaterializeVector(array),
             )) {
                 assertEquals(expected.toBits(), expr.eval(v = input).toBits())
@@ -478,7 +478,7 @@ class ExprTest {
 
     @Test fun `vector reductions preserve explicit sparse zeroes`() {
         val array = doubleArrayOf(2.0, 0.0, -3.0)
-        val input = F64SparseVector.of(3, intArrayOf(0, 1, 2), array)
+        val input = SparseVector.of(3, intArrayOf(0, 1, 2), array)
 
         for (op in VFoldOp.entries) {
             val fold = VFold(op)
@@ -521,7 +521,7 @@ class ExprTest {
             assertEquals(expr.eval(0.0, 0.0, values), expr.eval(v = NoMaterializeVector(values)))
         }
 
-        class CountingVector(private val values: DoubleArray) : F64VectorLike {
+        class CountingVector(private val values: DoubleArray) : VectorLike {
             var reads = 0
             override val size: Int get() = values.size
             override fun get(i: Int): Double = values[i].also { reads++ }
@@ -556,12 +556,12 @@ class ExprTest {
     /** Relative slack for [reassociating] folds; reassociation moves the last bits, nothing more. */
     private val reassociationTolerance = 1e-12
 
-    private fun sparse(values: DoubleArray): F64SparseVector {
+    private fun sparse(values: DoubleArray): SparseVector {
         val indices = values.indices.filter {
             values[it] != 0.0 || values[it].toBits() == (-0.0).toBits() ||
                 values[it].isNaN()
         }
-        return F64SparseVector.of(values.size, indices.toIntArray(), DoubleArray(indices.size) { values[indices[it]] })
+        return SparseVector.of(values.size, indices.toIntArray(), DoubleArray(indices.size) { values[indices[it]] })
     }
 
     @Test fun `foldPaired lifts series to paired with xy expression`() {

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/FilterFiniteTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.schema.expr.X
 import com.eignex.kumulant.schema.expr.isFinite
@@ -74,11 +74,11 @@ class FilterFiniteTest {
         // The modality where this matters most, because a poisoned coefficient never recovers: every
         // later gradient step multiplies the NaN forward.
         for (bad in NON_FINITE) {
-            val good = F64DenseVector.of(doubleArrayOf(1.0, 1.0))
+            val good = DenseVector.of(doubleArrayOf(1.0, 1.0))
 
             val onFeature = StochasticRegression(featureSize = 2).filterFinite().materialize()
             onFeature.update(good, 1.0)
-            onFeature.update(F64DenseVector.of(doubleArrayOf(bad, 1.0)), 1.0)
+            onFeature.update(DenseVector.of(doubleArrayOf(bad, 1.0)), 1.0)
             onFeature.update(good, 1.0)
             val f = onFeature.read()
             assertEquals(2.0, f.totalWeights, DELTA, "a non-finite feature ($bad) was absorbed")
@@ -100,10 +100,10 @@ class FilterFiniteTest {
         // rather than as sugar over V(0).isFinite(): the bad coordinate can be any of them.
         for (index in 0 until 4) {
             val stat = StochasticRegression(featureSize = 4).filterFinite().materialize()
-            stat.update(F64DenseVector.of(DoubleArray(4) { 1.0 }), 1.0)
+            stat.update(DenseVector.of(DoubleArray(4) { 1.0 }), 1.0)
 
             val poisoned = DoubleArray(4) { if (it == index) Double.NaN else 1.0 }
-            stat.update(F64DenseVector.of(poisoned), 1.0)
+            stat.update(DenseVector.of(poisoned), 1.0)
 
             assertEquals(1.0, stat.read().totalWeights, DELTA, "a NaN at coordinate $index slipped through")
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -31,7 +31,7 @@ class RegressionListStatsTest {
         override val featureSize = 1
         var workspace: Workspace? = null
 
-        override fun update(x: F64VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
+        override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
             this.workspace = workspace
         }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.schema
 
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
@@ -659,7 +659,7 @@ class VectorStatGroupTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>, workspace: com.eignex.koblas.Workspace?) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())
@@ -776,7 +776,7 @@ class VectorListStatsTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: F64VectorLike, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>, workspace: com.eignex.koblas.Workspace?) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,8 +29,8 @@ class HalfSpaceTreesStatTest {
             stat.update(doubleArrayOf(3.0 + rng.nextDouble() * 0.5, 3.0 + rng.nextDouble() * 0.5))
         }
         val r = stat.read()
-        val inlierScore = r.score(F64DenseVector.of(doubleArrayOf(3.2, 3.4)))
-        val outlierScore = r.score(F64DenseVector.of(doubleArrayOf(9.0, 9.0)))
+        val inlierScore = r.score(DenseVector.of(doubleArrayOf(3.2, 3.4)))
+        val outlierScore = r.score(DenseVector.of(doubleArrayOf(9.0, 9.0)))
         // Outliers route to leaves with little reference-window mass.
         assertTrue(inlierScore > outlierScore, "inlier=$inlierScore outlier=$outlierScore")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import kotlin.math.PI
 import kotlin.math.ln
 import kotlin.math.sqrt
@@ -23,9 +23,9 @@ class GaussianNaiveBayesResultTest {
     ) = GaussianNaiveBayesResult(
         featureSize = featureSize,
         numClasses = numClasses,
-        means = F64DenseMatrix.of(means),
-        variances = F64DenseMatrix.of(variances),
-        classWeights = F64DenseVector.of(classWeights),
+        means = DenseMatrix.of(means),
+        variances = DenseMatrix.of(variances),
+        classWeights = DenseVector.of(classWeights),
         totalWeights = totalWeights,
         varianceFloor = varianceFloor,
     )
@@ -88,16 +88,16 @@ class GaussianNaiveBayesResultTest {
         val logTwoPi = ln(2.0 * PI)
         val expectedClass0 = ln(0.5) + -0.5 * (logTwoPi + ln(0.5))
         val expectedClass1 = ln(0.5) + -0.5 * (logTwoPi + ln(0.5) + 100.0 / 0.5)
-        assertEquals(expectedClass0, r.logPosterior(F64DenseVector.of(doubleArrayOf(0.0)), 0), 1e-9)
-        assertEquals(expectedClass1, r.logPosterior(F64DenseVector.of(doubleArrayOf(0.0)), 1), 1e-9)
-        assertEquals(0, r.predict(F64DenseVector.of(doubleArrayOf(0.0))))
+        assertEquals(expectedClass0, r.logPosterior(DenseVector.of(doubleArrayOf(0.0)), 0), 1e-9)
+        assertEquals(expectedClass1, r.logPosterior(DenseVector.of(doubleArrayOf(0.0)), 1), 1e-9)
+        assertEquals(0, r.predict(DenseVector.of(doubleArrayOf(0.0))))
     }
 
     @Test
     fun `logPosterior rejects wrong feature size`() {
         val r = result(numClasses = 2, featureSize = 2)
         assertFailsWith<IllegalArgumentException> {
-            r.logPosterior(F64DenseVector.of(doubleArrayOf(1.0)), 0)
+            r.logPosterior(DenseVector.of(doubleArrayOf(1.0)), 0)
         }
     }
 
@@ -111,7 +111,7 @@ class GaussianNaiveBayesResultTest {
             classWeights = doubleArrayOf(1.0, 2.0, 1.0),
             totalWeights = 4.0,
         )
-        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.3)))
+        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.3)))
         assertEquals(1.0, p.sum(), 1e-12)
         for (pk in p) assertTrue(pk in 0.0..1.0, "prob out of [0,1]: $pk")
         // Sanity: stddev away from each mean still leaves nonzero mass everywhere.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64StridedVectorView
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
 
 class GaussianNaiveBayesStatTest {
 
-    private class CustomVector(private val values: DoubleArray) : F64VectorLike {
+    private class CustomVector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -94,7 +94,7 @@ class GaussianNaiveBayesStatTest {
         val n = 300
         repeat(n) {
             val c = rng.nextInt(3)
-            val x = F64DenseVector.of(
+            val x = DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() - 0.5,
                     centers[c][1] + rng.nextDouble() - 0.5,
@@ -111,10 +111,10 @@ class GaussianNaiveBayesStatTest {
         repeat(10) { stat.update(doubleArrayOf(0.0), 0.0) }
         repeat(10) { stat.update(doubleArrayOf(10.0), 1.0) }
         val r = stat.read()
-        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(9.5)))
+        val p = r.probabilities(DenseVector.of(doubleArrayOf(9.5)))
         assertEquals(1.0, p.sum(), 1e-9)
         assertTrue(p[1] > p[0])
-        assertEquals(1, r.predict(F64DenseVector.of(doubleArrayOf(9.5))))
+        assertEquals(1, r.predict(DenseVector.of(doubleArrayOf(9.5))))
     }
 
     @Test
@@ -123,13 +123,13 @@ class GaussianNaiveBayesStatTest {
         stat.update(doubleArrayOf(1.0, 0.0, -2.0), 0.0, weight = 2.0)
         stat.update(doubleArrayOf(-1.0, 0.0, 3.0), 1.0)
         val result = stat.read()
-        val dense = F64DenseVector.of(doubleArrayOf(0.5, 0.0, -1.0))
-        val sparse = F64SparseVector.of(3, intArrayOf(0, 1, 2), doubleArrayOf(0.5, 0.0, -1.0))
-        val strided = F64StridedVectorView(doubleArrayOf(0.5, 9.0, 0.0, 9.0, -1.0, 9.0), 0, 3, 2)
+        val dense = DenseVector.of(doubleArrayOf(0.5, 0.0, -1.0))
+        val sparse = SparseVector.of(3, intArrayOf(0, 1, 2), doubleArrayOf(0.5, 0.0, -1.0))
+        val strided = StridedVectorView(doubleArrayOf(0.5, 9.0, 0.0, 9.0, -1.0, 9.0), 0, 3, 2)
         val custom = CustomVector(doubleArrayOf(0.5, 0.0, -1.0))
         val expected = result.probabilities(dense)
 
-        for (x in listOf<F64VectorLike>(sparse, strided, custom)) {
+        for (x in listOf<VectorLike>(sparse, strided, custom)) {
             val logs = DoubleArray(2)
             val probabilities = DoubleArray(2)
             result.logPosteriorsInto(x, logs)
@@ -150,7 +150,7 @@ class GaussianNaiveBayesStatTest {
 
         assertFailsWith<IllegalArgumentException> {
             result.logPosteriorsInto(
-                F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 destination,
             )
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/OptimizerTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.expr.Const
 import com.eignex.kumulant.schema.optimizer.Adagrad
@@ -88,7 +88,7 @@ class OptimizerTest {
         var correct = 0
         repeat(300) {
             val c = rng.nextInt(3)
-            val x = F64DenseVector.of(
+            val x = DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() * 0.4 - 0.2,
                     centers[c][1] + rng.nextDouble() * 0.4 - 0.2,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionArityGuardTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
@@ -42,7 +42,7 @@ class RegressionArityGuardTest {
         val violations = mutableListOf<String>()
         for ((name, stat) in stats) {
             for (size in listOf(FEATURES - 1, FEATURES + 1)) {
-                val x = F64DenseVector.of(DoubleArray(size) { 1.0 })
+                val x = DenseVector.of(DoubleArray(size) { 1.0 })
                 val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
                 when {
                     thrown == null -> violations += "$name accepted a vector of size $size"
@@ -61,7 +61,7 @@ class RegressionArityGuardTest {
         // change, and because RegressionOpsTest greps it.
         for ((name, stat) in stats) {
             val thrown = runCatching {
-                stat.update(F64DenseVector.of(doubleArrayOf(1.0)), 1.0)
+                stat.update(DenseVector.of(doubleArrayOf(1.0)), 1.0)
             }.exceptionOrNull()
             val message = thrown?.message.orEmpty()
             assertTrue("x.size=1" in message, "$name did not report the size it got: $message")
@@ -73,7 +73,7 @@ class RegressionArityGuardTest {
     fun `a correctly sized vector is still accepted`() {
         // Guards the guard: a require that rejected everything would satisfy both tests above.
         for ((name, stat) in stats) {
-            val x = F64DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+            val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
             val thrown = runCatching { stat.update(x, 1.0) }.exceptionOrNull()
             assertEquals(null, thrown?.message, "$name rejected a correctly sized vector")
         }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionMergeGuardTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.stat.anomaly.FeatureRange
 import com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
@@ -58,14 +58,14 @@ class RegressionMergeGuardTest {
         val ranges = List(1) { FeatureRange(0.0, 1.0) }
         val source = HalfSpaceTreesStat(featureSize = 1, featureRanges = ranges, windowSize = 50)
         repeat(200) { source.update(doubleArrayOf(0.5)) }
-        val sourceScore = source.read().score(F64DenseVector.of(doubleArrayOf(0.5)))
+        val sourceScore = source.read().score(DenseVector.of(doubleArrayOf(0.5)))
 
         val target = source.create()
         target.merge(source.read())
 
         // The reference window is what score() reads, so folding into the latest window alone would
         // leave a merged model scoring every input maximally anomalous.
-        val mergedScore = target.read().score(F64DenseVector.of(doubleArrayOf(0.5)))
+        val mergedScore = target.read().score(DenseVector.of(doubleArrayOf(0.5)))
         assertTrue(mergedScore > 0.0, "a merged model scored $mergedScore, i.e. maximally anomalous")
         assertEquals(sourceScore, mergedScore, sourceScore * 1e-9)
     }
@@ -112,7 +112,7 @@ class RegressionMergeGuardTest {
 
         // A zero-weight call that drew once per tree from baggingRng would desynchronise every later
         // draw and change the forest's predictions.
-        val at = F64DenseVector.of(doubleArrayOf(3.0))
+        val at = DenseVector.of(doubleArrayOf(3.0))
         assertEquals(clean.read().predict(at), probed.read().predict(at), 1e-12)
 
         val tree = DecisionTreeRegressionStat(featureSize = 1, splitCandidates = splits)
@@ -130,12 +130,12 @@ class RegressionMergeGuardTest {
     fun `a non-square precision factor is rejected by name`() {
         val error = assertFailsWith<IllegalArgumentException> {
             PrecisionRegressionResult(
-                weights = F64DenseVector.of(doubleArrayOf(1.0, 2.0)),
+                weights = DenseVector.of(doubleArrayOf(1.0, 2.0)),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 1.0,
                 step = 1L,
-                precisionL = F64DenseMatrix.zero(2, 3),
+                precisionL = DenseMatrix.zero(2, 3),
             )
         }
         assertTrue(error.message?.contains("2x3") == true, "expected the shape in the message, got ${error.message}")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionStatConcurrencyTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
@@ -56,7 +56,7 @@ class RegressionStatConcurrencyTest {
     fun `StochasticRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = StochasticRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)
@@ -70,7 +70,7 @@ class RegressionStatConcurrencyTest {
     fun `DiagonalRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = DiagonalRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)
@@ -84,7 +84,7 @@ class RegressionStatConcurrencyTest {
     fun `BayesianRegressionStat sequential math equal across modes`() {
         val reads = Concurrency.entries.associateWith { mode ->
             val s = BayesianRegressionStat(featureSize = 2, concurrency = mode)
-            for (i in mvX.indices) s.update(F64DenseVector.of(mvX[i]), ys[i])
+            for (i in mvX.indices) s.update(DenseVector.of(mvX[i]), ys[i])
             s.read(0L)
         }
         val ref = reads.getValue(Concurrency.None)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
@@ -29,12 +29,12 @@ class RegressionWeightContractTest {
     private class Model(
         val name: String,
         val y: Double,
-        val update: (F64VectorLike, Double, Double) -> Unit,
+        val update: (VectorLike, Double, Double) -> Unit,
         val snapshot: () -> String,
     )
 
     private val splits = listOf(ThresholdSplit(featureIndex = 0, threshold = 0.5))
-    private val x = F64DenseVector.of(DoubleArray(FEATURES) { 1.0 })
+    private val x = DenseVector.of(DoubleArray(FEATURES) { 1.0 })
 
     // Bagging is off on the two forests. With it on, each tree draws Poisson(1) per observation and can
     // legitimately draw zero, so a single update may reach no tree at all. The early return that stops an
@@ -151,7 +151,7 @@ class RegressionWeightContractTest {
         val nonFinite = doubleArrayOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
         val violations = mutableListOf<String>()
         for (bad in nonFinite) {
-            val badFeatures = F64DenseVector.of(doubleArrayOf(bad, 1.0))
+            val badFeatures = DenseVector.of(doubleArrayOf(bad, 1.0))
             for (model in models()) {
                 // Feature position. The model is trained first so the bad input meets real state rather
                 // than a fresh accumulator, which is where the arithmetic has more ways to go wrong.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
@@ -1,16 +1,16 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorLike
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class SoftmaxRegressionResultTest {
 
-    private class StridedVector(private val backing: DoubleArray) : F64VectorLike {
+    private class StridedVector(private val backing: DoubleArray) : VectorLike {
         override val size: Int get() = backing.size / 2
         override fun get(i: Int): Double = backing[i * 2]
         override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
@@ -20,8 +20,8 @@ class SoftmaxRegressionResultTest {
         SoftmaxRegressionResult(
             featureSize = weights[0].size,
             numClasses = weights.size,
-            weights = F64DenseMatrix.of(weights),
-            biases = F64DenseVector.of(biases),
+            weights = DenseMatrix.of(weights),
+            biases = DenseVector.of(biases),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
@@ -33,7 +33,7 @@ class SoftmaxRegressionResultTest {
             weights = arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(-1.0, 0.5)),
             biases = doubleArrayOf(0.5, -0.25),
         )
-        val x = F64DenseVector.of(doubleArrayOf(3.0, 4.0))
+        val x = DenseVector.of(doubleArrayOf(3.0, 4.0))
         assertEquals(0.5 + 1.0 * 3.0 + 2.0 * 4.0, r.logit(x, 0), 1e-12)
         assertEquals(-0.25 + -1.0 * 3.0 + 0.5 * 4.0, r.logit(x, 1), 1e-12)
     }
@@ -42,7 +42,7 @@ class SoftmaxRegressionResultTest {
     fun `logit rejects wrong feature size`() {
         val r = result(arrayOf(doubleArrayOf(1.0, 2.0)), doubleArrayOf(0.0))
         assertFailsWith<IllegalArgumentException> {
-            r.logit(F64DenseVector.of(doubleArrayOf(1.0)), 0)
+            r.logit(DenseVector.of(doubleArrayOf(1.0)), 0)
         }
     }
 
@@ -52,12 +52,12 @@ class SoftmaxRegressionResultTest {
             weights = arrayOf(doubleArrayOf(1.0, -2.0, 0.5, 3.0), doubleArrayOf(-1.0, 1.0, 2.0, -0.5)),
             biases = doubleArrayOf(0.25, -0.75),
         )
-        val dense = F64DenseVector.of(doubleArrayOf(2.0, 0.0, -1.0, 0.0))
-        val sparse = F64SparseVector.of(4, intArrayOf(0, 2), doubleArrayOf(2.0, -1.0))
+        val dense = DenseVector.of(doubleArrayOf(2.0, 0.0, -1.0, 0.0))
+        val sparse = SparseVector.of(4, intArrayOf(0, 2), doubleArrayOf(2.0, -1.0))
         val strided = StridedVector(doubleArrayOf(2.0, 9.0, 0.0, 9.0, -1.0, 9.0, 0.0, 9.0))
 
         val expected = r.probabilities(dense)
-        for (x in listOf<F64VectorLike>(sparse, strided)) {
+        for (x in listOf<VectorLike>(sparse, strided)) {
             val actual = r.probabilities(x)
             assertEquals(expected[0], actual[0], 1e-12)
             assertEquals(expected[1], actual[1], 1e-12)
@@ -73,8 +73,8 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 3,
                 numClasses = 2,
-                weights = F64DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
-                biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                biases = DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 totalWeights = 0.0,
                 step = 0L,
                 crossEntropy = 0.0,
@@ -88,8 +88,8 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 2,
                 numClasses = 2,
-                weights = F64DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
-                biases = F64DenseVector.of(doubleArrayOf(0.0)),
+                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                biases = DenseVector.of(doubleArrayOf(0.0)),
                 totalWeights = 0.0,
                 step = 0L,
                 crossEntropy = 0.0,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
@@ -1,11 +1,11 @@
 package com.eignex.kumulant.stat.regression
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64StridedVectorView
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
 import kotlin.math.abs
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 
 class SoftmaxRegressionStatTest {
 
-    private class CustomVector(private val values: DoubleArray) : F64VectorLike {
+    private class CustomVector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -28,23 +28,23 @@ class SoftmaxRegressionStatTest {
         val r = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = F64DenseMatrix.of(
+            weights = DenseMatrix.of(
                 arrayOf(
                     doubleArrayOf(1.0, 0.0),
                     doubleArrayOf(0.0, 1.0),
                     doubleArrayOf(-1.0, -1.0),
                 ),
             ),
-            biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
+            biases = DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(2.0, 1.0)))
+        val p = r.probabilities(DenseVector.of(doubleArrayOf(2.0, 1.0)))
         val total = p.sum()
         assertEquals(1.0, total, 1e-9)
         // Class 0 has the largest logit (eta = 2), so argmax must be 0.
-        assertEquals(0, r.predict(F64DenseVector.of(doubleArrayOf(2.0, 1.0))))
+        assertEquals(0, r.predict(DenseVector.of(doubleArrayOf(2.0, 1.0))))
     }
 
     @Test
@@ -52,15 +52,15 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = F64DenseMatrix.of(
+            weights = DenseMatrix.of(
                 arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0), doubleArrayOf(-1.0, 1.0)),
             ),
-            biases = F64DenseVector.of(doubleArrayOf(0.2, -0.1, 0.4)),
+            biases = DenseVector.of(doubleArrayOf(0.2, -0.1, 0.4)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val x = F64DenseVector.of(doubleArrayOf(2.0, -1.0))
+        val x = DenseVector.of(doubleArrayOf(2.0, -1.0))
         val workspace = Workspace().apply { reserve(3, 1) }
         val probabilities = DoubleArray(3)
 
@@ -78,21 +78,21 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = F64DenseMatrix.of(
+            weights = DenseMatrix.of(
                 arrayOf(doubleArrayOf(1.0, -1.0), doubleArrayOf(2.0, 0.5), doubleArrayOf(-0.5, 1.5)),
             ),
-            biases = F64DenseVector.of(doubleArrayOf(0.1, 0.2, -0.3)),
+            biases = DenseVector.of(doubleArrayOf(0.1, 0.2, -0.3)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val dense = F64DenseVector.of(doubleArrayOf(0.25, -0.5))
-        val sparse = F64SparseVector.of(2, intArrayOf(0, 1), doubleArrayOf(0.25, -0.5))
-        val strided = F64StridedVectorView(doubleArrayOf(0.25, 9.0, -0.5, 9.0), 0, 2, 2)
+        val dense = DenseVector.of(doubleArrayOf(0.25, -0.5))
+        val sparse = SparseVector.of(2, intArrayOf(0, 1), doubleArrayOf(0.25, -0.5))
+        val strided = StridedVectorView(doubleArrayOf(0.25, 9.0, -0.5, 9.0), 0, 2, 2)
         val custom = CustomVector(doubleArrayOf(0.25, -0.5))
         val expected = result.probabilities(dense)
 
-        for (x in listOf<F64VectorLike>(sparse, strided, custom)) {
+        for (x in listOf<VectorLike>(sparse, strided, custom)) {
             val actual = DoubleArray(3)
             result.probabilitiesInto(x, actual)
             assertTrue(actual.contentEquals(expected))
@@ -105,16 +105,16 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 2,
-            weights = F64DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0))),
-            biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
+            weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0))),
+            biases = DenseVector.of(doubleArrayOf(0.0, 0.0)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
         val workspace = Workspace().apply { reserve(2, 1) }
 
-        assertFailsWith<IllegalArgumentException> { result.predict(F64DenseVector.of(doubleArrayOf(1.0)), workspace) }
-        assertEquals(0, result.predict(F64DenseVector.of(doubleArrayOf(1.0, 0.0)), workspace))
+        assertFailsWith<IllegalArgumentException> { result.predict(DenseVector.of(doubleArrayOf(1.0)), workspace) }
+        assertEquals(0, result.predict(DenseVector.of(doubleArrayOf(1.0, 0.0)), workspace))
     }
 
     @Test
@@ -141,7 +141,7 @@ class SoftmaxRegressionStatTest {
         val n = 600
         repeat(n) {
             val c = rng.nextInt(3)
-            val x = F64DenseVector.of(
+            val x = DenseVector.of(
                 doubleArrayOf(
                     centers[c][0] + rng.nextDouble() * 0.4 - 0.2,
                     centers[c][1] + rng.nextDouble() * 0.4 - 0.2,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/VectorSerializationTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorStorage
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorStorage
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
@@ -46,9 +46,9 @@ class VectorSerializationTest {
             var y = 0.0
             for (i in 0 until 5) y += truth[i] * xArr[i]
             y += rng.nextDouble() * 0.02 - 0.01
-            dense.update(F64DenseVector.of(xArr), y, 1.0)
+            dense.update(DenseVector.of(xArr), y, 1.0)
             val nz = (0 until 5).filter { idx -> xArr[idx] != 0.0 }
-            val xs = F64SparseVector.of(5, nz.toIntArray(), nz.map { idx -> xArr[idx] }.toDoubleArray())
+            val xs = SparseVector.of(5, nz.toIntArray(), nz.map { idx -> xArr[idx] }.toDoubleArray())
             sparse.update(xs, y, 1.0)
         }
         val rd = dense.read()
@@ -62,20 +62,20 @@ class VectorSerializationTest {
     }
 
     @Test
-    fun `F64DenseVector round-trips through JSON`() {
-        val v: F64VectorStorage = F64DenseVector.of(doubleArrayOf(1.0, -2.5, 3.14, 0.0))
-        val wire = json.encodeToString(F64VectorStorage.serializer(), v)
-        val decoded = json.decodeFromString(F64VectorStorage.serializer(), wire)
-        assertTrue(decoded is F64DenseVector)
+    fun `DenseVector round-trips through JSON`() {
+        val v: VectorStorage = DenseVector.of(doubleArrayOf(1.0, -2.5, 3.14, 0.0))
+        val wire = json.encodeToString(VectorStorage.serializer(), v)
+        val decoded = json.decodeFromString(VectorStorage.serializer(), wire)
+        assertTrue(decoded is DenseVector)
         assertEquals(v, decoded)
     }
 
     @Test
-    fun `F64SparseVector round-trips through JSON`() {
-        val v: F64VectorStorage = F64SparseVector.of(10, intArrayOf(2, 5, 9), doubleArrayOf(1.0, -2.0, 0.5))
-        val wire = json.encodeToString(F64VectorStorage.serializer(), v)
-        val decoded = json.decodeFromString(F64VectorStorage.serializer(), wire)
-        assertTrue(decoded is F64SparseVector)
+    fun `SparseVector round-trips through JSON`() {
+        val v: VectorStorage = SparseVector.of(10, intArrayOf(2, 5, 9), doubleArrayOf(1.0, -2.0, 0.5))
+        val wire = json.encodeToString(VectorStorage.serializer(), v)
+        val decoded = json.decodeFromString(VectorStorage.serializer(), wire)
+        assertTrue(decoded is SparseVector)
         assertEquals(v, decoded)
     }
 
@@ -133,7 +133,7 @@ class VectorSerializationTest {
             diag.update(xArr, y, 1.0)
             bayes.update(xArr, y, 1.0)
         }
-        val queryX = F64DenseVector.of(doubleArrayOf(0.4, -0.2, 0.6))
+        val queryX = DenseVector.of(doubleArrayOf(0.4, -0.2, 0.6))
         val analyticMean = 0.7 * 0.4 + -0.3 * -0.2 + 1.5 * 0.6
 
         for ((label, m) in listOf(

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import kotlin.math.abs
 import kotlin.math.sqrt
 import kotlin.random.Random
@@ -28,8 +28,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `custom prior seeds the initial weights and covariance`() {
-        val mean = F64DenseVector.of(doubleArrayOf(0.5, -1.0, 2.0))
-        val cov = F64DenseMatrix.of(
+        val mean = DenseVector.of(doubleArrayOf(0.5, -1.0, 2.0))
+        val cov = DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 0.3, 0.0),
                 doubleArrayOf(0.3, 1.0, 0.0),
@@ -52,7 +52,7 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `non positive definite prior covariance is rejected at construction`() {
         // Diagonal with a negative entry - immediately non-PD.
-        val bad = F64DenseMatrix.of(
+        val bad = DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(1.0, 0.0),
                 doubleArrayOf(0.0, -0.1),
@@ -65,8 +65,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `reset restores configured prior`() {
-        val mean = F64DenseVector.of(doubleArrayOf(1.0, -0.5))
-        val cov = F64DenseMatrix.diagonal(2, 0.25)
+        val mean = DenseVector.of(doubleArrayOf(1.0, -0.5))
+        val cov = DenseMatrix.diagonal(2, 0.25)
         val blr = BayesianRegressionStat(featureSize = 2, priorMean = mean, priorCovariance = cov)
         val rng = Random(7)
         repeat(200) {
@@ -89,11 +89,11 @@ class BayesianRegressionStatPriorTest {
     fun `custom prior converges to truth with enough data`() {
         // A confident-but-wrong prior should still be overridden by data.
         val truth = doubleArrayOf(0.5, -1.0, 0.7)
-        val wrongMean = F64DenseVector.of(doubleArrayOf(-2.0, 3.0, -1.0))
+        val wrongMean = DenseVector.of(doubleArrayOf(-2.0, 3.0, -1.0))
         val blr = BayesianRegressionStat(
             featureSize = 3,
             priorMean = wrongMean,
-            priorCovariance = F64DenseMatrix.diagonal(3, 0.1),
+            priorCovariance = DenseMatrix.diagonal(3, 0.1),
         )
         val rng = Random(42)
         repeat(5000) {
@@ -113,8 +113,8 @@ class BayesianRegressionStatPriorTest {
         // Property: merging two instances trained on disjoint data should agree with
         // a single instance trained on the union - independent of the prior, as long
         // as both branches start from the same prior.
-        val priorMean = F64DenseVector.of(doubleArrayOf(0.2, -0.1))
-        val priorCov = F64DenseMatrix.of(
+        val priorMean = DenseVector.of(doubleArrayOf(0.2, -0.1))
+        val priorCov = DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(0.5, 0.1),
                 doubleArrayOf(0.1, 0.5),
@@ -153,8 +153,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `merging an empty custom prior state preserves the populated posterior`() {
-        val priorMean = F64DenseVector.of(doubleArrayOf(0.4, -0.7))
-        val priorCovariance = F64DenseMatrix.of(
+        val priorMean = DenseVector.of(doubleArrayOf(0.4, -0.7))
+        val priorCovariance = DenseMatrix.of(
             arrayOf(
                 doubleArrayOf(0.8, 0.2),
                 doubleArrayOf(0.2, 0.6),
@@ -185,14 +185,14 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `fitPopulationPrior returns the simple mean for identical posteriors`() {
         val mean = doubleArrayOf(1.0, -0.5)
-        val cov = F64DenseMatrix.diagonal(2, 0.4)
+        val cov = DenseMatrix.diagonal(2, 0.4)
         val snap = PrecisionRegressionResult(
-            weights = F64DenseVector.of(mean),
+            weights = DenseVector.of(mean),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 100.0,
             step = 100L,
-            precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt(0.4)),
+            precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt(0.4)),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(List(5) { snap })
@@ -211,12 +211,12 @@ class BayesianRegressionStatPriorTest {
         // coordinates are what puts anything there to reflect.
         val sqrt01 = sqrt(0.01)
         fun snap(mu: DoubleArray) = PrecisionRegressionResult(
-            weights = F64DenseVector.of(mu),
+            weights = DenseVector.of(mu),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 100.0,
             step = 100L,
-            precisionL = F64DenseMatrix.diagonal(3, 1.0 / sqrt01),
+            precisionL = DenseMatrix.diagonal(3, 1.0 / sqrt01),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(
@@ -239,15 +239,15 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior captures between-instance spread`() {
         // Two posteriors with very different means and tight covariance: the population
         // covariance should be dominated by the between-instance term (~ (mu_diff/2)^2).
-        val tight = F64DenseMatrix.diagonal(2, 0.01)
+        val tight = DenseMatrix.diagonal(2, 0.01)
         val sqrt01 = sqrt(0.01)
         fun snap(mu: DoubleArray) = PrecisionRegressionResult(
-            weights = F64DenseVector.of(mu),
+            weights = DenseVector.of(mu),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 100.0,
             step = 100L,
-            precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt01),
+            precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt01),
             sse = 0.0,
         )
         val a = snap(doubleArrayOf(1.0, 0.0))
@@ -264,7 +264,7 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior result seeds a new BLR`() {
         // The output is exactly the shape BLR's constructor wants - feed it straight in
         // and confirm the new instance starts at the fitted population mean.
-        val cov = F64DenseMatrix.diagonal(2, 0.5)
+        val cov = DenseMatrix.diagonal(2, 0.5)
         val sqrt05 = sqrt(0.5)
         val snaps = listOf(
             doubleArrayOf(0.5, 1.0),
@@ -272,12 +272,12 @@ class BayesianRegressionStatPriorTest {
             doubleArrayOf(0.4, 1.2),
         ).map {
             PrecisionRegressionResult(
-                weights = F64DenseVector.of(it),
+                weights = DenseVector.of(it),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 50.0,
                 step = 50L,
-                precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt05),
+                precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt05),
                 sse = 0.0,
             )
         }
@@ -309,15 +309,15 @@ class BayesianRegressionStatPriorTest {
     fun `fitPopulationPrior honours custom weight selector`() {
         // With weight selector returning 1.0 for the first snapshot and 0.0 for the
         // second, the result should equal the first snapshot in isolation.
-        val cov = F64DenseMatrix.diagonal(2, 0.3)
+        val cov = DenseMatrix.diagonal(2, 0.3)
         val sqrt03 = sqrt(0.3)
         fun snap(mu: DoubleArray) = PrecisionRegressionResult(
-            weights = F64DenseVector.of(mu),
+            weights = DenseVector.of(mu),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 1.0,
             step = 1L,
-            precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt03),
+            precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt03),
             sse = 0.0,
         )
         val a = snap(doubleArrayOf(2.0, -2.0))
@@ -335,14 +335,14 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `fitPopulationPrior with a single snapshot has zero between-instance variance`() {
-        val cov = F64DenseMatrix.diagonal(2, 0.4)
+        val cov = DenseMatrix.diagonal(2, 0.4)
         val snap = PrecisionRegressionResult(
-            weights = F64DenseVector.of(doubleArrayOf(0.7, -0.3)),
+            weights = DenseVector.of(doubleArrayOf(0.7, -0.3)),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 50.0,
             step = 50L,
-            precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt(0.4)),
+            precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt(0.4)),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(listOf(snap))
@@ -359,8 +359,8 @@ class BayesianRegressionStatPriorTest {
 
     @Test
     fun `create propagates the configured prior to the clone`() {
-        val mean = F64DenseVector.of(doubleArrayOf(0.4, 1.1))
-        val cov = F64DenseMatrix.diagonal(2, 0.3)
+        val mean = DenseVector.of(doubleArrayOf(0.4, 1.1))
+        val cov = DenseMatrix.diagonal(2, 0.3)
         val original = BayesianRegressionStat(
             featureSize = 2,
             priorMean = mean,
@@ -382,7 +382,7 @@ class BayesianRegressionStatPriorTest {
         assertFailsWith<IllegalArgumentException> {
             BayesianRegressionStat(
                 featureSize = 3,
-                priorMean = F64DenseVector.of(doubleArrayOf(1.0, 2.0)),
+                priorMean = DenseVector.of(doubleArrayOf(1.0, 2.0)),
             )
         }
     }
@@ -392,7 +392,7 @@ class BayesianRegressionStatPriorTest {
         assertFailsWith<IllegalArgumentException> {
             BayesianRegressionStat(
                 featureSize = 3,
-                priorCovariance = F64DenseMatrix.diagonal(2, 1.0),
+                priorCovariance = DenseMatrix.diagonal(2, 1.0),
             )
         }
     }
@@ -401,8 +401,8 @@ class BayesianRegressionStatPriorTest {
     fun `strong prior dominates with very little data`() {
         // 5 noisy observations vs a very tight prior at the wrong mean: posterior
         // should sit much closer to the prior than to the data-only UnivariateRegression() fit.
-        val priorMean = F64DenseVector.of(doubleArrayOf(0.0, 0.0))
-        val tight = F64DenseMatrix.diagonal(2, 1e-4)
+        val priorMean = DenseVector.of(doubleArrayOf(0.0, 0.0))
+        val tight = DenseMatrix.diagonal(2, 1e-4)
         val blr = BayesianRegressionStat(
             featureSize = 2,
             priorMean = priorMean,
@@ -425,12 +425,12 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `PopulationPrior round-trips through JSON`() {
         val snap = PrecisionRegressionResult(
-            weights = F64DenseVector.of(doubleArrayOf(0.5, -0.5)),
+            weights = DenseVector.of(doubleArrayOf(0.5, -0.5)),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 10.0,
             step = 10L,
-            precisionL = F64DenseMatrix.diagonal(2, 1.0 / sqrt(0.5)),
+            precisionL = DenseMatrix.diagonal(2, 1.0 / sqrt(0.5)),
             sse = 0.0,
         )
         val prior = BayesianRegressionStat.fitPopulationPrior(listOf(snap, snap))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -1,9 +1,9 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.fitLine
 import kotlin.math.abs
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class BayesianRegressionStatTest {
 
-    private class StridedVector(private val backing: DoubleArray) : F64VectorLike {
+    private class StridedVector(private val backing: DoubleArray) : VectorLike {
         override val size: Int get() = backing.size / 2
         override fun get(i: Int): Double = backing[i * 2]
         override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
@@ -65,7 +65,7 @@ class BayesianRegressionStatTest {
         val reused = BayesianRegressionStat(featureSize = 2)
         val workspace = Workspace().apply { reserve(2, 3) }
         repeat(20) { i ->
-            val x = F64DenseVector.of(doubleArrayOf(i.toDouble() / 20.0, 1.0))
+            val x = DenseVector.of(doubleArrayOf(i.toDouble() / 20.0, 1.0))
             allocated.update(x, x[0] + 2.0)
             reused.update(x, x[0] + 2.0, workspace = workspace)
         }
@@ -119,7 +119,7 @@ class BayesianRegressionStatTest {
         val stat = BayesianRegressionStat(featureSize = 2)
         stat.update(doubleArrayOf(1.0, -2.0), 3.0)
         val snapshot = stat.read()
-        val dense = F64DenseVector.of(doubleArrayOf(0.5, -0.25))
+        val dense = DenseVector.of(doubleArrayOf(0.5, -0.25))
         val strided = StridedVector(doubleArrayOf(0.5, 9.0, -0.25, 9.0))
 
         assertEquals(snapshot.linearPredictor(dense), snapshot.linearPredictor(strided), 1e-12)
@@ -160,7 +160,7 @@ class BayesianRegressionStatTest {
             first.update(x, rng.nextDouble())
             second.update(DoubleArray(3) { rng.nextDouble() }, rng.nextDouble())
         }
-        val buffer = F64DenseMatrix.zero(3, 3)
+        val buffer = DenseMatrix.zero(3, 3)
 
         // Reused across two different posteriors: the second fill has to overwrite the first
         // completely, not blend with whatever it left behind.
@@ -279,8 +279,8 @@ class BayesianRegressionStatTest {
                     BayesianRegressionStat(
                         featureSize = 2,
                         priorVariance = 1.0,
-                        priorMean = F64DenseVector.of(doubleArrayOf(0.25, -0.5)),
-                        priorCovariance = F64DenseMatrix.of(
+                        priorMean = DenseVector.of(doubleArrayOf(0.25, -0.5)),
+                        priorCovariance = DenseMatrix.of(
                             arrayOf(doubleArrayOf(2.0, 0.5), doubleArrayOf(0.5, 1.5)),
                         ),
                     ).also { stat ->
@@ -377,7 +377,7 @@ class BayesianRegressionStatTest {
         assertEquals(Link.Identity, stat.link)
         val snap = stat.read()
         assertEquals(Link.Identity, snap.link)
-        val x = F64DenseVector.of(doubleArrayOf(0.5, -0.3))
+        val x = DenseVector.of(doubleArrayOf(0.5, -0.3))
         assertEquals(snap.linearPredictor(x), snap.predict(x))
     }
 
@@ -393,10 +393,10 @@ class BayesianRegressionStatTest {
             stat.update(x, y, 1.0)
         }
         val snap = stat.read()
-        val p1 = snap.predict(F64DenseVector.of(doubleArrayOf(1.0, 0.0)))
+        val p1 = snap.predict(DenseVector.of(doubleArrayOf(1.0, 0.0)))
         assertTrue(p1 in 0.0..1.0, "predict returned $p1, expected probability")
         assertTrue(p1 > 0.7, "predicted P(positive | (1,0)) = $p1, expected > 0.7")
-        val pNeg = snap.predict(F64DenseVector.of(doubleArrayOf(-1.0, 1.0)))
+        val pNeg = snap.predict(DenseVector.of(doubleArrayOf(-1.0, 1.0)))
         assertTrue(pNeg < 0.3, "predicted P(positive | (-1,1)) = $pNeg, expected < 0.3")
     }
 
@@ -410,7 +410,7 @@ class BayesianRegressionStatTest {
             stat.update(x, rate, 1.0)
         }
         val snap = stat.read()
-        val x = F64DenseVector.of(doubleArrayOf(0.5, 0.5))
+        val x = DenseVector.of(doubleArrayOf(0.5, 0.5))
         val pred = snap.predict(x)
         val expected = exp(0.75)
         assertTrue(abs(pred - expected) / expected < 0.3, "pred=$pred, expected $expected")
@@ -421,7 +421,7 @@ class BayesianRegressionStatTest {
         val stat = BayesianRegressionStat(featureSize = 2, link = Link.Logit)
         stat.update(doubleArrayOf(1.0, 0.5), 1.0, 5.0)
         val snap = stat.read()
-        val x = F64DenseVector.of(doubleArrayOf(0.7, -0.3))
+        val x = DenseVector.of(doubleArrayOf(0.7, -0.3))
         val eta = snap.linearPredictor(x)
         val expected = 1.0 / (1.0 + exp(-eta))
         assertEquals(expected, snap.predict(x), absoluteTolerance = 1e-12)
@@ -432,7 +432,7 @@ class BayesianRegressionStatTest {
         val stat = BayesianRegressionStat(featureSize = 2, link = Link.Log)
         stat.update(doubleArrayOf(0.3, 0.4), 2.0, 1.0)
         val snap = stat.read()
-        val x = F64DenseVector.of(doubleArrayOf(0.1, 0.2))
+        val x = DenseVector.of(doubleArrayOf(0.1, 0.2))
         val eta = snap.linearPredictor(x)
         assertEquals(exp(eta), snap.predict(x), absoluteTolerance = 1e-12)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegressionTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
@@ -131,7 +131,7 @@ class HierarchicalBayesianRegressionTest {
 
     @Test
     fun `caller-supplied initial prior is honoured`() {
-        val seedMean = F64DenseVector.of(doubleArrayOf(7.0, -3.0))
+        val seedMean = DenseVector.of(doubleArrayOf(7.0, -3.0))
         val pop = HierarchicalBayesianRegression(
             featureSize = 2,
             initialPriorMean = seedMean,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -1,12 +1,12 @@
 package com.eignex.kumulant.stat.regression.glm
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.VectorLike
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64StridedVectorView
-import com.eignex.koblas.core.F64VectorLike
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.schema.optimizer.Sgd
 import kotlin.math.abs
@@ -17,7 +17,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 class LinearPosteriorsTest {
 
-    private class CustomVector(private val values: DoubleArray) : F64VectorLike {
+    private class CustomVector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -59,7 +59,7 @@ class LinearPosteriorsTest {
     @Test
     fun `workspace covariance evaluation matches allocating evaluation and preserves random draws`() {
         val snapshot = bayesianSnapshot()
-        val x = F64SparseVector.of(size = 2, indices = intArrayOf(0), values = doubleArrayOf(0.3))
+        val x = SparseVector.of(size = 2, indices = intArrayOf(0), values = doubleArrayOf(0.3))
         val workspace = Workspace().apply { reserve(2, 1) }
 
         val allocated = MultivariateGaussian.evaluate(snapshot, x, Random(9), exploration = 0.7)
@@ -71,8 +71,8 @@ class LinearPosteriorsTest {
     @Test
     fun `workspace covariance evaluation accepts strided and custom vectors`() {
         val snapshot = bayesianSnapshot()
-        val dense = F64DenseVector.of(doubleArrayOf(0.3, -0.2))
-        val strided = F64StridedVectorView(doubleArrayOf(0.3, 7.0, -0.2, 7.0), 0, 2, 2)
+        val dense = DenseVector.of(doubleArrayOf(0.3, -0.2))
+        val strided = StridedVectorView(doubleArrayOf(0.3, 7.0, -0.2, 7.0), 0, 2, 2)
         val custom = CustomVector(doubleArrayOf(0.3, -0.2))
         val workspace = Workspace().apply { reserve(2, 1) }
 
@@ -143,7 +143,7 @@ class LinearPosteriorsTest {
     @Test
     fun `PointPosterior evaluate with zero exploration is the point prediction`() {
         val snap = sgdSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.3, -0.4))
+        val x = DenseVector.of(doubleArrayOf(0.3, -0.4))
         val v = PointPosterior.evaluate(snap, x, Random(0), exploration = 0.0)
         assertEquals(snap.predict(x), v, 1e-12)
     }
@@ -151,7 +151,7 @@ class LinearPosteriorsTest {
     @Test
     fun `PointPosterior evaluate with exploration is finite`() {
         val snap = sgdSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.3, -0.4))
+        val x = DenseVector.of(doubleArrayOf(0.3, -0.4))
         repeat(50) {
             val v = PointPosterior.evaluate(snap, x, Random(it.toLong()), exploration = 0.5)
             assertTrue(v.isFinite())
@@ -190,7 +190,7 @@ class LinearPosteriorsTest {
     @Test
     fun `FactorisedGaussian evaluate is centered on predict`() {
         val snap = diagonalSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.1, 0.2))
+        val x = DenseVector.of(doubleArrayOf(0.1, 0.2))
         val rng = Random(0)
         val n = 600
         var sum = 0.0
@@ -201,8 +201,8 @@ class LinearPosteriorsTest {
     @Test
     fun `FactorisedGaussian evaluate gives sparse inputs the dense score`() {
         val snap = diagonalSnapshot()
-        val dense = F64DenseVector.of(doubleArrayOf(0.1, 0.0))
-        val sparse = F64SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.1))
+        val dense = DenseVector.of(doubleArrayOf(0.1, 0.0))
+        val sparse = SparseVector.of(2, intArrayOf(0), doubleArrayOf(0.1))
 
         assertEquals(
             FactorisedGaussian.evaluate(snap, dense, Random(42), exploration = 0.1),
@@ -230,12 +230,12 @@ class LinearPosteriorsTest {
     @Test
     fun `MultivariateGaussian sample maps the draw through the inverse precision factor`() {
         val snapshot = PrecisionRegressionResult(
-            weights = F64DenseVector.of(doubleArrayOf(1.0, -1.0)),
+            weights = DenseVector.of(doubleArrayOf(1.0, -1.0)),
             bias = 0.0,
             biasPrecision = 1.0,
             totalWeights = 0.0,
             step = 0L,
-            precisionL = F64DenseMatrix.of(arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(3.0, 4.0))),
+            precisionL = DenseMatrix.of(arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(3.0, 4.0))),
         )
         val expectedRng = Random(7)
         val u0 = expectedRng.nextNormal(0.0, 0.5)
@@ -255,7 +255,7 @@ class LinearPosteriorsTest {
     @Test
     fun `MultivariateGaussian evaluate is finite and finite-variance`() {
         val snap = bayesianSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.5, 0.5))
+        val x = DenseVector.of(doubleArrayOf(0.5, 0.5))
         val rng = Random(0)
         val n = 300
         var sum = 0.0
@@ -266,7 +266,7 @@ class LinearPosteriorsTest {
     @Test
     fun `LinUcb evaluate is deterministic given the snapshot`() {
         val snap = bayesianSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.3, 0.7))
+        val x = DenseVector.of(doubleArrayOf(0.3, 0.7))
         val rng = Random(0)
         val a = LinUcb.evaluate(snap, x, rng, exploration = 1.0)
         val b = LinUcb.evaluate(snap, x, rng, exploration = 1.0)
@@ -276,7 +276,7 @@ class LinearPosteriorsTest {
     @Test
     fun `LinUcb evaluate is mean plus alpha times sqrt xT Sigma x`() {
         val snap = bayesianSnapshot()
-        val x = F64DenseVector.of(doubleArrayOf(0.5, -0.5))
+        val x = DenseVector.of(doubleArrayOf(0.5, -0.5))
         val alpha = 2.0
         val score = LinUcb.evaluate(snap, x, Random(0), exploration = alpha)
         val mean = snap.predict(x)
@@ -298,7 +298,7 @@ class LinearPosteriorsTest {
         val snap = sgdSnapshot()
         assertTrue(snap.featureSize == 2)
         assertFailsWith<IllegalArgumentException> {
-            snap.predict(F64DenseVector.of(doubleArrayOf(1.0)))
+            snap.predict(DenseVector.of(doubleArrayOf(1.0)))
         }
     }
 
@@ -306,12 +306,12 @@ class LinearPosteriorsTest {
     fun `PrecisionRegressionResult rejects shape mismatch`() {
         assertFailsWith<IllegalArgumentException> {
             PrecisionRegressionResult(
-                weights = F64DenseVector.of(doubleArrayOf(0.0, 0.0)),
+                weights = DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 bias = 0.0,
                 biasPrecision = 1.0,
                 totalWeights = 0.0,
                 step = 0L,
-                precisionL = F64DenseMatrix.zero(3, 3),
+                precisionL = DenseMatrix.zero(3, 3),
             )
         }
     }
@@ -377,7 +377,7 @@ class LinearPosteriorsTest {
         val point = sgdSnapshot().copy(link = Link.Logit)
         val diagonal = diagonalSnapshot().copy(link = Link.Logit)
         val bayesian = bayesianSnapshot().copy(link = Link.Logit)
-        val x = F64DenseVector.of(doubleArrayOf(1.0, 1.0))
+        val x = DenseVector.of(doubleArrayOf(1.0, 1.0))
         val rng = Random(3)
         repeat(100) {
             assertTrue(PointPosterior.evaluate(point, x, rng, exploration = 4.0) in 0.0..1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.fitLine
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -92,7 +92,7 @@ class StochasticRegressionStatTest {
         val snap = stat.read()
         assertTrue(snap.weights[0] > 0.0, "w[0] = ${snap.weights[0]} should be positive")
         assertTrue(snap.weights[1] < 0.0, "w[1] = ${snap.weights[1]} should be negative")
-        val p1 = snap.predict(F64DenseVector.of(doubleArrayOf(1.0, -1.0)))
+        val p1 = snap.predict(DenseVector.of(doubleArrayOf(1.0, -1.0)))
         assertTrue(p1 in 0.0..1.0)
     }
 
@@ -175,7 +175,7 @@ class StochasticRegressionStatTest {
             optimizer = Sgd(ConstantRate(0.01)),
             penalty = Penalty.L2(0.1),
         )
-        stat.update(F64DenseVector.of(doubleArrayOf(1.0, 0.5)), 1.0, 0L, weight = 1000.0)
+        stat.update(DenseVector.of(doubleArrayOf(1.0, 0.5)), 1.0, 0L, weight = 1000.0)
         val w = stat.read().weights.toDoubleArray()
         for (v in w) assertTrue(v.isFinite(), "weight $v not finite")
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,7 +39,7 @@ class DecisionTreeClassifierStatTest {
             val x0 = rng.nextDouble() * 2.0 - 1.0
             val x1 = rng.nextDouble() * 2.0 - 1.0
             val label = if (x0 > 0.0) 1 else 0
-            r.predict(F64DenseVector.of(doubleArrayOf(x0, x1))) == label
+            r.predict(DenseVector.of(doubleArrayOf(x0, x1))) == label
         }
         assertTrue(nRight > 180, "accuracy=$nRight/200, tree=${stat.tree().prettyPrint()}")
     }
@@ -62,7 +62,7 @@ class DecisionTreeClassifierStatTest {
             stat.update(doubleArrayOf(x0, x1), rng.nextInt(3).toDouble())
         }
         val r = stat.read()
-        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.4, -0.4)))
+        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.4, -0.4)))
         assertEquals(1.0, p.sum(), 1e-9)
     }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/ForestRegressionResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +21,7 @@ class ForestRegressionResultTest {
                 leaf(3.0, 5.0, 1.0),
             ),
         )
-        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
         val w = 5.0
         val expectedMean = (2.0 * 1.0 + 3.0 * 5.0) / w
         val delta = 5.0 - 1.0
@@ -39,7 +39,7 @@ class ForestRegressionResultTest {
                 leaf(4.0, 2.0, 1.0),
             ),
         )
-        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
         assertEquals(4.0, r.totalWeights, 1e-12)
         assertEquals(2.0, r.mean, 1e-12)
         assertEquals(1.0, r.variance, 1e-12)
@@ -50,7 +50,7 @@ class ForestRegressionResultTest {
         val forest = ForestRegressionResult(
             trees = listOf(leaf(1.0, 3.0, 0.0), leaf(1.0, 5.0, 0.0)),
         )
-        assertEquals(4.0, forest.predict(F64DenseVector.of(doubleArrayOf(0.0))), 1e-12)
+        assertEquals(4.0, forest.predict(DenseVector.of(doubleArrayOf(0.0))), 1e-12)
     }
 
     @Test
@@ -71,7 +71,7 @@ class ForestRegressionResultTest {
         val forest = ForestRegressionResult(
             trees = listOf(leaf(0.0, 0.0, 0.0), leaf(0.0, 0.0, 0.0)),
         )
-        val r = forest.findLeafMerged(F64DenseVector.of(doubleArrayOf(0.0)))
+        val r = forest.findLeafMerged(DenseVector.of(doubleArrayOf(0.0)))
         assertEquals(0.0, r.totalWeights, 1e-12)
         assertEquals(0.0, r.variance, 1e-12)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStatTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,13 +37,13 @@ class RandomForestClassifierStatTest {
             stat.update(doubleArrayOf(x0, x1), label.toDouble())
         }
         val r = stat.read()
-        val p = r.probabilities(F64DenseVector.of(doubleArrayOf(0.5, 0.5)))
+        val p = r.probabilities(DenseVector.of(doubleArrayOf(0.5, 0.5)))
         assertEquals(1.0, p.sum(), 1e-9)
         val correct = (0 until 200).count {
             val x0 = rng.nextDouble() * 2.0 - 1.0
             val x1 = rng.nextDouble() * 2.0 - 1.0
             val label = if (x0 > 0.0) 1 else 0
-            r.predict(F64DenseVector.of(doubleArrayOf(x0, x1))) == label
+            r.predict(DenseVector.of(doubleArrayOf(x0, x1))) == label
         }
         assertTrue(correct > 170, "accuracy=$correct/200")
     }
@@ -86,7 +86,7 @@ class ForestBaggingDowndateTest {
                 randomSeed = seed,
                 splitCandidates = emptyList(),
             )
-            val x = F64DenseVector.of(doubleArrayOf(1.0))
+            val x = DenseVector.of(doubleArrayOf(1.0))
             f.update(x, 0.0, weight = 1.0)
             f.update(x, 0.0, weight = -1.0)
             f.update(x, 1.0, weight = 5.0)
@@ -104,7 +104,7 @@ class ForestBaggingDowndateTest {
             randomSeed = 1,
             splitCandidates = emptyList(),
         )
-        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        val x = DenseVector.of(doubleArrayOf(1.0))
         f.update(x, 2.0, weight = 1.0)
         f.update(x, 2.0, weight = -1.0)
     }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64SparseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.SparseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.feat
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.X
@@ -57,8 +57,8 @@ class SplitTest {
     @Test
     fun `ExprSplit routes a sparse context by its stored values and implicit zeroes`() {
         val s = ExprSplit(V(2) gt 0.0)
-        assertTrue(s.direction(F64SparseVector.of(3, intArrayOf(2), doubleArrayOf(0.5))))
-        assertFalse(s.direction(F64SparseVector.of(3, intArrayOf(0), doubleArrayOf(1.0))))
+        assertTrue(s.direction(SparseVector.of(3, intArrayOf(2), doubleArrayOf(0.5))))
+        assertFalse(s.direction(SparseVector.of(3, intArrayOf(0), doubleArrayOf(1.0))))
     }
 
     @Test
@@ -68,7 +68,7 @@ class SplitTest {
         assertFalse(s.direction(NoMaterializeVector(doubleArrayOf(0.0, -1.0))))
     }
 
-    private class NoMaterializeVector(private val values: DoubleArray) : F64VectorLike {
+    private class NoMaterializeVector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("split materialised its context")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResultTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 class TreeClassificationResultTest {
 
     private fun counts(vararg c: Double) = ClassCountsResult(c.size, c)
-    private fun vec(vararg xs: Double) = F64DenseVector.of(xs)
+    private fun vec(vararg xs: Double) = DenseVector.of(xs)
 
     private fun stubTree(): TreeClassificationResult {
         // x[0] <= 0 routes pos (class 0 dominant); otherwise neg (class 1 dominant)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +21,7 @@ class TreeGrowthParityTest {
 
     private val candidates = listOf(ThresholdSplit(0, 0.5), ThresholdSplit(1, 0.5))
 
-    private fun regressionStructure(node: RegressionNode<F64VectorLike>): String = when (node) {
+    private fun regressionStructure(node: RegressionNode<VectorLike>): String = when (node) {
         is RegressionSplitNode -> "(${node.split} ? ${regressionStructure(node.pos)}" +
             " : ${regressionStructure(node.neg)})"
 
@@ -35,8 +35,8 @@ class TreeGrowthParityTest {
         is ClassificationLeafNode -> "leaf"
     }
 
-    private fun grownPair(observations: Int): Pair<RegressionTree<F64VectorLike>, ClassificationTree> {
-        val regression = RegressionTree<F64VectorLike>(splitCandidates = candidates, randomSeed = 7)
+    private fun grownPair(observations: Int): Pair<RegressionTree<VectorLike>, ClassificationTree> {
+        val regression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(
             numClasses = 2,
             splitCandidates = candidates,
@@ -71,7 +71,7 @@ class TreeGrowthParityTest {
 
     @Test
     fun `neither tree splits while the candidates carry no signal`() {
-        val regression = RegressionTree<F64VectorLike>(splitCandidates = candidates, randomSeed = 7)
+        val regression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 7)
         // A constant label leaves every candidate at zero impurity reduction, so shouldSplit must refuse
         // in both trees no matter how much weight piles up.
@@ -88,7 +88,7 @@ class TreeGrowthParityTest {
     fun `snapshot merge into a fresh tree reproduces the grown shape on both sides`() {
         val (regression, classification) = grownPair(observations = 4000)
 
-        val freshRegression = RegressionTree<F64VectorLike>(splitCandidates = candidates, randomSeed = 9)
+        val freshRegression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 9)
         freshRegression.mergeSnapshot(regression.rootNode().snapshot())
 
         val freshClassification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 9)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
@@ -2,8 +2,8 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.core.F64DenseVector
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.DenseVector
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 
 class TreeNodeTest {
 
-    private fun wvLeaf(): RegressionTerminalLeaf<F64VectorLike> = RegressionTerminalLeaf(VarianceStat())
+    private fun wvLeaf(): RegressionTerminalLeaf<VectorLike> = RegressionTerminalLeaf(VarianceStat())
     private fun ccLeaf(numClasses: Int = 2) = ClassificationTerminalLeaf(ClassCountsStat(numClasses))
 
     @Test
@@ -21,10 +21,10 @@ class TreeNodeTest {
         val pos = wvLeaf()
         val neg = wvLeaf()
         val node = RegressionSplitNode(ThresholdSplit(0, 0.0), pos = pos, neg = neg)
-        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(-1.0))))
-        assertSame(neg, node.findLeaf(F64DenseVector.of(doubleArrayOf(1.0))))
+        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(-1.0))))
+        assertSame(neg, node.findLeaf(DenseVector.of(doubleArrayOf(1.0))))
         // Threshold is inclusive on the pos side.
-        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(0.0))))
+        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(0.0))))
     }
 
     @Test
@@ -34,7 +34,7 @@ class TreeNodeTest {
         val node = RegressionSplitNode(ThresholdSplit(0, 0.0), pos = original, neg = wvLeaf())
         assertSame(original, node.pos)
         node.pos = replacement
-        assertSame(replacement, node.findLeaf(F64DenseVector.of(doubleArrayOf(-1.0))))
+        assertSame(replacement, node.findLeaf(DenseVector.of(doubleArrayOf(-1.0))))
     }
 
     @Test
@@ -67,8 +67,8 @@ class TreeNodeTest {
         val pos = ccLeaf()
         val neg = ccLeaf()
         val node = ClassificationSplitNode(ThresholdSplit(0, 0.5), pos = pos, neg = neg)
-        assertSame(pos, node.findLeaf(F64DenseVector.of(doubleArrayOf(0.0))))
-        assertSame(neg, node.findLeaf(F64DenseVector.of(doubleArrayOf(1.0))))
+        assertSame(pos, node.findLeaf(DenseVector.of(doubleArrayOf(0.0))))
+        assertSame(neg, node.findLeaf(DenseVector.of(doubleArrayOf(1.0))))
     }
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditAllocationTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.assertAllocatesAtMost
 import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
@@ -12,7 +12,7 @@ class Exp4BanditAllocationTest {
     fun `destination distribution removes Kumulant output allocation with reusable advice`() {
         val allocating = reusableBandit()
         val destination = reusableBandit()
-        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        val x = DenseVector.of(doubleArrayOf(1.0))
         val out = DoubleArray(ARMS)
 
         val (allocatingBytes, destinationBytes) = bytesPerCall(
@@ -28,7 +28,7 @@ class Exp4BanditAllocationTest {
 
     @Test
     fun `choose and update retain their distribution storage with reusable advice`() {
-        val x = F64DenseVector.of(doubleArrayOf(1.0))
+        val x = DenseVector.of(doubleArrayOf(1.0))
         val choosing = reusableBandit()
         val updating = reusableBandit()
         val arm = updating.choose(x)

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit.contextual
 
+import com.eignex.koblas.DenseVector
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.assertAllocatesAtMost
 import kotlin.test.Test
 
@@ -16,7 +16,7 @@ class KnnWorkspaceAllocationTest {
             repeat(HISTORY) { sample ->
                 bandit.update(
                     arm,
-                    F64DenseVector.of(DoubleArray(FEATURES) { (it + sample).toDouble() }),
+                    DenseVector.of(DoubleArray(FEATURES) { (it + sample).toDouble() }),
                     sample.toDouble(),
                 )
             }
@@ -27,7 +27,7 @@ class KnnWorkspaceAllocationTest {
     fun `k nearest neighbour scoring allocates nothing with or without a workspace`() {
         val bare = populatedBandit()
         val reused = populatedBandit()
-        val x = F64DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
+        val x = DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
         val workspace = Workspace().apply { reserve(3 * K, 1) }
 
         // The scan buffer is owned by the bandit, so there is nothing left for a workspace to save

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.core.F64VectorLike
+import com.eignex.koblas.VectorLike
 import com.eignex.kumulant.bytesPerCall
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.VElements
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 class ExprAllocationTest {
 
-    private class Vector(private val values: DoubleArray) : F64VectorLike {
+    private class Vector(private val values: DoubleArray) : VectorLike {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("unexpected materialisation")
@@ -23,7 +23,7 @@ class ExprAllocationTest {
         val scalar = V(0) + V(1)
         val predicate = V(0) gt 0.0
         val vector = VElements(listOf(V(0)))
-        fun evaluate(input: F64VectorLike) {
+        fun evaluate(input: VectorLike) {
             scalar.eval(v = input)
             predicate.eval(v = input)
             vector.eval(v = input)

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesAllocationTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -14,7 +14,7 @@ class GaussianNaiveBayesAllocationTest {
             stat.update(DoubleArray(32) { feature -> (sample - feature).toDouble() * 0.1 }, (sample % 4).toDouble())
         }
         val result = stat.read()
-        val x = F64DenseVector.of(DoubleArray(32) { it * 0.25 })
+        val x = DenseVector.of(DoubleArray(32) { it * 0.25 })
         val destination = DoubleArray(4)
 
         val (allocatedBytes, destinationBytes) = bytesPerCall(

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/OwnedStorageAllocationTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.core.F64SparseVector
+import com.eignex.koblas.SparseVector
 import com.eignex.kumulant.assertAllocatesAtMost
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
@@ -41,7 +41,7 @@ class OwnedStorageAllocationTest {
         for (featureSize in intArrayOf(32, 128, 512)) {
             for (density in intArrayOf(1, 10, 100)) {
                 val nnz = (featureSize * density / 100).coerceAtLeast(1)
-                val sparse = F64SparseVector.of(
+                val sparse = SparseVector.of(
                     featureSize,
                     IntArray(nnz) { it * featureSize / nnz },
                     DoubleArray(nnz) { it.toDouble() },

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
@@ -1,8 +1,8 @@
 package com.eignex.kumulant.stat.regression
 
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import com.eignex.koblas.Workspace
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
 import com.eignex.kumulant.assertAllocatesAtMost
 import com.eignex.kumulant.bytesPerCall
 import com.eignex.kumulant.schema.optimizer.Sgd
@@ -16,7 +16,7 @@ class SoftmaxWorkspaceAllocationTest {
     fun `reserved workspace removes softmax update logits allocation`() {
         val allocating = SoftmaxRegressionStat(featureSize = 8, numClasses = 4, optimizer = Sgd(ConstantRate(0.05)))
         val reused = SoftmaxRegressionStat(featureSize = 8, numClasses = 4, optimizer = Sgd(ConstantRate(0.05)))
-        val x = F64DenseVector.of(DoubleArray(8) { (it + 1).toDouble() / 8.0 })
+        val x = DenseVector.of(DoubleArray(8) { (it + 1).toDouble() / 8.0 })
         val workspace = Workspace().apply { reserve(4, 1) }
 
         val (allocatedBytes, workspaceBytes) = bytesPerCall(
@@ -35,15 +35,15 @@ class SoftmaxWorkspaceAllocationTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = F64DenseMatrix.of(
+            weights = DenseMatrix.of(
                 arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0), doubleArrayOf(-1.0, -1.0)),
             ),
-            biases = F64DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
+            biases = DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val x = F64DenseVector.of(doubleArrayOf(1.0, 0.5))
+        val x = DenseVector.of(doubleArrayOf(1.0, 0.5))
         val workspace = Workspace().apply { reserve(3, 1) }
 
         val (defaultBytes, nullBytes, workspaceBytes) = bytesPerCall(

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianPriorInfoAllocationTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
-import com.eignex.koblas.core.F64DenseMatrix
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.DenseVector
 import com.eignex.koblas.times
 import com.eignex.kumulant.bytesPerCall
 import kotlin.test.Test
@@ -12,8 +12,8 @@ class BayesianPriorInfoAllocationTest {
     @Test
     fun `destination prior information kernel avoids the materialized vector copy`() {
         val size = 128
-        val precision = F64DenseMatrix.diagonal(size, 2.0)
-        val mean = F64DenseVector.of(DoubleArray(size) { it * 0.01 })
+        val precision = DenseMatrix.diagonal(size, 2.0)
+        val mean = DenseVector.of(DoubleArray(size) { it * 0.01 })
         val destination = DoubleArray(size)
         var sink = 0.0
 

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stream/ConcurrentReadInvariantsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stream
 
-import com.eignex.koblas.core.F64DenseVector
+import com.eignex.koblas.DenseVector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.core.Stat
@@ -195,7 +195,7 @@ class ConcurrentReadInvariantsTest {
             val writers = 6
             val iters = 3_000
             assertReadInvariants("HalfSpaceTreesStat[$level]", stat, writers = writers, iters = iters, write = { t, i ->
-                val v = F64DenseVector.of(
+                val v = DenseVector.of(
                     doubleArrayOf(
                         ((t * 7 + i) % 100) / 100.0,
                         ((t * 13 + i * 3) % 100) / 100.0,
@@ -206,7 +206,7 @@ class ConcurrentReadInvariantsTest {
             }) { r ->
                 assertTrue(r.totalWeights >= 0.0, "totalWeights=${r.totalWeights}")
                 for (m in r.referenceMass) assertTrue(m >= 0.0 && m.isFinite(), "referenceMass entry $m")
-                val s = r.score(F64DenseVector.of(doubleArrayOf(0.5, 0.5, 0.5)))
+                val s = r.score(DenseVector.of(doubleArrayOf(0.5, 0.5, 0.5)))
                 assertTrue(s.isFinite() && s >= 0.0, "score=$s")
             }
             val fed = (writers * iters).toDouble()


### PR DESCRIPTION
## What changed

- Replace prefixed Koblas precision types with their unqualified aliases across Kumulant.
- Update the custom Cholesky implementation and its tests to use the aliases.

## Why

Koblas will rename the underlying precision-specific classes and remove these transitional aliases.

## Testing

./gradlew check lintDocs --rerun-tasks