### PR TITLE
perf: use packed koblas tiles for Cholesky

### DIFF
--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -27,24 +27,24 @@ public final class com/eignex/kumulant/bandit/BanditFactoryKt {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualBandit : com/eignex/kumulant/bandit/Bandit {
-	public abstract fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
-	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public abstract fun update (ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public abstract fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public abstract fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/bandit/ContextualBandit$DefaultImpls {
-	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualScorable {
-	public abstract fun evaluate (ILcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public abstract fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/bandit/ContextualScorable$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public abstract interface class com/eignex/kumulant/bandit/PerArmBandit : com/eignex/kumulant/bandit/Snapshotable {
@@ -73,14 +73,14 @@ public final class com/eignex/kumulant/bandit/Snapshotable$DefaultImpls {
 public final class com/eignex/kumulant/bandit/TrackedContextualBandit : com/eignex/kumulant/bandit/ContextualBandit {
 	public fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
 	public final fun chooseResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun getContextFeatureSize ()I
 	public final fun getInner ()Lcom/eignex/kumulant/bandit/ContextualBandit;
 	public fun getNbrArms ()I
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun reset ()V
-	public fun update (ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
 	public final fun updateArmRewardResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateJointResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateMarginalResult ()Lcom/eignex/kumulant/core/Result;
@@ -126,7 +126,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion;
 	public fun <init> (ILjava/util/List;DDLkotlin/random/Random;)V
 	public synthetic fun <init> (ILjava/util/List;DDLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit;
 	public final fun expertWeights ()[D
@@ -137,12 +137,12 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun merge (Lcom/eignex/kumulant/bandit/contextual/Exp4State;Lcom/eignex/koblas/Workspace;)V
 	public synthetic fun merge (Ljava/lang/Object;Lcom/eignex/koblas/Workspace;)V
-	public final fun playDistribution (Lcom/eignex/koblas/core/F64VectorLike;)[D
-	public final fun playDistributionInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
+	public final fun playDistribution (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun playDistributionInto (Lcom/eignex/koblas/VectorLike;[D)V
 	public fun reset ()V
 	public fun snapshot ()Lcom/eignex/kumulant/bandit/contextual/Exp4State;
 	public synthetic fun snapshot ()Ljava/lang/Object;
-	public fun update (ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
@@ -151,7 +151,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/contextual/Exp4Expert {
-	public abstract fun advise (Lcom/eignex/koblas/core/F64VectorLike;I)[D
+	public abstract fun advise (Lcom/eignex/koblas/VectorLike;I)[D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4State : com/eignex/kumulant/core/Result {
@@ -221,10 +221,10 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun armResult (I)Lcom/eignex/kumulant/bandit/contextual/KnnArmResult;
 	public synthetic fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armWeight (I)D
-	public fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)D
+	public fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
 	public final fun getColdStartScore ()D
 	public final fun getDistance ()Lkotlin/jvm/functions/Function2;
 	public final fun getExploration ()D
@@ -238,11 +238,11 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit$Companion {
-	public final fun squaredL2 (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/core/F64VectorLike;)D
+	public final fun squaredL2 (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/VectorLike;)D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -404,10 +404,10 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public synthetic fun <init> (ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/stat/regression/RegressionPosterior;DLcom/eignex/kumulant/core/RegressionStat;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armStat (I)Lcom/eignex/kumulant/core/RegressionStat;
-	public fun choose (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)D
+	public fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
 	public final fun getExploration ()D
 	public fun getNbrArms ()I
 	public final fun getPosterior ()Lcom/eignex/kumulant/stat/regression/RegressionPosterior;
@@ -421,7 +421,7 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/RegressionContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -1854,13 +1854,13 @@ public abstract interface class com/eignex/kumulant/core/HasCenterScale : com/ei
 public abstract interface class com/eignex/kumulant/core/HasLinearModel : com/eignex/kumulant/core/Result {
 	public abstract fun getBias ()D
 	public fun getFeatureSize ()I
-	public abstract fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 }
 
 public final class com/eignex/kumulant/core/HasLinearModel$DefaultImpls {
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasLinearModel;)I
-	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/core/F64VectorLike;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/VectorLike;)D
 }
 
 public abstract interface class com/eignex/kumulant/core/HasMinMax : com/eignex/kumulant/core/Result {
@@ -1953,16 +1953,16 @@ public abstract interface class com/eignex/kumulant/core/HasSlope : com/eignex/k
 	public fun getFeatureSize ()I
 	public abstract fun getIntercept ()D
 	public abstract fun getSlope ()D
-	public fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/VectorLike;
 	public fun predict (D)D
 }
 
 public final class com/eignex/kumulant/core/HasSlope$DefaultImpls {
 	public static fun getBias (Lcom/eignex/kumulant/core/HasSlope;)D
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasSlope;)I
-	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/core/F64VectorLike;
+	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/VectorLike;
 	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;D)D
-	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/core/F64VectorLike;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/VectorLike;)D
 }
 
 public final class com/eignex/kumulant/core/IndexedResult : com/eignex/kumulant/core/Result {
@@ -2017,22 +2017,22 @@ public abstract interface class com/eignex/kumulant/core/RegressionStat : com/ei
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public abstract fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public abstract fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/RegressionStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
@@ -2106,22 +2106,22 @@ public final class com/eignex/kumulant/core/Stat$DefaultImpls {
 public abstract interface class com/eignex/kumulant/core/VectorStat : com/eignex/kumulant/core/Stat {
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;D)V
-	public abstract fun update (Lcom/eignex/koblas/core/F64VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/VectorLike;D)V
+	public abstract fun update (Lcom/eignex/koblas/VectorLike;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorLike;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorLike;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/VectorStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorLike;D)V
+	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;D)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DD)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorLike;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/core/F64VectorLike;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
@@ -2395,12 +2395,12 @@ public final class com/eignex/kumulant/schema/expr/ExprKt {
 	public static final fun div (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/ScalarExpr;
 	public static final fun eq (Lcom/eignex/kumulant/schema/expr/ScalarExpr;D)Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public static final fun eq (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/BoolExpr;
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;)Z
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;)D
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;)[D
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)Z
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)D
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)[D
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)Z
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)D
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)[D
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)Z
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)D
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)[D
 	public static final fun exp (Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/ScalarExpr;
 	public static final fun ge (Lcom/eignex/kumulant/schema/expr/ScalarExpr;D)Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public static final fun ge (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -3041,8 +3041,8 @@ public final class com/eignex/kumulant/schema/runtime/RegressionStatGroup : com/
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -3141,8 +3141,8 @@ public final class com/eignex/kumulant/schema/runtime/VectorStatGroup : com/eign
 	public synthetic fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;D)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/VectorLike;D)V
+	public fun update (Lcom/eignex/koblas/VectorLike;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -5070,7 +5070,7 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult : com/e
 	public fun getTotalWeights ()D
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun score (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public final fun score (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -5107,8 +5107,8 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat : com/eig
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;D)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/VectorLike;D)V
+	public fun update (Lcom/eignex/koblas/VectorLike;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -6844,32 +6844,32 @@ public final class com/eignex/kumulant/stat/regression/CovarianceStat : com/eign
 }
 
 public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesResult : com/eignex/kumulant/core/HasObservationCount {
-	public fun <init> (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DD)V
+	public fun <init> (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/core/F64DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/core/F64DenseMatrix;
-	public final fun component5 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun component5 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component6 ()D
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public final fun copy (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DD)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getClassWeights ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun getClassWeights ()Lcom/eignex/koblas/DenseVector;
 	public final fun getFeatureSize ()I
-	public final fun getMeans ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getMeans ()Lcom/eignex/koblas/DenseMatrix;
 	public final fun getNumClasses ()I
 	public fun getTotalWeights ()D
 	public final fun getVarianceFloor ()D
-	public final fun getVariances ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getVariances ()Lcom/eignex/koblas/DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logPosterior (Lcom/eignex/koblas/core/F64VectorLike;I)D
-	public final fun logPosteriorsInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)I
+	public final fun logPosterior (Lcom/eignex/koblas/VectorLike;I)D
+	public final fun logPosteriorsInto (Lcom/eignex/koblas/VectorLike;[D)V
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
 	public final fun prior (I)D
-	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
-	public final fun probabilitiesInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
+	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun probabilitiesInto (Lcom/eignex/koblas/VectorLike;[D)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6899,8 +6899,8 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat : 
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -6917,12 +6917,12 @@ public final class com/eignex/kumulant/stat/regression/Optimizer$DefaultImpls {
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/RegressionPosterior {
-	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RegressionPosterior$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RmspropOptimizer : com/eignex/kumulant/stat/regression/Optimizer {
@@ -6950,32 +6950,32 @@ public final class com/eignex/kumulant/stat/regression/SgdOptimizer : com/eignex
 
 public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionResult : com/eignex/kumulant/core/HasObservationCount {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult$Companion;
-	public fun <init> (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJD)V
+	public fun <init> (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJD)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()Lcom/eignex/koblas/core/F64DenseMatrix;
-	public final fun component4 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun component3 ()Lcom/eignex/koblas/DenseMatrix;
+	public final fun component4 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component5 ()D
 	public final fun component6 ()J
 	public final fun component7 ()D
-	public final fun copy (IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/core/F64DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public final fun copy (IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJD)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;IILcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/DenseVector;DJDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBiases ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun getBiases ()Lcom/eignex/koblas/DenseVector;
 	public final fun getCrossEntropy ()D
 	public final fun getFeatureSize ()I
 	public final fun getNumClasses ()I
 	public final fun getStep ()J
 	public fun getTotalWeights ()D
-	public final fun getWeights ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getWeights ()Lcom/eignex/koblas/DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logit (Lcom/eignex/koblas/core/F64VectorLike;I)D
-	public final fun logitsInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;)I
-	public static synthetic fun predict$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
-	public final fun probabilitiesInto (Lcom/eignex/koblas/core/F64VectorLike;[D)V
+	public final fun logit (Lcom/eignex/koblas/VectorLike;I)D
+	public final fun logitsInto (Lcom/eignex/koblas/VectorLike;[D)V
+	public final fun predict (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public static synthetic fun predict$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun probabilitiesInto (Lcom/eignex/koblas/VectorLike;[D)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7013,16 +7013,16 @@ public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionStat : c
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat : com/eignex/kumulant/core/RegressionStat {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat$Companion;
-	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/core/F64MatrixLike;)V
-	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/core/F64VectorLike;Lcom/eignex/koblas/core/F64MatrixLike;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/MatrixLike;)V
+	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/MatrixLike;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
@@ -7035,8 +7035,8 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7048,25 +7048,25 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 
 public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun component6 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component7 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component8 ()D
-	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseVector;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
-	public final fun getPrecision ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun getPrecision ()Lcom/eignex/koblas/DenseVector;
 	public fun getRSquared ()D
 	public fun getRmse ()D
 	public fun getSampleStdDev ()D
@@ -7078,12 +7078,12 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionRes
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7119,8 +7119,8 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7128,12 +7128,12 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 public final class com/eignex/kumulant/stat/regression/glm/FactorisedGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/FactorisedGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;[DD)V
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7141,8 +7141,8 @@ public final class com/eignex/kumulant/stat/regression/glm/FactorisedGaussian : 
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/HierarchicalBayesianRegression {
-	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;)V
-	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;)V
+	public synthetic fun <init> (ILcom/eignex/kumulant/stat/regression/glm/Link;DLcom/eignex/kumulant/core/Concurrency;DLcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createInstance ()Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
 	public final fun getBiasPriorVariance ()D
 	public final fun getConcurrency ()Lcom/eignex/kumulant/core/Concurrency;
@@ -7166,12 +7166,12 @@ public final class com/eignex/kumulant/stat/regression/glm/LearningRatesKt {
 public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/LinUcb;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7180,10 +7180,10 @@ public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/k
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearPosterior : com/eignex/kumulant/stat/regression/RegressionPosterior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion;
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/core/F64VectorLike;
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorLike;
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public static synthetic fun sampleInto$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DDILjava/lang/Object;)V
 }
@@ -7193,8 +7193,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Compa
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$DefaultImpls {
-	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/core/F64VectorLike;
+	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorLike;
 	public static fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public static synthetic fun sampleInto$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DDILjava/lang/Object;)V
 }
@@ -7205,9 +7205,9 @@ public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRe
 	public abstract fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public abstract fun getStep ()J
 	public abstract fun getTotalWeights ()D
-	public abstract fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
-	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult$Companion {
@@ -7226,8 +7226,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResul
 	public static fun getStdDev (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun getVariance (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun isEmpty (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)Z
-	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;)D
-	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;)D
+	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;)D
+	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;)D
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/Link {
@@ -7277,12 +7277,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Link$Logit : com/eign
 public final class com/eignex/kumulant/stat/regression/glm/MultivariateGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/MultivariateGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7362,12 +7362,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Penalty$None : com/ei
 public final class com/eignex/kumulant/stat/regression/glm/PointPosterior : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/PointPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/core/F64VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7376,16 +7376,16 @@ public final class com/eignex/kumulant/stat/regression/glm/PointPosterior : com/
 
 public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior$Companion;
-	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;I)V
-	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
-	public final fun component2 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public fun <init> (Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;I)V
+	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
+	public final fun component2 ()Lcom/eignex/koblas/DenseMatrix;
 	public final fun component3 ()I
-	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/core/F64DenseVector;Lcom/eignex/koblas/core/F64DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public final fun copy (Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;I)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;Lcom/eignex/koblas/DenseVector;Lcom/eignex/koblas/DenseMatrix;IILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PopulationPrior;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCovariance ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getCovariance ()Lcom/eignex/koblas/DenseMatrix;
 	public final fun getInstanceCount ()I
-	public final fun getMean ()Lcom/eignex/koblas/core/F64DenseVector;
+	public final fun getMean ()Lcom/eignex/koblas/DenseVector;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7407,29 +7407,29 @@ public final class com/eignex/kumulant/stat/regression/glm/PopulationPrior$Compa
 
 public final class com/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
-	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)V
+	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()J
-	public final fun component6 ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun component6 ()Lcom/eignex/koblas/DenseMatrix;
 	public final fun component7 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component8 ()D
-	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDDJLcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
-	public final fun covariance (Lcom/eignex/koblas/Workspace;)Lcom/eignex/koblas/core/F64DenseMatrix;
-	public static synthetic fun covariance$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)Lcom/eignex/koblas/core/F64DenseMatrix;
-	public final fun covarianceInto (Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/Workspace;)Lcom/eignex/koblas/core/F64DenseMatrix;
-	public static synthetic fun covarianceInto$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/core/F64DenseMatrix;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun copy (Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;D)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/DenseVector;DDDJLcom/eignex/koblas/DenseMatrix;Lcom/eignex/kumulant/stat/regression/glm/Link;DILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
+	public final fun covariance (Lcom/eignex/koblas/Workspace;)Lcom/eignex/koblas/DenseMatrix;
+	public static synthetic fun covariance$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)Lcom/eignex/koblas/DenseMatrix;
+	public final fun covarianceInto (Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/Workspace;)Lcom/eignex/koblas/DenseMatrix;
+	public static synthetic fun covarianceInto$default (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/DenseMatrix;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)Lcom/eignex/koblas/DenseMatrix;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public final fun getBiasPrecision ()D
 	public fun getFeatureSize ()I
 	public fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public fun getMse ()D
-	public final fun getPrecisionL ()Lcom/eignex/koblas/core/F64DenseMatrix;
+	public final fun getPrecisionL ()Lcom/eignex/koblas/DenseMatrix;
 	public fun getRSquared ()D
 	public fun getRmse ()D
 	public fun getSampleStdDev ()D
@@ -7441,12 +7441,12 @@ public final class com/eignex/kumulant/stat/regression/glm/PrecisionRegressionRe
 	public fun getStep ()J
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7467,17 +7467,17 @@ public final class com/eignex/kumulant/stat/regression/glm/PrecisionRegressionRe
 
 public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionResult : com/eignex/kumulant/stat/regression/glm/LinearRegressionResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult$Companion;
-	public fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
-	public synthetic fun <init> (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/eignex/koblas/core/F64DenseVector;
+	public fun <init> (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)V
+	public synthetic fun <init> (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/eignex/koblas/DenseVector;
 	public final fun component2 ()D
 	public final fun component3 ()D
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public final fun component6 ()D
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
-	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/core/F64DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public final fun copy (Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
+	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/DenseVector;DDJLcom/eignex/kumulant/stat/regression/glm/Link;DLjava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getBias ()D
 	public fun getFeatureSize ()I
@@ -7495,12 +7495,12 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionR
 	public fun getTotalWeights ()D
 	public final fun getUpdaterState ()Ljava/util/List;
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/core/F64DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/core/F64VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7540,8 +7540,8 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionS
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7579,13 +7579,13 @@ public final class com/eignex/kumulant/stat/regression/glm/UnivariateRegressionR
 	public final fun getSxy ()D
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/core/F64VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/VectorLike;
 	public final fun getX ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public final fun getY ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public fun predict (D)D
-	public fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7687,12 +7687,12 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationAuditL
 }
 
 public abstract class com/eignex/kumulant/stat/regression/tree/ClassificationLeafNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public abstract fun getArm ()Lcom/eignex/kumulant/core/SeriesStat;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric {
@@ -7707,7 +7707,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitM
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
 	public fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getCarryover ()Lcom/eignex/kumulant/core/SeriesStat;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
@@ -7725,20 +7725,20 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTermin
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTree {
 	public fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;I)V
 	public synthetic fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getNodeCount ()I
 	public final fun merge (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;)V
 	public final fun mergeSnapshot (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/koblas/Workspace;)V
 	public static synthetic fun mergeSnapshot$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)I
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
 	public final fun prettyPrint (Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun prettyPrint$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
+	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
 	public final fun reset ()V
 	public final fun rootNode ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun rootSnapshot ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
-	public final fun update (Lcom/eignex/koblas/core/F64VectorLike;ID)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/core/F64VectorLike;IDILjava/lang/Object;)V
+	public final fun update (Lcom/eignex/koblas/VectorLike;ID)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/VectorLike;IDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
@@ -7805,8 +7805,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7827,8 +7827,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/RegressionTree;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7839,7 +7839,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ExprSplit : com/eign
 	public final fun component1 ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public final fun copy (Lcom/eignex/kumulant/schema/expr/BoolExpr;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;Lcom/eignex/kumulant/schema/expr/BoolExpr;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
-	public fun direction (Lcom/eignex/koblas/core/F64VectorLike;)Z
+	public fun direction (Lcom/eignex/koblas/VectorLike;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpr ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -7874,8 +7874,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestClassification
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)I
-	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
+	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7904,11 +7904,11 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestRegressionResu
 	public final fun copy (Ljava/util/List;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Ljava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeafMerged (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeafMerged (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7960,8 +7960,8 @@ public final class com/eignex/kumulant/stat/regression/tree/InformationGain : co
 public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior : com/eignex/kumulant/stat/regression/tree/ForestPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7969,8 +7969,8 @@ public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior 
 public final class com/eignex/kumulant/stat/regression/tree/MeanTreePosterior : com/eignex/kumulant/stat/regression/tree/TreePosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7994,8 +7994,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestClassificationResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -8018,8 +8018,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/core/F64VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -8176,8 +8176,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonForestPoster
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8193,8 +8193,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonTreePosterio
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8208,7 +8208,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ThresholdSplit : com
 	public final fun component2 ()D
 	public final fun copy (ID)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;IDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
-	public fun direction (Lcom/eignex/koblas/core/F64VectorLike;)Z
+	public fun direction (Lcom/eignex/koblas/VectorLike;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatureIndex ()I
@@ -8239,7 +8239,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8262,7 +8262,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 }
 
@@ -8277,13 +8277,13 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationRe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNumClasses ()I
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)I
-	public final fun probabilities (Lcom/eignex/koblas/core/F64VectorLike;)[D
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
+	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8312,7 +8312,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationSp
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8343,7 +8343,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult : com
 	public final fun copy (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8366,7 +8366,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult$Compa
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 }
 
@@ -8384,12 +8384,12 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeRegressionResult
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getRootMean ()D
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/core/F64VectorLike;)D
+	public final fun predict (Lcom/eignex/koblas/VectorLike;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8424,7 +8424,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeSplitResult : co
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/core/F64VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8457,8 +8457,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbForestPosterior :
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8474,8 +8474,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbTreePosterior : c
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/core/F64VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -91,7 +91,7 @@ final enum class com.eignex.kumulant.stat.sketch/AdmissionPolicy : kotlin/Enum<c
 }
 
 abstract fun interface com.eignex.kumulant.bandit.contextual/Exp4Expert { // com.eignex.kumulant.bandit.contextual/Exp4Expert|null[0]
-    abstract fun advise(com.eignex.koblas.core/F64VectorLike, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.core.F64VectorLike;kotlin.Int){}[0]
+    abstract fun advise(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
 }
 
 abstract fun interface com.eignex.kumulant.math/Hasher64 { // com.eignex.kumulant.math/Hasher64|null[0]
@@ -131,8 +131,8 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
         abstract fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/RegressionStat.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.core/RegressionStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
-    open fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    open fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
@@ -155,14 +155,14 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.core/VectorStat : com.eignex.kumulant.core/Stat<#A> { // com.eignex.kumulant.core/VectorStat|null[0]
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<#A> // com.eignex.kumulant.core/VectorStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas/VectorLike, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Long;kotlin.Double){}[0]
 }
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.stat.regression/RegressionPosterior { // com.eignex.kumulant.stat.regression/RegressionPosterior|null[0]
-    abstract fun evaluate(#A, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun evaluate(#A, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface <#A: in kotlin/Any?> com.eignex.kumulant.stat.regression.tree/Split { // com.eignex.kumulant.stat.regression.tree/Split|null[0]
@@ -185,12 +185,12 @@ abstract interface com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.ba
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualBandit : com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.bandit/ContextualBandit|null[0]
-    abstract fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
-    abstract fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    abstract fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualScorable { // com.eignex.kumulant.bandit/ContextualScorable|null[0]
-    abstract fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    abstract fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/Scorable { // com.eignex.kumulant.bandit/Scorable|null[0]
@@ -214,11 +214,11 @@ abstract interface com.eignex.kumulant.core/HasLinearModel : com.eignex.kumulant
     abstract val bias // com.eignex.kumulant.core/HasLinearModel.bias|{}bias[0]
         abstract fun <get-bias>(): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.bias.<get-bias>|<get-bias>(){}[0]
     abstract val weights // com.eignex.kumulant.core/HasLinearModel.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
     open val featureSize // com.eignex.kumulant.core/HasLinearModel.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasLinearModel.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
-    open fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    open fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.VectorLike){}[0]
 }
 
 abstract interface com.eignex.kumulant.core/HasMinMax : com.eignex.kumulant.core/Result { // com.eignex.kumulant.core/HasMinMax|null[0]
@@ -295,7 +295,7 @@ abstract interface com.eignex.kumulant.core/HasSlope : com.eignex.kumulant.core/
     open val featureSize // com.eignex.kumulant.core/HasSlope.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasSlope.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     open val weights // com.eignex.kumulant.core/HasSlope.weights|{}weights[0]
-        open fun <get-weights>(): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
+        open fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
 
     open fun predict(kotlin/Double): kotlin/Double // com.eignex.kumulant.core/HasSlope.predict|predict(kotlin.Double){}[0]
 }
@@ -403,8 +403,8 @@ sealed interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.schem
 }
 
 sealed interface <#A: com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> com.eignex.kumulant.stat.regression.glm/LinearPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<#A> { // com.eignex.kumulant.stat.regression.glm/LinearPosterior|null[0]
-    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
-    open fun evaluate(#A, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
+    open fun evaluate(#A, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun sampleInto(#A, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sampleInto|sampleInto(1:0;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion|null[0]
@@ -626,10 +626,10 @@ sealed interface com.eignex.kumulant.stat.regression.glm/LinearRegressionResult 
     abstract val totalWeights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights|{}totalWeights[0]
         abstract fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     abstract val weights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    open fun linearPredictor(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.core.F64VectorLike){}[0]
-    open fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    open fun linearPredictor(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.VectorLike){}[0]
+    open fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion.serializer|serializer(){}[0]
@@ -749,7 +749,7 @@ sealed interface com.eignex.kumulant.stat.regression.glm/Penalty { // com.eignex
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationNode { // com.eignex.kumulant.stat.regression.tree/ClassificationNode|null[0]
-    abstract fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric { // com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric|null[0]
@@ -763,7 +763,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMet
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ForestPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestPosterior|null[0]
 
-sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas.core/F64VectorLike> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
+sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/VectorLike> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/SerializableSplit> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(){}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -783,7 +783,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeClassificationNode
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion.serializer|serializer(){}[0]
@@ -795,7 +795,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeNodeResult { // co
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion.serializer|serializer(){}[0]
@@ -838,10 +838,10 @@ final class <#A: com.eignex.kumulant.bandit/ContextualBandit> com.eignex.kumulan
     final val random // com.eignex.kumulant.bandit/TrackedContextualBandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit/TrackedContextualBandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun chooseResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.chooseResult|chooseResult(){}[0]
     final fun reset() // com.eignex.kumulant.bandit/TrackedContextualBandit.reset|reset(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun updateArmRewardResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateArmRewardResult|updateArmRewardResult(){}[0]
     final fun updateJointResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateJointResult|updateJointResult(){}[0]
     final fun updateMarginalResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateMarginalResult|updateMarginalResult(){}[0]
@@ -894,16 +894,16 @@ final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.con
 
     final fun armResult(kotlin/Int): #A // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armResult|armResult(kotlin.Int){}[0]
     final fun armStat(kotlin/Int): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armStat|armStat(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/RegressionContextualBandit<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun globalSnapshot(): #A? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalSnapshot|globalSnapshot(){}[0]
     final fun globalStat(): com.eignex.kumulant.core/RegressionStat<#A>? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalStat|globalStat(){}[0]
     final fun merge(kotlin.collections/List<#A>, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.merge|merge(kotlin.collections.List<1:0>;com.eignex.koblas.Workspace?){}[0]
     final fun mergeGlobal(#A, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.mergeGlobal|mergeGlobal(1:0;com.eignex.koblas.Workspace?){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.univariate/MultiArmedBandit : com.eignex.kumulant.bandit/PerArmBandit<#A>, com.eignex.kumulant.bandit/Scorable, com.eignex.kumulant.bandit/UnivariateBandit { // com.eignex.kumulant.bandit.univariate/MultiArmedBandit|null[0]
@@ -1197,15 +1197,15 @@ final class com.eignex.kumulant.bandit.contextual/Exp4Bandit : com.eignex.kumula
     final val random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/Exp4Bandit // com.eignex.kumulant.bandit.contextual/Exp4Bandit.create|create(kotlin.random.Random){}[0]
     final fun expertWeights(): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.expertWeights|expertWeights(){}[0]
     final fun merge(com.eignex.kumulant.bandit.contextual/Exp4State, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.merge|merge(com.eignex.kumulant.bandit.contextual.Exp4State;com.eignex.koblas.Workspace?){}[0]
-    final fun playDistribution(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.core.F64VectorLike){}[0]
-    final fun playDistributionInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistributionInto|playDistributionInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
+    final fun playDistribution(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.VectorLike){}[0]
+    final fun playDistributionInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistributionInto|playDistributionInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/Exp4Bandit.reset|reset(){}[0]
     final fun snapshot(): com.eignex.kumulant.bandit.contextual/Exp4State // com.eignex.kumulant.bandit.contextual/Exp4Bandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion|null[0]
         final fun defaultEta(kotlin/Int, kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion.defaultEta|defaultEta(kotlin.Int;kotlin.Int){}[0]
@@ -1277,12 +1277,12 @@ final class com.eignex.kumulant.bandit.contextual/KnnArmResult : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eignex.kumulant.bandit/ContextualBandit, com.eignex.kumulant.bandit/ContextualScorable, com.eignex.kumulant.bandit/PerArmBandit<com.eignex.kumulant.bandit.contextual/KnnArmResult> { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas.core/F64VectorLike, com.eignex.koblas.core/F64VectorLike, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.core.F64VectorLike,com.eignex.koblas.core.F64VectorLike,kotlin.Double>;kotlin.random.Random){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.VectorLike,com.eignex.koblas.VectorLike,kotlin.Double>;kotlin.random.Random){}[0]
 
     final val coldStartScore // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore|{}coldStartScore[0]
         final fun <get-coldStartScore>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore.<get-coldStartScore>|<get-coldStartScore>(){}[0]
     final val distance // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance|{}distance[0]
-        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas.core/F64VectorLike, com.eignex.koblas.core/F64VectorLike, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
+        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
     final val exploration // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration|{}exploration[0]
         final fun <get-exploration>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration.<get-exploration>|<get-exploration>(){}[0]
     final val k // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.k|{}k[0]
@@ -1295,17 +1295,17 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.random.<get-random>|<get-random>(){}[0]
 
     final fun armWeight(kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.armWeight|armWeight(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
     final fun historySize(kotlin/Int): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.historySize|historySize(kotlin.Int){}[0]
     final fun merge(kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult>, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.merge|merge(kotlin.collections.List<com.eignex.kumulant.bandit.contextual.KnnArmResult>;com.eignex.koblas.Workspace?){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion|null[0]
-        final fun squaredL2(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.core.F64VectorLike){}[0]
+        final fun squaredL2(com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.VectorLike;com.eignex.koblas.VectorLike){}[0]
     }
 }
 
@@ -2865,7 +2865,7 @@ final class com.eignex.kumulant.schema.runtime/RegressionStatGroup : com.eignex.
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.schema.runtime/RegressionStatGroup.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/RegressionStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.schema.runtime/StatGroup : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.schema/GroupResult>, com.eignex.kumulant.schema.runtime/AbstractStatGroup<com.eignex.kumulant.core/SeriesStat<*>> { // com.eignex.kumulant.schema.runtime/StatGroup|null[0]
@@ -2913,7 +2913,7 @@ final class com.eignex.kumulant.schema.runtime/VectorStatGroup : com.eignex.kumu
     constructor <init>(kotlin/Array<out kotlin/Pair<com.eignex.kumulant.schema/StatKey<*>, com.eignex.kumulant.core/VectorStat<*>>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/VectorStatGroup.<init>|<init>(kotlin.Array<out|kotlin.Pair<com.eignex.kumulant.schema.StatKey<*>,com.eignex.kumulant.core.VectorStat<*>>>...;com.eignex.kumulant.core.Concurrency?){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/VectorStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
@@ -4670,7 +4670,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult : com.eignex.k
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/IntArray = ..., kotlin/DoubleArray = ..., kotlin/DoubleArray = ...): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.IntArray;kotlin.DoubleArray;kotlin.DoubleArray){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.hashCode|hashCode(){}[0]
-    final fun score(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun score(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.VectorLike){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult> { // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.$serializer|null[0]
@@ -4709,7 +4709,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat : com.eignex.kum
     final fun merge(com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.merge|merge(com.eignex.kumulant.stat.anomaly.HalfSpaceTreesResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.anomaly/QuantileFilterResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.anomaly/QuantileFilterResult|null[0]
@@ -6330,7 +6330,7 @@ final class com.eignex.kumulant.stat.rate/RateStat : com.eignex.kumulant.core/Se
 }
 
 final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult> { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat|null[0]
-    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas.core/F64VectorLike? = ..., com.eignex.koblas.core/F64MatrixLike? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.core.F64VectorLike?;com.eignex.koblas.core.F64MatrixLike?){}[0]
+    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/VectorLike? = ..., com.eignex.koblas/MatrixLike? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.VectorLike?;com.eignex.koblas.MatrixLike?){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
@@ -6345,7 +6345,7 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion|null[0]
         final fun fitPopulationPrior(kotlin.collections/List<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlin/Function1<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin/Double> = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion.fitPopulationPrior|fitPopulationPrior(kotlin.collections.List<com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult>;kotlin.Function1<com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult,kotlin.Double>){}[0]
@@ -6353,7 +6353,7 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
 }
 
 final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas.core/F64DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/DenseVector, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6362,7 +6362,7 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val precision // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision|{}precision[0]
-        final fun <get-precision>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
+        final fun <get-precision>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.precision.<get-precision>|<get-precision>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse|{}sse[0]
         final fun <get-sse>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.sse.<get-sse>|<get-sse>(){}[0]
     final val step // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.step|{}step[0]
@@ -6370,17 +6370,17 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult : c
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
+    final fun component6(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component6|component6(){}[0]
     final fun component7(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component7|component7(){}[0]
     final fun component8(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.component8|component8(){}[0]
-    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas.core/F64DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/DenseVector = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseVector;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult.toString|toString(){}[0]
@@ -6421,11 +6421,11 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression { // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression|null[0]
-    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas.core/F64DenseVector? = ..., com.eignex.koblas.core/F64DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.core.F64DenseVector?;com.eignex.koblas.core.F64DenseMatrix?){}[0]
+    constructor <init>(kotlin/Int, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., com.eignex.kumulant.core/Concurrency = ..., kotlin/Double = ..., com.eignex.koblas/DenseVector? = ..., com.eignex.koblas/DenseMatrix? = ...) // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.<init>|<init>(kotlin.Int;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;com.eignex.kumulant.core.Concurrency;kotlin.Double;com.eignex.koblas.DenseVector?;com.eignex.koblas.DenseMatrix?){}[0]
 
     final val biasPriorVariance // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance|{}biasPriorVariance[0]
         final fun <get-biasPriorVariance>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression.biasPriorVariance.<get-biasPriorVariance>|<get-biasPriorVariance>(){}[0]
@@ -6447,19 +6447,19 @@ final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegressi
 }
 
 final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eignex.kumulant.stat.regression.glm/PopulationPrior|null[0]
-    constructor <init>(com.eignex.koblas.core/F64DenseVector, com.eignex.koblas.core/F64DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.core.F64DenseVector;com.eignex.koblas.core.F64DenseMatrix;kotlin.Int){}[0]
+    constructor <init>(com.eignex.koblas/DenseVector, com.eignex.koblas/DenseMatrix, kotlin/Int) // com.eignex.kumulant.stat.regression.glm/PopulationPrior.<init>|<init>(com.eignex.koblas.DenseVector;com.eignex.koblas.DenseMatrix;kotlin.Int){}[0]
 
     final val covariance // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance|{}covariance[0]
-        final fun <get-covariance>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
+        final fun <get-covariance>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.covariance.<get-covariance>|<get-covariance>(){}[0]
     final val instanceCount // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount|{}instanceCount[0]
         final fun <get-instanceCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.instanceCount.<get-instanceCount>|<get-instanceCount>(){}[0]
     final val mean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean|{}mean[0]
-        final fun <get-mean>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
+        final fun <get-mean>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.mean.<get-mean>|<get-mean>(){}[0]
 
-    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
-    final fun component2(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
+    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component1|component1(){}[0]
+    final fun component2(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component2|component2(){}[0]
     final fun component3(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.component3|component3(){}[0]
-    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., com.eignex.koblas.core/F64DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.core.F64DenseVector;com.eignex.koblas.core.F64DenseMatrix;kotlin.Int){}[0]
+    final fun copy(com.eignex.koblas/DenseVector = ..., com.eignex.koblas/DenseMatrix = ..., kotlin/Int = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/PopulationPrior.copy|copy(com.eignex.koblas.DenseVector;com.eignex.koblas.DenseMatrix;kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PopulationPrior.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PopulationPrior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PopulationPrior.toString|toString(){}[0]
@@ -6479,7 +6479,7 @@ final class com.eignex.kumulant.stat.regression.glm/PopulationPrior { // com.eig
 }
 
 final class com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas.core/F64DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.koblas/DenseMatrix, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6488,7 +6488,7 @@ final class com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult : 
     final val link // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.link|{}link[0]
         final fun <get-link>(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.link.<get-link>|<get-link>(){}[0]
     final val precisionL // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.precisionL|{}precisionL[0]
-        final fun <get-precisionL>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.precisionL.<get-precisionL>|<get-precisionL>(){}[0]
+        final fun <get-precisionL>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.precisionL.<get-precisionL>|<get-precisionL>(){}[0]
     final val sse // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.sse|{}sse[0]
         final fun <get-sse>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.sse.<get-sse>|<get-sse>(){}[0]
     final val step // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.step|{}step[0]
@@ -6496,19 +6496,19 @@ final class com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult : 
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component5|component5(){}[0]
-    final fun component6(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component6|component6(){}[0]
+    final fun component6(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component6|component6(){}[0]
     final fun component7(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component7|component7(){}[0]
     final fun component8(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.component8|component8(){}[0]
-    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.core.F64DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
-    final fun covariance(com.eignex.koblas/Workspace? = ...): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.covariance|covariance(com.eignex.koblas.Workspace?){}[0]
-    final fun covarianceInto(com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas/Workspace? = ...): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.covarianceInto|covarianceInto(com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.Workspace?){}[0]
+    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.koblas.DenseMatrix;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double){}[0]
+    final fun covariance(com.eignex.koblas/Workspace? = ...): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.covariance|covariance(com.eignex.koblas.Workspace?){}[0]
+    final fun covarianceInto(com.eignex.koblas/DenseMatrix, com.eignex.koblas/Workspace? = ...): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.covarianceInto|covarianceInto(com.eignex.koblas.DenseMatrix;com.eignex.koblas.Workspace?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult.toString|toString(){}[0]
@@ -6530,7 +6530,7 @@ final class com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult : 
 }
 
 final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas.core/F64VectorLike> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.core.F64VectorLike>){}[0]
+    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorLike> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorLike>){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6543,18 +6543,18 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val updaterState // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState|{}updaterState[0]
-        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas.core/F64VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
+        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    final fun component1(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
+    final fun component1(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component2|component2(){}[0]
     final fun component3(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component3|component3(){}[0]
     final fun component4(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component4|component4(){}[0]
     final fun component5(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<com.eignex.koblas.core/F64VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
-    final fun copy(com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas.core/F64VectorLike> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.core.F64VectorLike>){}[0]
+    final fun component7(): kotlin.collections/List<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
+    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorLike> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorLike>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.toString|toString(){}[0]
@@ -6603,7 +6603,7 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat : c
     final fun merge(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult : com.eignex.kumulant.core/HasRegression, com.eignex.kumulant.core/HasSlope, com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult|null[0]
@@ -6765,7 +6765,7 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode : c
         final fun <get-pos>(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<get-pos>|<get-pos>(){}[0]
         final fun <set-pos>(com.eignex.kumulant.stat.regression.tree/ClassificationNode) // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<set-pos>|<set-pos>(com.eignex.kumulant.stat.regression.tree.ClassificationNode){}[0]
 
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf : com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode { // com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf|null[0]
@@ -6781,16 +6781,16 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationTree { // com
     final val nodeCount // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount|{}nodeCount[0]
         final fun <get-nodeCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount.<get-nodeCount>|<get-nodeCount>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun merge(com.eignex.kumulant.stat.regression.tree/ClassificationTree) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.merge|merge(com.eignex.kumulant.stat.regression.tree.ClassificationTree){}[0]
     final fun mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.mergeSnapshot|mergeSnapshot(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.koblas.Workspace?){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.VectorLike){}[0]
     final fun prettyPrint(kotlin/String = ...): kotlin/String // com.eignex.kumulant.stat.regression.tree/ClassificationTree.prettyPrint|prettyPrint(kotlin.String){}[0]
-    final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/ClassificationTree.reset|reset(){}[0]
     final fun rootNode(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootNode|rootNode(){}[0]
     final fun rootSnapshot(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootSnapshot|rootSnapshot(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Int;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.VectorLike;kotlin.Int;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
@@ -6867,7 +6867,7 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.reset|reset(){}[0]
     final fun tree(): com.eignex.kumulant.stat.regression.tree/ClassificationTree // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat|null[0]
@@ -6886,8 +6886,8 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.reset|reset(){}[0]
-    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorLike> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumulant.stat.regression.tree/SerializableSplit { // com.eignex.kumulant.stat.regression.tree/ExprSplit|null[0]
@@ -6898,7 +6898,7 @@ final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumu
 
     final fun component1(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.stat.regression.tree/ExprSplit.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.schema.expr/BoolExpr = ...): com.eignex.kumulant.stat.regression.tree/ExprSplit // com.eignex.kumulant.stat.regression.tree/ExprSplit.copy|copy(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-    final fun direction(com.eignex.koblas.core/F64VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun direction(com.eignex.koblas/VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.VectorLike){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ExprSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ExprSplit.toString|toString(){}[0]
@@ -6934,8 +6934,8 @@ final class com.eignex.kumulant.stat.regression.tree/ForestClassificationResult 
     final fun copy(kotlin/Int = ..., kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.copy|copy(kotlin.Int;kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeClassificationResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
-    final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestClassificationResult> { // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.$serializer|null[0]
@@ -6965,9 +6965,9 @@ final class com.eignex.kumulant.stat.regression.tree/ForestRegressionResult : co
     final fun component1(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.component1|component1(){}[0]
     final fun copy(kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.copy|copy(kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeRegressionResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeafMerged(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeafMerged(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.$serializer|null[0]
@@ -7009,7 +7009,7 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.reset|reset(){}[0]
     final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/ClassificationTree> // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat|null[0]
@@ -7032,8 +7032,8 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.reset|reset(){}[0]
-    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorLike>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
@@ -7122,7 +7122,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior : c
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.toString|toString(){}[0]
 }
@@ -7139,7 +7139,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior : com
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.toString|toString(){}[0]
 }
@@ -7155,7 +7155,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThresholdSplit : com.eignex
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component2|component2(){}[0]
     final fun copy(kotlin/Int = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThresholdSplit // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.copy|copy(kotlin.Int;kotlin.Double){}[0]
-    final fun direction(com.eignex.koblas.core/F64VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun direction(com.eignex.koblas/VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.VectorLike){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.toString|toString(){}[0]
@@ -7183,7 +7183,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResul
     final fun component1(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.copy|copy(com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.toString|toString(){}[0]
 
@@ -7214,10 +7214,10 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationResult : 
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
-    final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> { // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.$serializer|null[0]
@@ -7254,7 +7254,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResu
     final fun component4(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.toString|toString(){}[0]
 
@@ -7283,7 +7283,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeLeafResult : com.eignex
     final fun component1(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeLeafResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.copy|copy(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.toString|toString(){}[0]
 
@@ -7314,9 +7314,9 @@ final class com.eignex.kumulant.stat.regression.tree/TreeRegressionResult : com.
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.$serializer|null[0]
@@ -7353,7 +7353,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeSplitResult : com.eigne
     final fun component4(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeSplitResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.toString|toString(){}[0]
 
@@ -7385,7 +7385,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbForestPosterior : com.ei
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbForestPosterior // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.toString|toString(){}[0]
 }
@@ -7402,7 +7402,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbTreePosterior : com.eign
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbTreePosterior // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.toString|toString(){}[0]
 }
@@ -7505,14 +7505,14 @@ final class com.eignex.kumulant.stat.regression/CovarianceStat : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double){}[0]
 
     final val classWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights|{}classWeights[0]
-        final fun <get-classWeights>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
+        final fun <get-classWeights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.classWeights.<get-classWeights>|<get-classWeights>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize|{}featureSize[0]
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     final val means // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means|{}means[0]
-        final fun <get-means>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
+        final fun <get-means>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.means.<get-means>|<get-means>(){}[0]
     final val numClasses // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses|{}numClasses[0]
         final fun <get-numClasses>(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.numClasses.<get-numClasses>|<get-numClasses>(){}[0]
     final val totalWeights // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.totalWeights|{}totalWeights[0]
@@ -7520,24 +7520,24 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.e
     final val varianceFloor // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor|{}varianceFloor[0]
         final fun <get-varianceFloor>(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.varianceFloor.<get-varianceFloor>|<get-varianceFloor>(){}[0]
     final val variances // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances|{}variances[0]
-        final fun <get-variances>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
+        final fun <get-variances>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.variances.<get-variances>|<get-variances>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
-    final fun component5(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
+    final fun component3(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component4|component4(){}[0]
+    final fun component5(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.hashCode|hashCode(){}[0]
-    final fun logPosterior(com.eignex.koblas.core/F64VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.core.F64VectorLike;kotlin.Int){}[0]
-    final fun logPosteriorsInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosteriorsInto|logPosteriorsInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun logPosterior(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
+    final fun logPosteriorsInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosteriorsInto|logPosteriorsInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
+    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
     final fun prior(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.prior|prior(kotlin.Int){}[0]
-    final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
-    final fun probabilitiesInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
+    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
+    final fun probabilitiesInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult> { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.$serializer|null[0]
@@ -7566,7 +7566,7 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat : com.eig
     final fun merge(com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.merge|merge(com.eignex.kumulant.stat.regression.GaussianNaiveBayesResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression/RmspropOptimizer : com.eignex.kumulant.stat.regression/Optimizer { // com.eignex.kumulant.stat.regression/RmspropOptimizer|null[0]
@@ -7602,10 +7602,10 @@ final class com.eignex.kumulant.stat.regression/SgdOptimizer : com.eignex.kumula
 }
 
 final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas.core/F64DenseMatrix, com.eignex.koblas.core/F64DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.eignex.koblas/DenseMatrix, com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.<init>|<init>(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
 
     final val biases // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases|{}biases[0]
-        final fun <get-biases>(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
+        final fun <get-biases>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.biases.<get-biases>|<get-biases>(){}[0]
     final val crossEntropy // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy|{}crossEntropy[0]
         final fun <get-crossEntropy>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.crossEntropy.<get-crossEntropy>|<get-crossEntropy>(){}[0]
     final val featureSize // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.featureSize|{}featureSize[0]
@@ -7617,23 +7617,23 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.ei
     final val totalWeights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights|{}weights[0]
-        final fun <get-weights>(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        final fun <get-weights>(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component1|component1(){}[0]
     final fun component2(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component2|component2(){}[0]
-    final fun component3(): com.eignex.koblas.core/F64DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
-    final fun component4(): com.eignex.koblas.core/F64DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
+    final fun component3(): com.eignex.koblas/DenseMatrix // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component3|component3(){}[0]
+    final fun component4(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component4|component4(){}[0]
     final fun component5(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Long // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component6|component6(){}[0]
     final fun component7(): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.component7|component7(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas.core/F64DenseMatrix = ..., com.eignex.koblas.core/F64DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.core.F64DenseMatrix;com.eignex.koblas.core.F64DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.hashCode|hashCode(){}[0]
-    final fun logit(com.eignex.koblas.core/F64VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.core.F64VectorLike;kotlin.Int){}[0]
-    final fun logitsInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logitsInto|logitsInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
-    final fun predict(com.eignex.koblas.core/F64VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.core.F64VectorLike;com.eignex.koblas.Workspace?){}[0]
-    final fun probabilities(com.eignex.koblas.core/F64VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.core.F64VectorLike){}[0]
-    final fun probabilitiesInto(com.eignex.koblas.core/F64VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.core.F64VectorLike;kotlin.DoubleArray){}[0]
+    final fun logit(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
+    final fun logitsInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logitsInto|logitsInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
+    final fun predict(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
+    final fun probabilitiesInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/SoftmaxRegressionResult> { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.$serializer|null[0]
@@ -7674,7 +7674,7 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionStat : com.eign
     final fun merge(com.eignex.kumulant.stat.regression/SoftmaxRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.SoftmaxRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas.core/F64VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.core.F64VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.score/AccuracyStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.stat.score/AccuracyStat|null[0]
@@ -8855,7 +8855,7 @@ sealed class com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode : c
     abstract val arm // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm|{}arm[0]
         abstract fun <get-arm>(): com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.regression.tree/ClassCountsResult> // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm.<get-arm>|<get-arm>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas.core/F64VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.core.F64VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
 }
 
 final object com.eignex.kumulant.bandit.univariate/BetaPosterior : com.eignex.kumulant.bandit.univariate/Posterior<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.univariate/BetaPosterior|null[0]
@@ -9187,9 +9187,9 @@ final object com.eignex.kumulant.schema.spec/Variance : com.eignex.kumulant.sche
 
 final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/FactorisedGaussian> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9198,9 +9198,9 @@ final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.ei
 
 final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinUcb|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/LinUcb.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/LinUcb.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/LinUcb.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinUcb> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9209,9 +9209,9 @@ final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulan
 
 final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/MultivariateGaussian> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9220,9 +9220,9 @@ final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.
 
 final object com.eignex.kumulant.stat.regression.glm/PointPosterior : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/PointPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PointPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PointPosterior.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas.core/F64VectorLike // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/PointPosterior.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/PointPosterior> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9249,14 +9249,14 @@ final object com.eignex.kumulant.stat.regression.tree/InformationGain : com.eign
 
 final object com.eignex.kumulant.stat.regression.tree/MeanForestPosterior : com.eignex.kumulant.stat.regression.tree/ForestPosterior { // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.toString|toString(){}[0]
 }
 
 final object com.eignex.kumulant.stat.regression.tree/MeanTreePosterior : com.eignex.kumulant.stat.regression.tree/TreePosterior { // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas.core/F64VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.core.F64VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.toString|toString(){}[0]
 }
@@ -9288,7 +9288,7 @@ final fun (com.eignex.kumulant.bandit.univariate/RouletteWheelSpec).com.eignex.k
 final fun (com.eignex.kumulant.bandit.univariate/UnivariateBanditSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ...): com.eignex.kumulant.bandit/Bandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.univariate.UnivariateBanditSpec(kotlin.random.Random){}[0]
 final fun (com.eignex.kumulant.core/Concurrency).com.eignex.kumulant.stream/lock(): com.eignex.kumulant.stream/Mutex // com.eignex.kumulant.stream/lock|lock@com.eignex.kumulant.core.Concurrency(){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/and(com.eignex.kumulant.schema.expr/BoolExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/and|and@com.eignex.kumulant.schema.expr.BoolExpr(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas.core/F64VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Boolean // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.BoolExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.core.F64VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Boolean // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.BoolExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/not(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/not|not@com.eignex.kumulant.schema.expr.BoolExpr(){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/or(com.eignex.kumulant.schema.expr/BoolExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/or|or@com.eignex.kumulant.schema.expr.BoolExpr(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/abs(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/abs|abs@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
@@ -9296,7 +9296,7 @@ final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schem
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/div(kotlin/Double): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/div|div@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eq(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/eq|eq@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eq(kotlin/Double): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/eq|eq@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
-final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas.core/F64VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Double // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.core.F64VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Double // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/exp(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/exp|exp@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/ge(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/ge|ge@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/ge(kotlin/Double): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/ge|ge@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
@@ -9324,7 +9324,7 @@ final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schem
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/times(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/times|times@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/times(kotlin/Double): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/times|times@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/unaryMinus(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/unaryMinus|unaryMinus@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
-final fun (com.eignex.kumulant.schema.expr/VectorExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas.core/F64VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/DoubleArray // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.VectorExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.core.F64VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/VectorExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/DoubleArray // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.VectorExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materialize(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, *, *>> // com.eignex.kumulant.schema.runtime/materialize|materialize@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeDiscrete(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/DiscreteStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeDiscrete|materializeDiscrete@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializePaired(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/PairedStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializePaired|materializePaired@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
@@ -9340,8 +9340,8 @@ final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.k
 final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.kumulant.stat.score/pitKsDistance(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.score/pitKsDistance|pitKsDistance@com.eignex.kumulant.stat.quantile.SparseHistogramResult(kotlin.Int){}[0]
 final fun (com.eignex.kumulant.stat.quantile/TDigestResult).com.eignex.kumulant.stat.quantile/toSparseHistogram(): com.eignex.kumulant.stat.quantile/SparseHistogramResult // com.eignex.kumulant.stat.quantile/toSparseHistogram|toSparseHistogram@com.eignex.kumulant.stat.quantile.TDigestResult(){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<*>).com.eignex.kumulant.stat.regression.tree/aggregate(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/aggregate|aggregate@com.eignex.kumulant.stat.regression.tree.RegressionNode<*>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas.core/F64VectorLike>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.core.F64VectorLike>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas.core/F64VectorLike>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.core.F64VectorLike>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.koblas.Workspace?){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/VectorLike>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.VectorLike>(){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.VectorLike>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.koblas.Workspace?){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/SplitMetric).com.eignex.kumulant.stat.regression.tree/rank(com.eignex.kumulant.stat.summary/WeightedVarianceResult, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin/Double, kotlin/Double): com.eignex.kumulant.stat.regression.tree/SplitInfo // com.eignex.kumulant.stat.regression.tree/rank|rank@com.eignex.kumulant.stat.regression.tree.SplitMetric(com.eignex.kumulant.stat.summary.WeightedVarianceResult;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.Double;kotlin.Double){}[0]
 final fun (com.eignex.kumulant.stat.sketch/BloomFilterResult).com.eignex.kumulant.stat.sketch/contains(kotlin/Long): kotlin/Boolean // com.eignex.kumulant.stat.sketch/contains|contains@com.eignex.kumulant.stat.sketch.BloomFilterResult(kotlin.Long){}[0]
 final fun (com.eignex.kumulant.stat.sketch/CountMinSketchResult).com.eignex.kumulant.stat.sketch/estimate(kotlin/Long): kotlin/Long // com.eignex.kumulant.stat.sketch/estimate|estimate@com.eignex.kumulant.stat.sketch.CountMinSketchResult(kotlin.Long){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -2,9 +2,9 @@
 
 package com.eignex.kumulant.math
 
+import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.dense.Kernels
 import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.koblas
@@ -13,12 +13,9 @@ import kotlin.math.hypot
 import kotlin.math.min
 import kotlin.math.sqrt
 
-// Adapted from Eignex/koblas ReferenceCholesky.kt and ReferenceLevel3.kt at cfdef98439f7baff0febc7a0892f16734bf55315.
-// Apache-2.0; module-internal API and a Cholesky-only specialization of the blocked product.
+// Adapted from Eignex/koblas ReferenceCholesky.kt at cfdef98439f7baff0febc7a0892f16734bf55315.
+// Apache-2.0; module-internal API.
 private const val CHOLESKY_BLOCK = 64
-private const val PRODUCT_ROWS = 256
-private const val PRODUCT_COLUMNS = 8
-private const val PRODUCT_DEPTH = 128
 
 internal sealed interface CholeskyPolicy {
     data object Strict : CholeskyPolicy
@@ -108,12 +105,15 @@ internal fun DenseMatrix.choleskyInvertInto(out: DenseMatrix, workspace: Workspa
     return out
 }
 
-internal fun DenseMatrix.cholesky(policy: CholeskyPolicy = CholeskyPolicy.Strict): DenseMatrix =
-    choleskyInto(DenseMatrix.zero(rows, cols), policy)
+internal fun DenseMatrix.cholesky(
+    policy: CholeskyPolicy = CholeskyPolicy.Strict,
+    workspace: Workspace? = null,
+): DenseMatrix = choleskyInto(DenseMatrix.zero(rows, cols), policy, workspace)
 
 internal fun DenseMatrix.choleskyInto(
     out: DenseMatrix,
     policy: CholeskyPolicy = CholeskyPolicy.Strict,
+    workspace: Workspace? = null,
 ): DenseMatrix {
     require(rows == cols) { "cholesky requires a square matrix" }
     require(out.rows == rows && out.cols == rows) { "cholesky destination must be ${rows}x$rows" }
@@ -126,68 +126,43 @@ internal fun DenseMatrix.choleskyInto(
         ld.fill(0.0, j * n, j * n + j)
         if (data !== ld) data.copyInto(ld, j + j * n, j + j * n, (j + 1) * n)
     }
-    // Left-looking blocked Cholesky. Each block column first takes what every earlier block owes it as one
-    // level-3 product, then finishes column by column against the few columns inside the block. Gathering
-    // one column at a time instead is a level-1 axpy per (column, earlier column) pair, which streams
-    // n^3/6 doubles for n^3/3 flops and leaves the factorization bandwidth-bound.
-    // One pack buffer for the whole factorization rather than one per block column. The seam takes no
-    // workspace, and a matrix that fits in a single block never gathers at all.
-    val packed = if (n > CHOLESKY_BLOCK) DoubleArray(CHOLESKY_BLOCK * n) else null
-    var blockStart = 0
-    while (blockStart < n) {
-        val width = min(CHOLESKY_BLOCK, n - blockStart)
-        val height = n - blockStart
-        if (blockStart > 0) {
-            gatherEarlierBlocks(kernels, ld, n, blockStart, width, height, packed!!)
+    if (n <= CHOLESKY_BLOCK || !kernels.supportsCholeskyPanels()) {
+        factorBlockColumn(kernels, ld, n, 0, n, policy)
+        return out
+    }
+    val minimumPivot = (policy as? CholeskyPolicy.Regularize)?.minimumPivot ?: 0.0
+    val block = min(CHOLESKY_BLOCK, n / 4)
+    var start = 0
+    while (start < n) {
+        val width = min(block, n - start)
+        if (!tryCholeskyBlock(kernels, out, start, width, minimumPivot, workspace)) {
+            // Regularization needs the entire corrected column to bound its multipliers.
+            factorBlockColumn(kernels, ld, n, start, width, policy)
+            if (columnsAreFinite(ld, n, start, width)) {
+                updateCholeskyTrailing(kernels, out, start, width, workspace)
+            } else {
+                // A zero multiplier must skip infinite column entries instead of forming 0 * infinity.
+                subtractTrailingColumns(kernels, ld, n, start, width)
+            }
         }
-        factorBlockColumn(kernels, ld, n, blockStart, width, policy)
-        blockStart += width
+        start += width
     }
     return out
 }
 
-@Suppress("LongParameterList") // the factor, its shape, the block being gathered into, and scratch
-private fun gatherEarlierBlocks(
-    kernels: Kernels,
-    ld: DoubleArray,
-    n: Int,
-    start: Int,
-    width: Int,
-    height: Int,
-    packed: DoubleArray,
-) {
-    for (t in 0 until width) {
-        for (p in 0 until start) packed[p + t * start] = ld[start + t + p * n]
+private fun columnsAreFinite(data: DoubleArray, n: Int, start: Int, width: Int): Boolean {
+    for (j in start until start + width) {
+        for (i in j until n) if (!data[i + j * n].isFinite()) return false
     }
-    var column = 0
-    while (column < width) {
-        val columnEnd = min(column + PRODUCT_COLUMNS, width)
-        var inner = 0
-        while (inner < start) {
-            val innerEnd = min(inner + PRODUCT_DEPTH, start)
-            var row = 0
-            while (row < height) {
-                val length = min(row + PRODUCT_ROWS, height) - row
-                for (p in inner until innerEnd) {
-                    val source = start + row + p * n
-                    for (j in column until columnEnd) {
-                        val value = packed[p + j * start]
-                        if (value != 0.0) {
-                            kernels.axpy(ld, start + start * n + row + j * n, -value, ld, source, length)
-                        }
-                    }
-                }
-                row += length
-            }
-            inner = innerEnd
+    return true
+}
+
+private fun subtractTrailingColumns(kernels: Kernels, data: DoubleArray, n: Int, start: Int, width: Int) {
+    for (p in start until start + width) {
+        for (j in start + width until n) {
+            val value = data[j + p * n]
+            if (value != 0.0) kernels.axpy(data, j + j * n, -value, data, j + p * n, n - j)
         }
-        column = columnEnd
-    }
-    // The product covers the whole diagonal block, including the strict upper half of it that the column
-    // sweep neither writes nor reads. Left there it would surface as a nonzero above the factor's diagonal.
-    for (t in 1 until width) {
-        val column = start + t
-        ld.fill(0.0, start + column * n, column + column * n)
     }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CholeskyBlocks.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CholeskyBlocks.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2009, 2010 The University of Texas at Austin.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT
+ * AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,
+ * INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF
+ * MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE
+ * DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT
+ * AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE
+ * GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF
+ * LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT
+ * OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of The University of Texas at Austin.
+ */
+
+@file:OptIn(com.eignex.koblas.ExperimentalKoblasApi::class)
+
+package com.eignex.kumulant.math
+
+import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.StridedVectorView
+import com.eignex.koblas.Workspace
+import com.eignex.koblas.borrow
+import com.eignex.koblas.dense.Kernels
+import com.eignex.koblas.dense.PackedPanels
+import com.eignex.koblas.koblas
+import com.eignex.koblas.view
+import kotlin.math.min
+import kotlin.math.sqrt
+
+private const val CHOLESKY_LEAF = 16
+
+// Adapted from OpenBLAS potrf_L_single.c and potf2_L.c
+// at 632ef874379c16ca8646d9fa0f6c60449e47d960. Packing and compute leaves belong to koblas.
+internal fun Kernels.supportsCholeskyPanels(): Boolean =
+    gemmTileRows == PackedPanels.tileRows && gemmTileCols == PackedPanels.tileColumns
+
+// Staging preserves the input block for full-column regularization if a trial pivot needs repair.
+internal fun tryCholeskyBlock(
+    kernels: Kernels,
+    matrix: DenseMatrix,
+    start: Int,
+    width: Int,
+    minimumPivot: Double,
+    workspace: Workspace?,
+): Boolean = workspace.borrow(width * width) { data ->
+    val n = matrix.rows
+    for (j in 0 until width) {
+        val source = start + (start + j) * n
+        matrix.data.copyInto(data, j * width, source, source + width)
+    }
+    val diagonal = DenseMatrix.wrap(width, width, data)
+    if (!tryCholeskyDiagonal(kernels, diagonal, minimumPivot, workspace)) return@borrow false
+    val end = start + width
+    val height = n - end
+    workspace.borrow(PackedPanels.leftSize(height, width)) { panel ->
+        if (height > 0) {
+            PackedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
+            solveCholeskyPanel(kernels, diagonal, panel, height, workspace)
+            if (!panel.all { it.isFinite() }) return@borrow false
+        }
+        for (j in 0 until width) data.copyInto(matrix.data, start + (start + j) * n, j * width, (j + 1) * width)
+        if (height > 0) {
+            PackedPanels.writeLeft(panel, matrix, height, width, destinationRow = end, destinationColumn = start)
+            subtractCholeskyPanel(kernels, matrix, end, width, panel, workspace)
+        }
+        true
+    }
+}
+
+private fun tryCholeskyDiagonal(
+    kernels: Kernels,
+    matrix: DenseMatrix,
+    minimumPivot: Double,
+    workspace: Workspace?,
+): Boolean {
+    val n = matrix.rows
+    if (n <= CHOLESKY_LEAF) return tryCholeskyLeaf(kernels, matrix, minimumPivot, workspace)
+    val block = n / 4
+    var start = 0
+    while (start < n) {
+        val width = min(block, n - start)
+        if (!tryCholeskyBlock(kernels, matrix, start, width, minimumPivot, workspace)) return false
+        start += width
+    }
+    return true
+}
+
+private fun solveCholeskyPanel(
+    kernels: Kernels,
+    diagonal: DenseMatrix,
+    panel: DoubleArray,
+    height: Int,
+    workspace: Workspace?,
+) {
+    val width = diagonal.rows
+    val rows = kernels.gemmTileRows
+    val columns = kernels.gemmTileCols
+    workspace.borrow(PackedPanels.rightSize(width, width)) { triangle ->
+        PackedPanels.packTriangularRight(diagonal, triangle, width, width, lower = true, transpose = true)
+        var column = 0
+        while (column < width) {
+            val order = min(columns, width - column)
+            val trianglePanel = column * width
+            var row = 0
+            while (row < height) {
+                val validRows = min(rows, height - row)
+                val rowPanel = row * width
+                kernels.gemmTrsmTile(
+                    column, validRows, order, panel, rowPanel, triangle, trianglePanel,
+                    triangle, trianglePanel + column * columns, false, false, panel, rowPanel + column * rows,
+                )
+                row += rows
+            }
+            column += columns
+        }
+    }
+    PackedPanels.clearLeftPadding(panel, height, width)
+}
+
+internal fun updateCholeskyTrailing(
+    kernels: Kernels,
+    matrix: DenseMatrix,
+    start: Int,
+    width: Int,
+    workspace: Workspace?,
+) {
+    val end = start + width
+    val height = matrix.rows - end
+    if (height == 0) return
+    workspace.borrow(PackedPanels.leftSize(height, width)) { panel ->
+        PackedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
+        subtractCholeskyPanel(kernels, matrix, end, width, panel, workspace)
+    }
+}
+
+// The solved left panel remains packed after TRSM. Only its transposed right format needs packing for SYRK.
+private fun subtractCholeskyPanel(
+    kernels: Kernels,
+    matrix: DenseMatrix,
+    start: Int,
+    width: Int,
+    left: DoubleArray,
+    workspace: Workspace?,
+) {
+    val height = matrix.rows - start
+    val rows = kernels.gemmTileRows
+    val columns = kernels.gemmTileCols
+    kernels.scale(left, 0, -1.0, left.size)
+    workspace.borrow(PackedPanels.rightSize(width, height)) { right ->
+        PackedPanels.packRight(
+            matrix,
+            right,
+            width,
+            height,
+            sourceRow = start - width,
+            sourceColumn = start,
+            transpose = true,
+        )
+        workspace.borrow(rows * columns) { edge ->
+            var column = 0
+            while (column < height) {
+                var row = column / rows * rows
+                while (row < height) {
+                    val destination = start + row + (start + column) * matrix.rows
+                    if (row >= column + columns - 1 && row + rows <= height && column + columns <= height) {
+                        kernels.gemmTile(
+                            width,
+                            left,
+                            row * width,
+                            right,
+                            column * width,
+                            matrix.data,
+                            destination,
+                            matrix.rows,
+                        )
+                    } else {
+                        // A diagonal or edge tile must preserve entries outside the stored lower triangle.
+                        edge.fill(0.0)
+                        kernels.gemmTile(width, left, row * width, right, column * width, edge, 0, rows)
+                        for (j in 0 until min(columns, height - column)) {
+                            for (i in 0 until min(rows, height - row)) {
+                                if (row + i >= column + j) {
+                                    matrix.data[destination + i + j * matrix.rows] += edge[i + j * rows]
+                                }
+                            }
+                        }
+                    }
+                    row += rows
+                }
+                column += columns
+            }
+        }
+    }
+}
+
+private fun tryCholeskyLeaf(
+    kernels: Kernels,
+    matrix: DenseMatrix,
+    minimumPivot: Double,
+    workspace: Workspace?,
+): Boolean {
+    val n = matrix.rows
+    val data = matrix.data
+    return workspace.borrow(n) { row ->
+        for (j in 0 until n) {
+            val base = j + j * n
+            for (p in 0 until j) row[p] = data[j + p * n]
+            val pivot = data[base] - kernels.dot(row, 0, row, 0, j)
+            if (!pivot.isFinite() || pivot <= 0.0 || pivot < minimumPivot) return@borrow false
+            val diagonal = sqrt(pivot)
+            data[base] = diagonal
+            val length = n - j - 1
+            if (length > 0) {
+                if (j > 0) {
+                    koblas.blas.gemv(
+                        -1.0,
+                        matrix.view(j + 1, length, 0, j),
+                        StridedVectorView(row, 0, j),
+                        1.0,
+                        StridedVectorView(data, base + 1, length),
+                    )
+                }
+                kernels.scale(data, base + 1, 1.0 / diagonal, length)
+                for (i in base + 1 until base + 1 + length) if (!data[i].isFinite()) return@borrow false
+            }
+        }
+        true
+    }
+}

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -271,7 +271,7 @@ class BayesianRegressionStat(
                 }
 
                 // Solve H_new * mu_new = b via chol(H_new); that factor is the merged state.
-                hNew.choleskyInto(hNew, CholeskyPolicy.Regularize())
+                hNew.choleskyInto(hNew, CholeskyPolicy.Regularize(), workspace)
                 hNew.choleskySolveInto(b, b)
 
                 for (i in 0 until n) {

--- a/kumulant/src/commonMain/resources/META-INF/NOTICE
+++ b/kumulant/src/commonMain/resources/META-INF/NOTICE
@@ -1,0 +1,39 @@
+CholeskyBlocks.kt adapts the OpenBLAS portable Cholesky algorithm.
+OpenBLAS revision: 632ef874379c16ca8646d9fa0f6c60449e47d960
+Source: lapack/potrf/potrf_L_single.c and lapack/potf2/potf2_L.c
+
+Copyright 2009, 2010 The University of Texas at Austin.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT
+AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,
+INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF
+MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE
+DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT
+AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE
+GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF
+LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT
+OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and
+documentation are those of the authors and should not be
+interpreted as representing official policies, either expressed
+or implied, of The University of Texas at Austin.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.math
 
-import com.eignex.koblas.Workspace
 import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.Workspace
 import kotlin.math.abs
 import kotlin.math.min
 import kotlin.math.sqrt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class CholeskyTest {
     @Test
     fun `factorization recovers a known factor across block boundaries`() {
-        for (n in listOf(0, 1, 63, 64, 65, 129, 193, 321)) {
+        for (n in listOf(0, 1, 63, 64, 65, 71, 75, 79, 129, 257)) {
             val tail = 1.0 / (n + 1)
             val a = DenseMatrix.wrap(
                 n,
@@ -62,7 +62,9 @@ class CholeskyTest {
             assertSame(out, factor)
             for (j in 0 until 65) {
                 for (i in 0 until 65) {
-                    val expected = if (i == j) 2.0 else if (i == 64 && j == 0) {
+                    val expected = if (i == j) {
+                        2.0
+                    } else if (i == 64 && j == 0) {
                         1.0
                     } else {
                         0.0
@@ -88,7 +90,9 @@ class CholeskyTest {
             assertSame(out, factor)
             for (j in 0 until 65) {
                 for (i in 0 until 65) {
-                    val expected = if (i == j) 2.0 else if (i == 64 && j == 0) {
+                    val expected = if (i == j) {
+                        2.0
+                    } else if (i == 64 && j == 0) {
                         1.0
                     } else {
                         0.0
@@ -97,6 +101,137 @@ class CholeskyTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `factorization reconstructs nearly dependent columns across blocks`() {
+        for (epsilon in listOf(1e-4, 1e-8)) {
+            val n = 129
+            val a = DenseMatrix.wrap(
+                n,
+                n,
+                DoubleArray(n * n) { index ->
+                    if (index % n == index / n) 1.0 + epsilon else 1.0
+                },
+            )
+
+            val factor = a.cholesky()
+
+            var maxError = 0.0
+            for (j in 0 until n) {
+                for (i in j until n) {
+                    var reconstructed = 0.0
+                    for (k in 0..j) reconstructed += factor[i, k] * factor[j, k]
+                    maxError = maxOf(maxError, abs(reconstructed - a[i, j]))
+                }
+            }
+            assertTrue(maxError < 1e-12, "epsilon=$epsilon reconstruction error=$maxError")
+        }
+    }
+
+    @Test
+    fun `workspace reuse preserves factors across different matrices and scales`() {
+        val workspace = Workspace()
+        val first = DenseMatrix.diagonal(129, 4.0).cholesky(workspace = workspace)
+        for (scale in listOf(1e-100, 1.0, 1e100)) {
+            val n = 129
+            val tail = 0.01
+            val a = DenseMatrix.wrap(
+                n,
+                n,
+                DoubleArray(n * n) { index ->
+                    val i = index % n
+                    val j = index / n
+                    val sign = if ((i + j) % 2 == 0) 1.0 else -1.0
+                    val entry = if (i == j) 4.0 + j * tail * tail else sign * (min(i, j) * tail * tail + 2.0 * tail)
+                    if (i < j) Double.NaN else entry * scale * scale
+                },
+            )
+
+            val factor = a.choleskyInto(a, workspace = workspace)
+
+            var maxError = 0.0
+            for (j in 0 until n) {
+                for (i in 0 until n) {
+                    val sign = if ((i + j) % 2 == 0) 1.0 else -1.0
+                    val expected = if (i < j) {
+                        0.0
+                    } else if (i == j) {
+                        2.0
+                    } else {
+                        sign * tail
+                    }
+                    maxError = maxOf(maxError, abs(factor[i, j] / scale - expected))
+                    assertEquals(if (i == j) 2.0 else 0.0, first[i, j])
+                }
+            }
+            assertTrue(maxError < 1e-12, "scale=$scale factor error=$maxError")
+        }
+    }
+
+    @Test
+    fun `zero coefficients preserve the first failing pivot with infinite column tails`() {
+        for (tail in listOf(1e200, Double.POSITIVE_INFINITY)) {
+            val a = DenseMatrix.diagonal(66, 1.0)
+            a[0, 0] = 1e-300
+            a[65, 0] = tail
+
+            val error = assertFailsWith<NotPositiveDefinite> { a.cholesky() }
+
+            assertEquals(65, error.pivotIndex)
+            assertEquals(Double.NEGATIVE_INFINITY, error.pivot)
+        }
+    }
+
+    @Test
+    fun `regularization bounds a corrected column across a block boundary`() {
+        for (pivot in listOf(-1.0, 0.0, 1e-12)) {
+            val a = DenseMatrix.diagonal(66, 1.0)
+            a[64, 0] = 1.0
+            a[65, 0] = 2.0
+            a[64, 64] = 1.0 + pivot
+            a[65, 64] = 5.0
+            a[65, 65] = 6.0
+
+            val factor = a.cholesky(CholeskyPolicy.Regularize())
+
+            assertEquals(3.0, factor[64, 64])
+            assertEquals(1.0, factor[65, 64])
+            assertEquals(1.0, factor[65, 65])
+        }
+    }
+
+    @Test
+    fun `every policy reports NaN pivots beyond the first block with reused scratch`() {
+        val workspace = Workspace()
+        for (policy in listOf(CholeskyPolicy.Strict, CholeskyPolicy.Regularize())) {
+            for (pivot in listOf(64, 65, 128)) {
+                val a = DenseMatrix.diagonal(129, 1.0)
+                a[pivot, pivot] = Double.NaN
+
+                val error = assertFailsWith<NotPositiveDefinite> { a.cholesky(policy, workspace) }
+
+                assertEquals(pivot, error.pivotIndex)
+                assertTrue(error.pivot.isNaN())
+            }
+        }
+        val factor = DenseMatrix.diagonal(129, 4.0).cholesky(workspace = workspace)
+        for (i in 0 until 129) assertEquals(2.0, factor[i, i])
+    }
+
+    @Test
+    fun `regularization uses the column tail outside the diagonal block after a rejected trial`() {
+        val a = DenseMatrix.diagonal(65, 4.0)
+        a[20, 20] = 0.0
+        a[64, 20] = 3.0
+        a[64, 64] = 2.0
+
+        a.choleskyInto(a, CholeskyPolicy.Regularize())
+
+        for (i in 0 until 20) assertEquals(2.0, a[i, i])
+        assertEquals(3.0, a[20, 20])
+        assertEquals(1.0, a[64, 20])
+        assertEquals(1.0, a[64, 64])
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Replace the AXPY-based Cholesky block update with recursive diagonal factorization, packed GEMM/TRSM panel solves, and lower-triangle GEMM tile updates. Retain the solved left panel across the solve and update, using koblas's expanded PackedPanels and kernel APIs.
- Accept optional reusable scratch in the private factorization functions and use the regression merge workspace. Stage trial blocks so regularization can fall back to the full corrected column; preserve in-place operation, upper-triangle clearing, and failure reporting. Keep the original column sweep for small matrices and incompatible custom tile geometry.
- Retain the OpenBLAS source notice and package it with the library. In a separate commit, refresh ABI snapshots for the koblas precision/package rename already adopted on main.

## Why

The factorization in #119 spends its block-update work in Level 1 AXPY calls. OpenBLAS's `lapack/potrf/potrf_L_single.c` instead factors recursively, solves a packed panel with TRSM, and updates the trailing lower triangle through GEMM-backed SYRK. This follows that structure using koblas's new compute leaves; the small recursive leaf uses DOT, GEMV, and SCAL as in `potf2_L.c`. The source reference is the local OpenBLAS checkout at 632ef874379c16ca8646d9fa0f6c60449e47d960.

The 64-column cap and 16-column leaf are conservative choices, not tuned crossovers. Cholesky remains private to kumulant. This follows #119, which has merged, so the PR targets main.

## Testing

`./gradlew check lintDocs --rerun-tasks` passed on the complete diff: 2,030 JVM and 1,971 Linux Native tests, ABI validation, detekt, and documentation checks. All Cholesky JVM tests were below 300 ms in the final full run (maximum 282 ms). The built JVM JAR contains the OpenBLAS notice.

Focused Cholesky and GLM tests also passed with `-Pkumulant.noSimd=true`, covering the scalar JVM tile geometry. The 20 Cholesky tests cover partial tiles, reconstruction of nearly dependent matrices, in-place factorization, reused scratch across scales, regularization across block boundaries, and NaN/infinite failure paths.

An ignored throw-away microbenchmark under `.codex/cholesky-packed-bench` compares main at 449d282 and this implementation in the same process against the same koblas artifact. Both recover constant-tail and varied known factors within 1e-12. Shared-host thread-CPU medians with reused scratch were approximately 1.4x, 1.9x, and 2.3x faster at sizes 256, 512, and 1024; size 128 was roughly even. At size 1024, allocated bytes per call including the output were 8.9 MB for main, 18.0 MB for packed without scratch reuse, and 8.5 MB with reuse. Scheduling, cache contention, JIT, and heterogeneous cores make these exploratory results unsuitable for choosing tuning constants or claiming OpenBLAS parity.
