### PR TITLE
Migrate to latest Koblas

### DIFF
--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BayesianWorkspaceBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/BayesianWorkspaceBenchmark.kt
@@ -24,7 +24,7 @@ open class BayesianWorkspaceBenchmark {
     @Setup
     fun setup() {
         x = DenseVector.of(DoubleArray(featureSize) { (it % 7 - 3) * 0.125 })
-        workspace = Workspace().apply { reserve(featureSize, count = 3) }
+        workspace = Workspace()
         stat = BayesianRegressionStat(featureSize)
         val other = BayesianRegressionStat(featureSize)
         other.update(x, -0.5)

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/PredictionKernelBenchmark.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.bench
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.stat.regression.SoftmaxRegressionResult
 import com.eignex.kumulant.stat.regression.GaussianNaiveBayesStat
@@ -29,7 +29,7 @@ open class PredictionKernelBenchmark {
     @Param("1", "10", "100")
     var densityPercent: Int = 1
 
-    private lateinit var x: VectorLike
+    private lateinit var x: Vector
     private lateinit var linear: StochasticRegressionResult
     private lateinit var softmax: SoftmaxRegressionResult
     private lateinit var posterior: PrecisionRegressionResult
@@ -52,7 +52,7 @@ open class PredictionKernelBenchmark {
         softmax = SoftmaxRegressionResult(
             featureSize,
             4,
-            DenseMatrix.of(Array(4) { k -> DoubleArray(featureSize) { i -> (k - i % 5) * 0.1 } }),
+            DenseMatrix.ofRows(Array(4) { k -> DoubleArray(featureSize) { i -> (k - i % 5) * 0.1 } }),
             DenseVector.of(doubleArrayOf(-0.2, 0.0, 0.1, 0.3)),
             0.0,
             0L,
@@ -69,11 +69,7 @@ open class PredictionKernelBenchmark {
         repeat(4) { arm ->
             repeat(32) { sample -> knn.update(arm, x, (sample - arm).toDouble()) }
         }
-        workspace = Workspace().apply {
-            reserve(featureSize, count = 3)
-            reserve(4, count = 1)
-            reserve(24, count = 1)
-        }
+        workspace = Workspace()
         probabilities = DoubleArray(4)
     }
 
@@ -105,7 +101,7 @@ open class PredictionKernelBenchmark {
     fun knnChooseWorkspace(): Int = knn.choose(x, workspace)
 
     @Benchmark
-    fun multivariateSample(): VectorLike = MultivariateGaussian.sample(posterior, Random(1234), 1.0)
+    fun multivariateSample(): Vector = MultivariateGaussian.sample(posterior, Random(1234), 1.0)
 
     @Benchmark
     fun multivariateEvaluate(): Double = MultivariateGaussian.evaluate(posterior, x, Random(1234), 1.0)

--- a/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
+++ b/kumulant-bench/src/commonMain/kotlin/com/eignex/kumulant/bench/VectorExprBenchmark.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.bench
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.koblas.StridedVectorView
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.ScalarExpr
 import com.eignex.kumulant.schema.expr.VFoldOp
@@ -30,7 +30,7 @@ open class VectorExprBenchmark {
     @Param("dense", "sparse", "strided", "custom")
     lateinit var representation: String
 
-    private lateinit var input: VectorLike
+    private lateinit var input: Vector
     private val scalar = V(0) + V(1)
     private val predicate = V(0) gt 0.0
     private val vector = vectorOf(V(0), V(1))
@@ -51,7 +51,7 @@ open class VectorExprBenchmark {
                 SparseVector.of(featureSize, IntArray(nnz) { it * featureSize / nnz }, DoubleArray(nnz) { 1.0 })
             }
             "strided" -> StridedVectorView(DoubleArray(featureSize * 2) { values[it / 2] }, 0, featureSize, 2)
-            else -> Vector(values)
+            else -> CustomVector(values)
         }
         dot = vDot(List(featureSize) { if (it % 2 == 0) 1.0 else -1.0 })
     }
@@ -69,7 +69,7 @@ open class VectorExprBenchmark {
     @Benchmark fun materializedPredicate(): Boolean = predicate.eval(0.0, 0.0, input.toDoubleArray())
     @Benchmark fun materializedVector(): DoubleArray = vector.eval(0.0, 0.0, input.toDoubleArray())
 
-    private class Vector(private val values: DoubleArray) : VectorLike {
+    private class CustomVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()

--- a/kumulant/api/kumulant.api
+++ b/kumulant/api/kumulant.api
@@ -27,24 +27,24 @@ public final class com/eignex/kumulant/bandit/BanditFactoryKt {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualBandit : com/eignex/kumulant/bandit/Bandit {
-	public abstract fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
-	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public abstract fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public abstract fun choose (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
+	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public abstract fun update (ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/bandit/ContextualBandit$DefaultImpls {
-	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun choose$default (Lcom/eignex/kumulant/bandit/ContextualBandit;Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public static synthetic fun update$default (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/eignex/kumulant/bandit/ContextualScorable {
-	public abstract fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public abstract fun evaluate (ILcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/bandit/ContextualScorable$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/bandit/ContextualScorable;ILcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public abstract interface class com/eignex/kumulant/bandit/PerArmBandit : com/eignex/kumulant/bandit/Snapshotable {
@@ -73,14 +73,14 @@ public final class com/eignex/kumulant/bandit/Snapshotable$DefaultImpls {
 public final class com/eignex/kumulant/bandit/TrackedContextualBandit : com/eignex/kumulant/bandit/ContextualBandit {
 	public fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/bandit/ContextualBandit;ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/core/PairedStat;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
 	public final fun chooseResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun getContextFeatureSize ()I
 	public final fun getInner ()Lcom/eignex/kumulant/bandit/ContextualBandit;
 	public fun getNbrArms ()I
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun reset ()V
-	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
 	public final fun updateArmRewardResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateJointResult ()Lcom/eignex/kumulant/core/Result;
 	public final fun updateMarginalResult ()Lcom/eignex/kumulant/core/Result;
@@ -126,7 +126,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public static final field Companion Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion;
 	public fun <init> (ILjava/util/List;DDLkotlin/random/Random;)V
 	public synthetic fun <init> (ILjava/util/List;DDLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/Exp4Bandit;
 	public final fun expertWeights ()[D
@@ -137,12 +137,12 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit : com/eignex
 	public fun getRandom ()Lkotlin/random/Random;
 	public fun merge (Lcom/eignex/kumulant/bandit/contextual/Exp4State;Lcom/eignex/koblas/Workspace;)V
 	public synthetic fun merge (Ljava/lang/Object;Lcom/eignex/koblas/Workspace;)V
-	public final fun playDistribution (Lcom/eignex/koblas/VectorLike;)[D
-	public final fun playDistributionInto (Lcom/eignex/koblas/VectorLike;[D)V
+	public final fun playDistribution (Lcom/eignex/koblas/Vector;)[D
+	public final fun playDistributionInto (Lcom/eignex/koblas/Vector;[D)V
 	public fun reset ()V
 	public fun snapshot ()Lcom/eignex/kumulant/bandit/contextual/Exp4State;
 	public synthetic fun snapshot ()Ljava/lang/Object;
-	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
@@ -151,7 +151,7 @@ public final class com/eignex/kumulant/bandit/contextual/Exp4Bandit$Companion {
 }
 
 public abstract interface class com/eignex/kumulant/bandit/contextual/Exp4Expert {
-	public abstract fun advise (Lcom/eignex/koblas/VectorLike;I)[D
+	public abstract fun advise (Lcom/eignex/koblas/Vector;I)[D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/Exp4State : com/eignex/kumulant/core/Result {
@@ -221,10 +221,10 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun armResult (I)Lcom/eignex/kumulant/bandit/contextual/KnnArmResult;
 	public synthetic fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armWeight (I)D
-	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/KnnContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
+	public fun evaluate (ILcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)D
 	public final fun getColdStartScore ()D
 	public final fun getDistance ()Lkotlin/jvm/functions/Function2;
 	public final fun getExploration ()D
@@ -238,11 +238,11 @@ public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit : c
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualBandit$Companion {
-	public final fun squaredL2 (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/VectorLike;)D
+	public final fun squaredL2 (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Vector;)D
 }
 
 public final class com/eignex/kumulant/bandit/contextual/KnnContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -404,10 +404,10 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public synthetic fun <init> (ILcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/kumulant/stat/regression/RegressionPosterior;DLcom/eignex/kumulant/core/RegressionStat;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun armResult (I)Lcom/eignex/kumulant/core/Result;
 	public final fun armStat (I)Lcom/eignex/kumulant/core/RegressionStat;
-	public fun choose (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
+	public fun choose (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
 	public synthetic fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/Snapshotable;
 	public fun create (Lkotlin/random/Random;)Lcom/eignex/kumulant/bandit/contextual/RegressionContextualBandit;
-	public fun evaluate (ILcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)D
+	public fun evaluate (ILcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)D
 	public final fun getExploration ()D
 	public fun getNbrArms ()I
 	public final fun getPosterior ()Lcom/eignex/kumulant/stat/regression/RegressionPosterior;
@@ -421,7 +421,7 @@ public final class com/eignex/kumulant/bandit/contextual/RegressionContextualBan
 	public fun reset ()V
 	public synthetic fun snapshot ()Ljava/lang/Object;
 	public fun snapshot ()Ljava/util/List;
-	public fun update (ILcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (ILcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/bandit/contextual/RegressionContextualSpec : com/eignex/kumulant/bandit/contextual/ContextualBanditSpec {
@@ -1854,13 +1854,13 @@ public abstract interface class com/eignex/kumulant/core/HasCenterScale : com/ei
 public abstract interface class com/eignex/kumulant/core/HasLinearModel : com/eignex/kumulant/core/Result {
 	public abstract fun getBias ()D
 	public fun getFeatureSize ()I
-	public abstract fun getWeights ()Lcom/eignex/koblas/VectorLike;
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/Vector;
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 }
 
 public final class com/eignex/kumulant/core/HasLinearModel$DefaultImpls {
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasLinearModel;)I
-	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/VectorLike;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasLinearModel;Lcom/eignex/koblas/Vector;)D
 }
 
 public abstract interface class com/eignex/kumulant/core/HasMinMax : com/eignex/kumulant/core/Result {
@@ -1953,16 +1953,16 @@ public abstract interface class com/eignex/kumulant/core/HasSlope : com/eignex/k
 	public fun getFeatureSize ()I
 	public abstract fun getIntercept ()D
 	public abstract fun getSlope ()D
-	public fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/Vector;
 	public fun predict (D)D
 }
 
 public final class com/eignex/kumulant/core/HasSlope$DefaultImpls {
 	public static fun getBias (Lcom/eignex/kumulant/core/HasSlope;)D
 	public static fun getFeatureSize (Lcom/eignex/kumulant/core/HasSlope;)I
-	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/VectorLike;
+	public static fun getWeights (Lcom/eignex/kumulant/core/HasSlope;)Lcom/eignex/koblas/Vector;
 	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;D)D
-	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/VectorLike;)D
+	public static fun predict (Lcom/eignex/kumulant/core/HasSlope;Lcom/eignex/koblas/Vector;)D
 }
 
 public final class com/eignex/kumulant/core/IndexedResult : com/eignex/kumulant/core/Result {
@@ -2017,22 +2017,22 @@ public abstract interface class com/eignex/kumulant/core/RegressionStat : com/ei
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public abstract fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public abstract fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/RegressionStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
+	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;)V
 	public static fun update (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/RegressionStat;[DDJDLcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
 }
@@ -2106,22 +2106,22 @@ public final class com/eignex/kumulant/core/Stat$DefaultImpls {
 public abstract interface class com/eignex/kumulant/core/VectorStat : com/eignex/kumulant/core/Stat {
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public abstract fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/VectorLike;D)V
-	public abstract fun update (Lcom/eignex/koblas/VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/Vector;D)V
+	public abstract fun update (Lcom/eignex/koblas/Vector;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/Vector;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/Vector;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/core/VectorStat$DefaultImpls {
-	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;D)V
+	public static fun update (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/Vector;D)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DD)V
 	public static fun update (Lcom/eignex/kumulant/core/VectorStat;[DJD)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;DILjava/lang/Object;)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/VectorLike;JDILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/Vector;DILjava/lang/Object;)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;Lcom/eignex/koblas/Vector;JDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DDILjava/lang/Object;)V
 	public static synthetic fun update$default (Lcom/eignex/kumulant/core/VectorStat;[DJDILjava/lang/Object;)V
 }
@@ -2395,12 +2395,12 @@ public final class com/eignex/kumulant/schema/expr/ExprKt {
 	public static final fun div (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/ScalarExpr;
 	public static final fun eq (Lcom/eignex/kumulant/schema/expr/ScalarExpr;D)Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public static final fun eq (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/BoolExpr;
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)Z
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)D
-	public static final fun eval (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;)[D
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)Z
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)D
-	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/VectorLike;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)[D
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;)Z
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;)D
+	public static final fun eval (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;)[D
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/BoolExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)Z
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/ScalarExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)D
+	public static synthetic fun eval$default (Lcom/eignex/kumulant/schema/expr/VectorExpr;DDLcom/eignex/koblas/Vector;Lcom/eignex/kumulant/core/Result;ILjava/lang/Object;)[D
 	public static final fun exp (Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/ScalarExpr;
 	public static final fun ge (Lcom/eignex/kumulant/schema/expr/ScalarExpr;D)Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public static final fun ge (Lcom/eignex/kumulant/schema/expr/ScalarExpr;Lcom/eignex/kumulant/schema/expr/ScalarExpr;)Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -3041,8 +3041,8 @@ public final class com/eignex/kumulant/schema/runtime/RegressionStatGroup : com/
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun getFeatureSize ()I
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -3141,8 +3141,8 @@ public final class com/eignex/kumulant/schema/runtime/VectorStatGroup : com/eign
 	public synthetic fun <init> ([Lkotlin/Pair;Lcom/eignex/kumulant/core/Concurrency;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/VectorStat;
-	public fun update (Lcom/eignex/koblas/VectorLike;D)V
-	public fun update (Lcom/eignex/koblas/VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/Vector;D)V
+	public fun update (Lcom/eignex/koblas/Vector;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -5070,7 +5070,7 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult : com/e
 	public fun getTotalWeights ()D
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun score (Lcom/eignex/koblas/VectorLike;)D
+	public final fun score (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -5107,8 +5107,8 @@ public final class com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat : com/eig
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/anomaly/HalfSpaceTreesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;D)V
-	public fun update (Lcom/eignex/koblas/VectorLike;JD)V
+	public fun update (Lcom/eignex/koblas/Vector;D)V
+	public fun update (Lcom/eignex/koblas/Vector;JD)V
 	public fun update ([DD)V
 	public fun update ([DJD)V
 }
@@ -6864,12 +6864,12 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesResult 
 	public final fun getVariances ()Lcom/eignex/koblas/DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logPosterior (Lcom/eignex/koblas/VectorLike;I)D
-	public final fun logPosteriorsInto (Lcom/eignex/koblas/VectorLike;[D)V
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
+	public final fun logPosterior (Lcom/eignex/koblas/Vector;I)D
+	public final fun logPosteriorsInto (Lcom/eignex/koblas/Vector;[D)V
+	public final fun predict (Lcom/eignex/koblas/Vector;)I
 	public final fun prior (I)D
-	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
-	public final fun probabilitiesInto (Lcom/eignex/koblas/VectorLike;[D)V
+	public final fun probabilities (Lcom/eignex/koblas/Vector;)[D
+	public final fun probabilitiesInto (Lcom/eignex/koblas/Vector;[D)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6899,8 +6899,8 @@ public final class com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat : 
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/GaussianNaiveBayesResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -6917,12 +6917,12 @@ public final class com/eignex/kumulant/stat/regression/Optimizer$DefaultImpls {
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/RegressionPosterior {
-	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public abstract fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RegressionPosterior$DefaultImpls {
-	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
+	public static synthetic fun evaluate$default (Lcom/eignex/kumulant/stat/regression/RegressionPosterior;Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;ILjava/lang/Object;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/RmspropOptimizer : com/eignex/kumulant/stat/regression/Optimizer {
@@ -6970,12 +6970,12 @@ public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionResult :
 	public final fun getWeights ()Lcom/eignex/koblas/DenseMatrix;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public final fun logit (Lcom/eignex/koblas/VectorLike;I)D
-	public final fun logitsInto (Lcom/eignex/koblas/VectorLike;[D)V
-	public final fun predict (Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;)I
-	public static synthetic fun predict$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
-	public final fun probabilitiesInto (Lcom/eignex/koblas/VectorLike;[D)V
+	public final fun logit (Lcom/eignex/koblas/Vector;I)D
+	public final fun logitsInto (Lcom/eignex/koblas/Vector;[D)V
+	public final fun predict (Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;)I
+	public static synthetic fun predict$default (Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)I
+	public final fun probabilities (Lcom/eignex/koblas/Vector;)[D
+	public final fun probabilitiesInto (Lcom/eignex/koblas/Vector;[D)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7013,16 +7013,16 @@ public final class com/eignex/kumulant/stat/regression/SoftmaxRegressionStat : c
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/SoftmaxRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat : com/eignex/kumulant/core/RegressionStat {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat$Companion;
-	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/MatrixLike;)V
-	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/VectorLike;Lcom/eignex/koblas/MatrixLike;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Matrix;)V
+	public synthetic fun <init> (IDLcom/eignex/kumulant/stat/regression/glm/Link;Lcom/eignex/kumulant/core/Concurrency;Lcom/eignex/koblas/Vector;Lcom/eignex/koblas/Matrix;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/RegressionStat;
 	public synthetic fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/core/Stat;
 	public fun create (Lcom/eignex/kumulant/core/Concurrency;)Lcom/eignex/kumulant/stat/regression/glm/BayesianRegressionStat;
@@ -7035,8 +7035,8 @@ public final class com/eignex/kumulant/stat/regression/glm/BayesianRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7079,11 +7079,11 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionRes
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
 	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/Vector;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/Vector;)D
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7119,8 +7119,8 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7128,12 +7128,12 @@ public final class com/eignex/kumulant/stat/regression/glm/DiagonalRegressionSta
 public final class com/eignex/kumulant/stat/regression/glm/FactorisedGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/FactorisedGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/DiagonalRegressionResult;Lkotlin/random/Random;[DD)V
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7166,12 +7166,12 @@ public final class com/eignex/kumulant/stat/regression/glm/LearningRatesKt {
 public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/LinUcb;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7180,10 +7180,10 @@ public final class com/eignex/kumulant/stat/regression/glm/LinUcb : com/eignex/k
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearPosterior : com/eignex/kumulant/stat/regression/RegressionPosterior {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior$Companion;
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorLike;
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public abstract fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/Vector;
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public static synthetic fun sampleInto$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DDILjava/lang/Object;)V
 }
@@ -7193,8 +7193,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$Compa
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearPosterior$DefaultImpls {
-	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/VectorLike;
+	public static fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public static synthetic fun sample$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;DILjava/lang/Object;)Lcom/eignex/koblas/Vector;
 	public static fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public static synthetic fun sampleInto$default (Lcom/eignex/kumulant/stat/regression/glm/LinearPosterior;Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DDILjava/lang/Object;)V
 }
@@ -7205,9 +7205,9 @@ public abstract interface class com/eignex/kumulant/stat/regression/glm/LinearRe
 	public abstract fun getLink ()Lcom/eignex/kumulant/stat/regression/glm/Link;
 	public abstract fun getStep ()J
 	public abstract fun getTotalWeights ()D
-	public abstract fun getWeights ()Lcom/eignex/koblas/VectorLike;
-	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public abstract fun getWeights ()Lcom/eignex/koblas/Vector;
+	public fun linearPredictor (Lcom/eignex/koblas/Vector;)D
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 }
 
 public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResult$Companion {
@@ -7226,8 +7226,8 @@ public final class com/eignex/kumulant/stat/regression/glm/LinearRegressionResul
 	public static fun getStdDev (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun getVariance (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)D
 	public static fun isEmpty (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;)Z
-	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;)D
-	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;)D
+	public static fun linearPredictor (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;)D
+	public static fun predict (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;)D
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/glm/Link {
@@ -7277,12 +7277,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Link$Logit : com/eign
 public final class com/eignex/kumulant/stat/regression/glm/MultivariateGaussian : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/MultivariateGaussian;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/PrecisionRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7362,12 +7362,12 @@ public final class com/eignex/kumulant/stat/regression/glm/Penalty$None : com/ei
 public final class com/eignex/kumulant/stat/regression/glm/PointPosterior : com/eignex/kumulant/stat/regression/glm/LinearPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/glm/PointPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
-	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
-	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/VectorLike;
+	public synthetic fun sample (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
+	public fun sample (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;D)Lcom/eignex/koblas/Vector;
 	public synthetic fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/LinearRegressionResult;Lkotlin/random/Random;[DD)V
 	public fun sampleInto (Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;Lkotlin/random/Random;[DD)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
@@ -7442,11 +7442,11 @@ public final class com/eignex/kumulant/stat/regression/glm/PrecisionRegressionRe
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
 	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/Vector;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/Vector;)D
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7496,11 +7496,11 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionR
 	public final fun getUpdaterState ()Ljava/util/List;
 	public fun getVariance ()D
 	public fun getWeights ()Lcom/eignex/koblas/DenseVector;
-	public synthetic fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public synthetic fun getWeights ()Lcom/eignex/koblas/Vector;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
-	public fun linearPredictor (Lcom/eignex/koblas/VectorLike;)D
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public fun linearPredictor (Lcom/eignex/koblas/Vector;)D
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7540,8 +7540,8 @@ public final class com/eignex/kumulant/stat/regression/glm/StochasticRegressionS
 	public synthetic fun read (J)Lcom/eignex/kumulant/core/Result;
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/glm/StochasticRegressionResult;
 	public fun reset ()V
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7579,13 +7579,13 @@ public final class com/eignex/kumulant/stat/regression/glm/UnivariateRegressionR
 	public final fun getSxy ()D
 	public fun getTotalWeights ()D
 	public fun getVariance ()D
-	public fun getWeights ()Lcom/eignex/koblas/VectorLike;
+	public fun getWeights ()Lcom/eignex/koblas/Vector;
 	public final fun getX ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public final fun getY ()Lcom/eignex/kumulant/stat/summary/VarianceResult;
 	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public fun predict (D)D
-	public fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7687,12 +7687,12 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationAuditL
 }
 
 public abstract class com/eignex/kumulant/stat/regression/tree/ClassificationLeafNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public abstract fun getArm ()Lcom/eignex/kumulant/core/SeriesStat;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationNode {
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public abstract fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 }
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/ClassificationSplitMetric {
@@ -7707,7 +7707,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitM
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationSplitNode : com/eignex/kumulant/stat/regression/tree/ClassificationNode {
 	public fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;)V
 	public synthetic fun <init> (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;Lcom/eignex/kumulant/core/SeriesStat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getCarryover ()Lcom/eignex/kumulant/core/SeriesStat;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
@@ -7725,20 +7725,20 @@ public final class com/eignex/kumulant/stat/regression/tree/ClassificationTermin
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTree {
 	public fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;I)V
 	public synthetic fun <init> (ILjava/util/List;Lcom/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig;Lcom/eignex/kumulant/core/Concurrency;Lkotlin/jvm/functions/Function0;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
+	public final fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassificationLeafNode;
 	public final fun getNodeCount ()I
 	public final fun merge (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;)V
 	public final fun mergeSnapshot (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/koblas/Workspace;)V
 	public static synthetic fun mergeSnapshot$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/koblas/Workspace;ILjava/lang/Object;)V
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
+	public final fun predict (Lcom/eignex/koblas/Vector;)I
 	public final fun prettyPrint (Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun prettyPrint$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun probabilities (Lcom/eignex/koblas/Vector;)[D
 	public final fun reset ()V
 	public final fun rootNode ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationNode;
 	public final fun rootSnapshot ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
-	public final fun update (Lcom/eignex/koblas/VectorLike;ID)V
-	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/VectorLike;IDILjava/lang/Object;)V
+	public final fun update (Lcom/eignex/koblas/Vector;ID)V
+	public static synthetic fun update$default (Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;Lcom/eignex/koblas/Vector;IDILjava/lang/Object;)V
 }
 
 public final class com/eignex/kumulant/stat/regression/tree/ClassificationTreeConfig : com/eignex/kumulant/stat/regression/tree/HoeffdingTreeConfig {
@@ -7805,8 +7805,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/ClassificationTree;
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7827,8 +7827,8 @@ public final class com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun reset ()V
 	public final fun tree ()Lcom/eignex/kumulant/stat/regression/tree/RegressionTree;
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -7839,7 +7839,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ExprSplit : com/eign
 	public final fun component1 ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
 	public final fun copy (Lcom/eignex/kumulant/schema/expr/BoolExpr;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;Lcom/eignex/kumulant/schema/expr/BoolExpr;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ExprSplit;
-	public fun direction (Lcom/eignex/koblas/VectorLike;)Z
+	public fun direction (Lcom/eignex/koblas/Vector;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpr ()Lcom/eignex/kumulant/schema/expr/BoolExpr;
@@ -7874,8 +7874,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestClassification
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun predict (Lcom/eignex/koblas/Vector;)I
+	public final fun probabilities (Lcom/eignex/koblas/Vector;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7904,11 +7904,11 @@ public final class com/eignex/kumulant/stat/regression/tree/ForestRegressionResu
 	public final fun copy (Ljava/util/List;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Ljava/util/List;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeafMerged (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeafMerged (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getTotalWeights ()D
 	public final fun getTrees ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public final fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7960,8 +7960,8 @@ public final class com/eignex/kumulant/stat/regression/tree/InformationGain : co
 public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior : com/eignex/kumulant/stat/regression/tree/ForestPosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7969,8 +7969,8 @@ public final class com/eignex/kumulant/stat/regression/tree/MeanForestPosterior 
 public final class com/eignex/kumulant/stat/regression/tree/MeanTreePosterior : com/eignex/kumulant/stat/regression/tree/TreePosterior {
 	public static final field INSTANCE Lcom/eignex/kumulant/stat/regression/tree/MeanTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7994,8 +7994,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestClassifi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestClassificationResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -8018,8 +8018,8 @@ public final class com/eignex/kumulant/stat/regression/tree/RandomForestRegressi
 	public fun read (J)Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;
 	public fun reset ()V
 	public final fun trees ()Ljava/util/List;
-	public fun update (Lcom/eignex/koblas/VectorLike;DDLcom/eignex/koblas/Workspace;)V
-	public fun update (Lcom/eignex/koblas/VectorLike;DJDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DDLcom/eignex/koblas/Workspace;)V
+	public fun update (Lcom/eignex/koblas/Vector;DJDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDDLcom/eignex/koblas/Workspace;)V
 	public fun update ([DDJDLcom/eignex/koblas/Workspace;)V
 }
@@ -8176,8 +8176,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonForestPoster
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8193,8 +8193,8 @@ public final class com/eignex/kumulant/stat/regression/tree/ThompsonTreePosterio
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThompsonTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8208,7 +8208,7 @@ public final class com/eignex/kumulant/stat/regression/tree/ThresholdSplit : com
 	public final fun component2 ()D
 	public final fun copy (ID)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;IDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/ThresholdSplit;
-	public fun direction (Lcom/eignex/koblas/VectorLike;)Z
+	public fun direction (Lcom/eignex/koblas/Vector;)Z
 	public synthetic fun direction (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatureIndex ()I
@@ -8239,7 +8239,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8262,7 +8262,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationLe
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 }
 
@@ -8277,13 +8277,13 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationRe
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public final fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNumClasses ()I
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)I
-	public final fun probabilities (Lcom/eignex/koblas/VectorLike;)[D
+	public final fun predict (Lcom/eignex/koblas/Vector;)I
+	public final fun probabilities (Lcom/eignex/koblas/Vector;)[D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8312,7 +8312,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeClassificationSp
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
+	public fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/regression/tree/ClassCountsResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeClassificationNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8343,7 +8343,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult : com
 	public final fun copy (Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeLeafResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -8366,7 +8366,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeLeafResult$Compa
 
 public abstract interface class com/eignex/kumulant/stat/regression/tree/TreeNodeResult {
 	public static final field Companion Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult$Companion;
-	public abstract fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public abstract fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public abstract fun getValue ()Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 }
 
@@ -8384,12 +8384,12 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeRegressionResult
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public final fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getRoot ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getRootMean ()D
 	public final fun getTotalWeights ()D
 	public fun hashCode ()I
-	public final fun predict (Lcom/eignex/koblas/VectorLike;)D
+	public final fun predict (Lcom/eignex/koblas/Vector;)D
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8424,7 +8424,7 @@ public final class com/eignex/kumulant/stat/regression/tree/TreeSplitResult : co
 	public final fun copy (Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;ILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/TreeSplitResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun findLeaf (Lcom/eignex/koblas/VectorLike;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
+	public fun findLeaf (Lcom/eignex/koblas/Vector;)Lcom/eignex/kumulant/stat/summary/WeightedVarianceResult;
 	public final fun getNeg ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getPos ()Lcom/eignex/kumulant/stat/regression/tree/TreeNodeResult;
 	public final fun getSplit ()Lcom/eignex/kumulant/stat/regression/tree/SerializableSplit;
@@ -8457,8 +8457,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbForestPosterior :
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbForestPosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/ForestRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I
@@ -8474,8 +8474,8 @@ public final class com/eignex/kumulant/stat/regression/tree/UcbTreePosterior : c
 	public final fun copy (DD)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public static synthetic fun copy$default (Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;DDILjava/lang/Object;)Lcom/eignex/kumulant/stat/regression/tree/UcbTreePosterior;
 	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
-	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/VectorLike;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public synthetic fun evaluate (Lcom/eignex/kumulant/core/Result;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
+	public fun evaluate (Lcom/eignex/kumulant/stat/regression/tree/TreeRegressionResult;Lcom/eignex/koblas/Vector;Lkotlin/random/Random;DLcom/eignex/koblas/Workspace;)D
 	public final fun getPriorVariance ()D
 	public final fun getPriorWeight ()D
 	public fun hashCode ()I

--- a/kumulant/api/kumulant.klib.api
+++ b/kumulant/api/kumulant.klib.api
@@ -91,7 +91,7 @@ final enum class com.eignex.kumulant.stat.sketch/AdmissionPolicy : kotlin/Enum<c
 }
 
 abstract fun interface com.eignex.kumulant.bandit.contextual/Exp4Expert { // com.eignex.kumulant.bandit.contextual/Exp4Expert|null[0]
-    abstract fun advise(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
+    abstract fun advise(com.eignex.koblas/Vector, kotlin/Int): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Expert.advise|advise(com.eignex.koblas.Vector;kotlin.Int){}[0]
 }
 
 abstract fun interface com.eignex.kumulant.math/Hasher64 { // com.eignex.kumulant.math/Hasher64|null[0]
@@ -131,8 +131,8 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
         abstract fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/RegressionStat.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.core/RegressionStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
-    open fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    open fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double, kotlin/Long, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.core/RegressionStat.update|update(kotlin.DoubleArray;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
@@ -155,14 +155,14 @@ abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.cor
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.core/VectorStat : com.eignex.kumulant.core/Stat<#A> { // com.eignex.kumulant.core/VectorStat|null[0]
     abstract fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<#A> // com.eignex.kumulant.core/VectorStat.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    abstract fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
-    open fun update(com.eignex.koblas/VectorLike, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double){}[0]
+    abstract fun update(com.eignex.koblas/Vector, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.Vector;kotlin.Long;kotlin.Double){}[0]
+    open fun update(com.eignex.koblas/Vector, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(com.eignex.koblas.Vector;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Double){}[0]
     open fun update(kotlin/DoubleArray, kotlin/Long, kotlin/Double = ...) // com.eignex.kumulant.core/VectorStat.update|update(kotlin.DoubleArray;kotlin.Long;kotlin.Double){}[0]
 }
 
 abstract interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.stat.regression/RegressionPosterior { // com.eignex.kumulant.stat.regression/RegressionPosterior|null[0]
-    abstract fun evaluate(#A, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun evaluate(#A, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.stat.regression/RegressionPosterior.evaluate|evaluate(1:0;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface <#A: in kotlin/Any?> com.eignex.kumulant.stat.regression.tree/Split { // com.eignex.kumulant.stat.regression.tree/Split|null[0]
@@ -185,12 +185,12 @@ abstract interface com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.ba
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualBandit : com.eignex.kumulant.bandit/Bandit { // com.eignex.kumulant.bandit/ContextualBandit|null[0]
-    abstract fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
-    abstract fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun choose(com.eignex.koblas/Vector, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.bandit/ContextualBandit.choose|choose(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
+    abstract fun update(kotlin/Int, com.eignex.koblas/Vector, kotlin/Double, kotlin/Double = ..., com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit/ContextualBandit.update|update(kotlin.Int;com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/ContextualScorable { // com.eignex.kumulant.bandit/ContextualScorable|null[0]
-    abstract fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    abstract fun evaluate(kotlin/Int, com.eignex.koblas/Vector, com.eignex.koblas/Workspace? = ...): kotlin/Double // com.eignex.kumulant.bandit/ContextualScorable.evaluate|evaluate(kotlin.Int;com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
 }
 
 abstract interface com.eignex.kumulant.bandit/Scorable { // com.eignex.kumulant.bandit/Scorable|null[0]
@@ -214,11 +214,11 @@ abstract interface com.eignex.kumulant.core/HasLinearModel : com.eignex.kumulant
     abstract val bias // com.eignex.kumulant.core/HasLinearModel.bias|{}bias[0]
         abstract fun <get-bias>(): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.bias.<get-bias>|<get-bias>(){}[0]
     abstract val weights // com.eignex.kumulant.core/HasLinearModel.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/Vector // com.eignex.kumulant.core/HasLinearModel.weights.<get-weights>|<get-weights>(){}[0]
     open val featureSize // com.eignex.kumulant.core/HasLinearModel.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasLinearModel.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
-    open fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    open fun predict(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.core/HasLinearModel.predict|predict(com.eignex.koblas.Vector){}[0]
 }
 
 abstract interface com.eignex.kumulant.core/HasMinMax : com.eignex.kumulant.core/Result { // com.eignex.kumulant.core/HasMinMax|null[0]
@@ -295,7 +295,7 @@ abstract interface com.eignex.kumulant.core/HasSlope : com.eignex.kumulant.core/
     open val featureSize // com.eignex.kumulant.core/HasSlope.featureSize|{}featureSize[0]
         open fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.core/HasSlope.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
     open val weights // com.eignex.kumulant.core/HasSlope.weights|{}weights[0]
-        open fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
+        open fun <get-weights>(): com.eignex.koblas/Vector // com.eignex.kumulant.core/HasSlope.weights.<get-weights>|<get-weights>(){}[0]
 
     open fun predict(kotlin/Double): kotlin/Double // com.eignex.kumulant.core/HasSlope.predict|predict(kotlin.Double){}[0]
 }
@@ -403,8 +403,8 @@ sealed interface <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.schem
 }
 
 sealed interface <#A: com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> com.eignex.kumulant.stat.regression.glm/LinearPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<#A> { // com.eignex.kumulant.stat.regression.glm/LinearPosterior|null[0]
-    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
-    open fun evaluate(#A, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    abstract fun sample(#A, kotlin.random/Random, kotlin/Double = ...): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sample|sample(1:0;kotlin.random.Random;kotlin.Double){}[0]
+    open fun evaluate(#A, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearPosterior.evaluate|evaluate(1:0;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     open fun sampleInto(#A, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.glm/LinearPosterior.sampleInto|sampleInto(1:0;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearPosterior.Companion|null[0]
@@ -626,10 +626,10 @@ sealed interface com.eignex.kumulant.stat.regression.glm/LinearRegressionResult 
     abstract val totalWeights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights|{}totalWeights[0]
         abstract fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     abstract val weights // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights|{}weights[0]
-        abstract fun <get-weights>(): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
+        abstract fun <get-weights>(): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
-    open fun linearPredictor(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.VectorLike){}[0]
-    open fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    open fun linearPredictor(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.linearPredictor|linearPredictor(com.eignex.koblas.Vector){}[0]
+    open fun predict(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.predict|predict(com.eignex.koblas.Vector){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinearRegressionResult> // com.eignex.kumulant.stat.regression.glm/LinearRegressionResult.Companion.serializer|serializer(){}[0]
@@ -749,7 +749,7 @@ sealed interface com.eignex.kumulant.stat.regression.glm/Penalty { // com.eignex
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationNode { // com.eignex.kumulant.stat.regression.tree/ClassificationNode|null[0]
-    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationNode.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
 }
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric { // com.eignex.kumulant.stat.regression.tree/ClassificationSplitMetric|null[0]
@@ -763,7 +763,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/ClassificationSplitMet
 
 sealed interface com.eignex.kumulant.stat.regression.tree/ForestPosterior : com.eignex.kumulant.stat.regression/RegressionPosterior<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestPosterior|null[0]
 
-sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/VectorLike> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
+sealed interface com.eignex.kumulant.stat.regression.tree/SerializableSplit : com.eignex.kumulant.stat.regression.tree/Split<com.eignex.koblas/Vector> { // com.eignex.kumulant.stat.regression.tree/SerializableSplit|null[0]
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/SerializableSplit> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(){}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.tree/SerializableSplit.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -783,7 +783,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeClassificationNode
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult.Companion.serializer|serializer(){}[0]
@@ -795,7 +795,7 @@ sealed interface com.eignex.kumulant.stat.regression.tree/TreeNodeResult { // co
     abstract val value // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value|{}value[0]
         abstract fun <get-value>(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.value.<get-value>|<get-value>(){}[0]
 
-    abstract fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    abstract fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.tree/TreeNodeResult> // com.eignex.kumulant.stat.regression.tree/TreeNodeResult.Companion.serializer|serializer(){}[0]
@@ -838,10 +838,10 @@ final class <#A: com.eignex.kumulant.bandit/ContextualBandit> com.eignex.kumulan
     final val random // com.eignex.kumulant.bandit/TrackedContextualBandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit/TrackedContextualBandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit/TrackedContextualBandit.choose|choose(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun chooseResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.chooseResult|chooseResult(){}[0]
     final fun reset() // com.eignex.kumulant.bandit/TrackedContextualBandit.reset|reset(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/Vector, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit/TrackedContextualBandit.update|update(kotlin.Int;com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun updateArmRewardResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateArmRewardResult|updateArmRewardResult(){}[0]
     final fun updateJointResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateJointResult|updateJointResult(){}[0]
     final fun updateMarginalResult(): com.eignex.kumulant.core/Result? // com.eignex.kumulant.bandit/TrackedContextualBandit.updateMarginalResult|updateMarginalResult(){}[0]
@@ -894,16 +894,16 @@ final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.con
 
     final fun armResult(kotlin/Int): #A // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armResult|armResult(kotlin.Int){}[0]
     final fun armStat(kotlin/Int): com.eignex.kumulant.core/RegressionStat<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.armStat|armStat(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.choose|choose(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/RegressionContextualBandit<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun globalSnapshot(): #A? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalSnapshot|globalSnapshot(){}[0]
     final fun globalStat(): com.eignex.kumulant.core/RegressionStat<#A>? // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.globalStat|globalStat(){}[0]
     final fun merge(kotlin.collections/List<#A>, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.merge|merge(kotlin.collections.List<1:0>;com.eignex.koblas.Workspace?){}[0]
     final fun mergeGlobal(#A, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.mergeGlobal|mergeGlobal(1:0;com.eignex.koblas.Workspace?){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<#A> // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/Vector, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/RegressionContextualBandit.update|update(kotlin.Int;com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class <#A: com.eignex.kumulant.core/Result> com.eignex.kumulant.bandit.univariate/MultiArmedBandit : com.eignex.kumulant.bandit/PerArmBandit<#A>, com.eignex.kumulant.bandit/Scorable, com.eignex.kumulant.bandit/UnivariateBandit { // com.eignex.kumulant.bandit.univariate/MultiArmedBandit|null[0]
@@ -1197,15 +1197,15 @@ final class com.eignex.kumulant.bandit.contextual/Exp4Bandit : com.eignex.kumula
     final val random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random|{}random[0]
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/Exp4Bandit.random.<get-random>|<get-random>(){}[0]
 
-    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/Exp4Bandit.choose|choose(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/Exp4Bandit // com.eignex.kumulant.bandit.contextual/Exp4Bandit.create|create(kotlin.random.Random){}[0]
     final fun expertWeights(): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.expertWeights|expertWeights(){}[0]
     final fun merge(com.eignex.kumulant.bandit.contextual/Exp4State, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.merge|merge(com.eignex.kumulant.bandit.contextual.Exp4State;com.eignex.koblas.Workspace?){}[0]
-    final fun playDistribution(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.VectorLike){}[0]
-    final fun playDistributionInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistributionInto|playDistributionInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
+    final fun playDistribution(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistribution|playDistribution(com.eignex.koblas.Vector){}[0]
+    final fun playDistributionInto(com.eignex.koblas/Vector, kotlin/DoubleArray) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.playDistributionInto|playDistributionInto(com.eignex.koblas.Vector;kotlin.DoubleArray){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/Exp4Bandit.reset|reset(){}[0]
     final fun snapshot(): com.eignex.kumulant.bandit.contextual/Exp4State // com.eignex.kumulant.bandit.contextual/Exp4Bandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/Vector, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/Exp4Bandit.update|update(kotlin.Int;com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion|null[0]
         final fun defaultEta(kotlin/Int, kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/Exp4Bandit.Companion.defaultEta|defaultEta(kotlin.Int;kotlin.Int){}[0]
@@ -1277,12 +1277,12 @@ final class com.eignex.kumulant.bandit.contextual/KnnArmResult : com.eignex.kumu
 }
 
 final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eignex.kumulant.bandit/ContextualBandit, com.eignex.kumulant.bandit/ContextualScorable, com.eignex.kumulant.bandit/PerArmBandit<com.eignex.kumulant.bandit.contextual/KnnArmResult> { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.VectorLike,com.eignex.koblas.VectorLike,kotlin.Double>;kotlin.random.Random){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Function2<com.eignex.koblas/Vector, com.eignex.koblas/Vector, kotlin/Double> = ..., kotlin.random/Random = ...) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.Double;kotlin.Function2<com.eignex.koblas.Vector,com.eignex.koblas.Vector,kotlin.Double>;kotlin.random.Random){}[0]
 
     final val coldStartScore // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore|{}coldStartScore[0]
         final fun <get-coldStartScore>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.coldStartScore.<get-coldStartScore>|<get-coldStartScore>(){}[0]
     final val distance // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance|{}distance[0]
-        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
+        final fun <get-distance>(): kotlin/Function2<com.eignex.koblas/Vector, com.eignex.koblas/Vector, kotlin/Double> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.distance.<get-distance>|<get-distance>(){}[0]
     final val exploration // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration|{}exploration[0]
         final fun <get-exploration>(): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.exploration.<get-exploration>|<get-exploration>(){}[0]
     final val k // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.k|{}k[0]
@@ -1295,17 +1295,17 @@ final class com.eignex.kumulant.bandit.contextual/KnnContextualBandit : com.eign
         final fun <get-random>(): kotlin.random/Random // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.random.<get-random>|<get-random>(){}[0]
 
     final fun armWeight(kotlin/Int): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.armWeight|armWeight(kotlin.Int){}[0]
-    final fun choose(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun choose(com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.choose|choose(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun create(kotlin.random/Random): com.eignex.kumulant.bandit.contextual/KnnContextualBandit // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.create|create(kotlin.random.Random){}[0]
-    final fun evaluate(kotlin/Int, com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(kotlin/Int, com.eignex.koblas/Vector, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.evaluate|evaluate(kotlin.Int;com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
     final fun historySize(kotlin/Int): kotlin/Int // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.historySize|historySize(kotlin.Int){}[0]
     final fun merge(kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult>, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.merge|merge(kotlin.collections.List<com.eignex.kumulant.bandit.contextual.KnnArmResult>;com.eignex.koblas.Workspace?){}[0]
     final fun reset() // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.reset|reset(){}[0]
     final fun snapshot(): kotlin.collections/List<com.eignex.kumulant.bandit.contextual/KnnArmResult> // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.snapshot|snapshot(){}[0]
-    final fun update(kotlin/Int, com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(kotlin/Int, com.eignex.koblas/Vector, kotlin/Double, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.update|update(kotlin.Int;com.eignex.koblas.Vector;kotlin.Double;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion|null[0]
-        final fun squaredL2(com.eignex.koblas/VectorLike, com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.VectorLike;com.eignex.koblas.VectorLike){}[0]
+        final fun squaredL2(com.eignex.koblas/Vector, com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.bandit.contextual/KnnContextualBandit.Companion.squaredL2|squaredL2(com.eignex.koblas.Vector;com.eignex.koblas.Vector){}[0]
     }
 }
 
@@ -2865,7 +2865,7 @@ final class com.eignex.kumulant.schema.runtime/RegressionStatGroup : com.eignex.
         final fun <get-featureSize>(): kotlin/Int // com.eignex.kumulant.schema.runtime/RegressionStatGroup.featureSize.<get-featureSize>|<get-featureSize>(){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/RegressionStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.schema.runtime/RegressionStatGroup.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.schema.runtime/StatGroup : com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.schema/GroupResult>, com.eignex.kumulant.schema.runtime/AbstractStatGroup<com.eignex.kumulant.core/SeriesStat<*>> { // com.eignex.kumulant.schema.runtime/StatGroup|null[0]
@@ -2913,7 +2913,7 @@ final class com.eignex.kumulant.schema.runtime/VectorStatGroup : com.eignex.kumu
     constructor <init>(kotlin/Array<out kotlin/Pair<com.eignex.kumulant.schema/StatKey<*>, com.eignex.kumulant.core/VectorStat<*>>>..., com.eignex.kumulant.core/Concurrency? = ...) // com.eignex.kumulant.schema.runtime/VectorStatGroup.<init>|<init>(kotlin.Array<out|kotlin.Pair<com.eignex.kumulant.schema.StatKey<*>,com.eignex.kumulant.core.VectorStat<*>>>...;com.eignex.kumulant.core.Concurrency?){}[0]
 
     final fun create(com.eignex.kumulant.core/Concurrency?): com.eignex.kumulant.core/VectorStat<com.eignex.kumulant.schema/GroupResult> // com.eignex.kumulant.schema.runtime/VectorStatGroup.create|create(com.eignex.kumulant.core.Concurrency?){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Long, kotlin/Double) // com.eignex.kumulant.schema.runtime/VectorStatGroup.update|update(com.eignex.koblas.Vector;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.schema.spec/Accuracy : com.eignex.kumulant.schema.spec/PairedStatSpec<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.schema.spec/Accuracy|null[0]
@@ -4670,7 +4670,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult : com.eignex.k
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Double = ..., kotlin/IntArray = ..., kotlin/DoubleArray = ..., kotlin/DoubleArray = ...): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.copy|copy(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Double;kotlin.IntArray;kotlin.DoubleArray;kotlin.DoubleArray){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.hashCode|hashCode(){}[0]
-    final fun score(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.VectorLike){}[0]
+    final fun score(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.score|score(com.eignex.koblas.Vector){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult> { // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult.$serializer|null[0]
@@ -4709,7 +4709,7 @@ final class com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat : com.eignex.kum
     final fun merge(com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.merge|merge(com.eignex.kumulant.stat.anomaly.HalfSpaceTreesResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.anomaly/HalfSpaceTreesResult // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.VectorLike;kotlin.Long;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Long, kotlin/Double) // com.eignex.kumulant.stat.anomaly/HalfSpaceTreesStat.update|update(com.eignex.koblas.Vector;kotlin.Long;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.anomaly/QuantileFilterResult : com.eignex.kumulant.core/HasObservationCount { // com.eignex.kumulant.stat.anomaly/QuantileFilterResult|null[0]
@@ -6330,7 +6330,7 @@ final class com.eignex.kumulant.stat.rate/RateStat : com.eignex.kumulant.core/Se
 }
 
 final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult> { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat|null[0]
-    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/VectorLike? = ..., com.eignex.koblas/MatrixLike? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.VectorLike?;com.eignex.koblas.MatrixLike?){}[0]
+    constructor <init>(kotlin/Int, kotlin/Double = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., com.eignex.kumulant.core/Concurrency = ..., com.eignex.koblas/Vector? = ..., com.eignex.koblas/Matrix? = ...) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.<init>|<init>(kotlin.Int;kotlin.Double;com.eignex.kumulant.stat.regression.glm.Link;com.eignex.kumulant.core.Concurrency;com.eignex.koblas.Vector?;com.eignex.koblas.Matrix?){}[0]
 
     final val concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency|{}concurrency[0]
         final fun <get-concurrency>(): com.eignex.kumulant.core/Concurrency // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.concurrency.<get-concurrency>|<get-concurrency>(){}[0]
@@ -6345,7 +6345,7 @@ final class com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 
     final object Companion { // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion|null[0]
         final fun fitPopulationPrior(kotlin.collections/List<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlin/Function1<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin/Double> = ...): com.eignex.kumulant.stat.regression.glm/PopulationPrior // com.eignex.kumulant.stat.regression.glm/BayesianRegressionStat.Companion.fitPopulationPrior|fitPopulationPrior(kotlin.collections.List<com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult>;kotlin.Function1<com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult,kotlin.Double>){}[0]
@@ -6421,7 +6421,7 @@ final class com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat : com
     final fun merge(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/DiagonalRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression { // com.eignex.kumulant.stat.regression.glm/HierarchicalBayesianRegression|null[0]
@@ -6530,7 +6530,7 @@ final class com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult : 
 }
 
 final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult : com.eignex.kumulant.stat.regression.glm/LinearRegressionResult { // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult|null[0]
-    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorLike> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorLike>){}[0]
+    constructor <init>(com.eignex.koblas/DenseVector, kotlin/Double, kotlin/Double, kotlin/Long, com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/Vector> = ...) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.<init>|<init>(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.Vector>){}[0]
 
     final val bias // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias|{}bias[0]
         final fun <get-bias>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.bias.<get-bias>|<get-bias>(){}[0]
@@ -6543,7 +6543,7 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult :
     final val totalWeights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights|{}totalWeights[0]
         final fun <get-totalWeights>(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.totalWeights.<get-totalWeights>|<get-totalWeights>(){}[0]
     final val updaterState // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState|{}updaterState[0]
-        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
+        final fun <get-updaterState>(): kotlin.collections/List<com.eignex.koblas/Vector> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.updaterState.<get-updaterState>|<get-updaterState>(){}[0]
     final val weights // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights|{}weights[0]
         final fun <get-weights>(): com.eignex.koblas/DenseVector // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.weights.<get-weights>|<get-weights>(){}[0]
 
@@ -6553,8 +6553,8 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult :
     final fun component4(): kotlin/Long // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component4|component4(){}[0]
     final fun component5(): com.eignex.kumulant.stat.regression.glm/Link // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component5|component5(){}[0]
     final fun component6(): kotlin/Double // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
-    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/VectorLike> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.VectorLike>){}[0]
+    final fun component7(): kotlin.collections/List<com.eignex.koblas/Vector> // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.component7|component7(){}[0]
+    final fun copy(com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Long = ..., com.eignex.kumulant.stat.regression.glm/Link = ..., kotlin/Double = ..., kotlin.collections/List<com.eignex.koblas/Vector> = ...): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.copy|copy(com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double;kotlin.Long;com.eignex.kumulant.stat.regression.glm.Link;kotlin.Double;kotlin.collections.List<com.eignex.koblas.Vector>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult.toString|toString(){}[0]
@@ -6603,7 +6603,7 @@ final class com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat : c
     final fun merge(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.glm/StochasticRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult : com.eignex.kumulant.core/HasRegression, com.eignex.kumulant.core/HasSlope, com.eignex.kumulant.core/Result { // com.eignex.kumulant.stat.regression.glm/UnivariateRegressionResult|null[0]
@@ -6765,7 +6765,7 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode : c
         final fun <get-pos>(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<get-pos>|<get-pos>(){}[0]
         final fun <set-pos>(com.eignex.kumulant.stat.regression.tree/ClassificationNode) // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.pos.<set-pos>|<set-pos>(com.eignex.kumulant.stat.regression.tree.ClassificationNode){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationSplitNode.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf : com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode { // com.eignex.kumulant.stat.regression.tree/ClassificationTerminalLeaf|null[0]
@@ -6781,16 +6781,16 @@ final class com.eignex.kumulant.stat.regression.tree/ClassificationTree { // com
     final val nodeCount // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount|{}nodeCount[0]
         final fun <get-nodeCount>(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.nodeCount.<get-nodeCount>|<get-nodeCount>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun merge(com.eignex.kumulant.stat.regression.tree/ClassificationTree) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.merge|merge(com.eignex.kumulant.stat.regression.tree.ClassificationTree){}[0]
     final fun mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.mergeSnapshot|mergeSnapshot(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.koblas.Workspace?){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ClassificationTree.predict|predict(com.eignex.koblas.Vector){}[0]
     final fun prettyPrint(kotlin/String = ...): kotlin/String // com.eignex.kumulant.stat.regression.tree/ClassificationTree.prettyPrint|prettyPrint(kotlin.String){}[0]
-    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
+    final fun probabilities(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ClassificationTree.probabilities|probabilities(com.eignex.koblas.Vector){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/ClassificationTree.reset|reset(){}[0]
     final fun rootNode(): com.eignex.kumulant.stat.regression.tree/ClassificationNode // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootNode|rootNode(){}[0]
     final fun rootSnapshot(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/ClassificationTree.rootSnapshot|rootSnapshot(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.VectorLike;kotlin.Int;kotlin.Double){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Int, kotlin/Double = ...) // com.eignex.kumulant.stat.regression.tree/ClassificationTree.update|update(com.eignex.koblas.Vector;kotlin.Int;kotlin.Double){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/ClassificationTreeConfig|null[0]
@@ -6867,7 +6867,7 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.reset|reset(){}[0]
     final fun tree(): com.eignex.kumulant.stat.regression.tree/ClassificationTree // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeClassifierStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat|null[0]
@@ -6886,8 +6886,8 @@ final class com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.reset|reset(){}[0]
-    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun tree(): com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/Vector> // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.tree|tree(){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/DecisionTreeRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumulant.stat.regression.tree/SerializableSplit { // com.eignex.kumulant.stat.regression.tree/ExprSplit|null[0]
@@ -6898,7 +6898,7 @@ final class com.eignex.kumulant.stat.regression.tree/ExprSplit : com.eignex.kumu
 
     final fun component1(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.stat.regression.tree/ExprSplit.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.schema.expr/BoolExpr = ...): com.eignex.kumulant.stat.regression.tree/ExprSplit // com.eignex.kumulant.stat.regression.tree/ExprSplit.copy|copy(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-    final fun direction(com.eignex.koblas/VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.VectorLike){}[0]
+    final fun direction(com.eignex.koblas/Vector): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.direction|direction(com.eignex.koblas.Vector){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ExprSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ExprSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ExprSplit.toString|toString(){}[0]
@@ -6934,8 +6934,8 @@ final class com.eignex.kumulant.stat.regression.tree/ForestClassificationResult 
     final fun copy(kotlin/Int = ..., kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.copy|copy(kotlin.Int;kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeClassificationResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
-    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.predict|predict(com.eignex.koblas.Vector){}[0]
+    final fun probabilities(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.probabilities|probabilities(com.eignex.koblas.Vector){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestClassificationResult> { // com.eignex.kumulant.stat.regression.tree/ForestClassificationResult.$serializer|null[0]
@@ -6965,9 +6965,9 @@ final class com.eignex.kumulant.stat.regression.tree/ForestRegressionResult : co
     final fun component1(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.component1|component1(){}[0]
     final fun copy(kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> = ...): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.copy|copy(kotlin.collections.List<com.eignex.kumulant.stat.regression.tree.TreeRegressionResult>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeafMerged(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeafMerged(com.eignex.koblas/Vector): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.findLeafMerged|findLeafMerged(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.predict|predict(com.eignex.koblas.Vector){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/ForestRegressionResult.$serializer|null[0]
@@ -7009,7 +7009,7 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat 
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestClassificationResult // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.reset|reset(){}[0]
     final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/ClassificationTree> // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestClassifierStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat : com.eignex.kumulant.core/RegressionStat<com.eignex.kumulant.stat.regression.tree/ForestRegressionResult> { // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat|null[0]
@@ -7032,8 +7032,8 @@ final class com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat 
     final fun merge(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression.tree/ForestRegressionResult // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.reset|reset(){}[0]
-    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun trees(): kotlin.collections/List<com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/Vector>> // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.trees|trees(){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression.tree/RandomForestRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig : com.eignex.kumulant.stat.regression.tree/HoeffdingTreeConfig { // com.eignex.kumulant.stat.regression.tree/RegressionTreeConfig|null[0]
@@ -7122,7 +7122,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior : c
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonForestPosterior.toString|toString(){}[0]
 }
@@ -7139,7 +7139,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior : com
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThompsonTreePosterior.toString|toString(){}[0]
 }
@@ -7155,7 +7155,7 @@ final class com.eignex.kumulant.stat.regression.tree/ThresholdSplit : com.eignex
     final fun component1(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component1|component1(){}[0]
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.component2|component2(){}[0]
     final fun copy(kotlin/Int = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/ThresholdSplit // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.copy|copy(kotlin.Int;kotlin.Double){}[0]
-    final fun direction(com.eignex.koblas/VectorLike): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.VectorLike){}[0]
+    final fun direction(com.eignex.koblas/Vector): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.direction|direction(com.eignex.koblas.Vector){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/ThresholdSplit.toString|toString(){}[0]
@@ -7183,7 +7183,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResul
     final fun component1(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.copy|copy(com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationLeafResult.toString|toString(){}[0]
 
@@ -7214,10 +7214,10 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationResult : 
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
-    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.predict|predict(com.eignex.koblas.Vector){}[0]
+    final fun probabilities(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.probabilities|probabilities(com.eignex.koblas.Vector){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeClassificationResult> { // com.eignex.kumulant.stat.regression.tree/TreeClassificationResult.$serializer|null[0]
@@ -7254,7 +7254,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResu
     final fun component4(): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeClassificationNodeResult = ..., com.eignex.kumulant.stat.regression.tree/ClassCountsResult = ...): com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.TreeClassificationNodeResult;com.eignex.kumulant.stat.regression.tree.ClassCountsResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassCountsResult // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeClassificationSplitResult.toString|toString(){}[0]
 
@@ -7283,7 +7283,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeLeafResult : com.eignex
     final fun component1(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeLeafResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.copy|copy(com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeLeafResult.toString|toString(){}[0]
 
@@ -7314,9 +7314,9 @@ final class com.eignex.kumulant.stat.regression.tree/TreeRegressionResult : com.
     final fun component1(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.component1|component1(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ...): com.eignex.kumulant.stat.regression.tree/TreeRegressionResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.copy|copy(com.eignex.kumulant.stat.regression.tree.TreeNodeResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.hashCode|hashCode(){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Double // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.predict|predict(com.eignex.koblas.Vector){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression.tree/TreeRegressionResult> { // com.eignex.kumulant.stat.regression.tree/TreeRegressionResult.$serializer|null[0]
@@ -7353,7 +7353,7 @@ final class com.eignex.kumulant.stat.regression.tree/TreeSplitResult : com.eigne
     final fun component4(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.component4|component4(){}[0]
     final fun copy(com.eignex.kumulant.stat.regression.tree/SerializableSplit = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.regression.tree/TreeNodeResult = ..., com.eignex.kumulant.stat.summary/WeightedVarianceResult = ...): com.eignex.kumulant.stat.regression.tree/TreeSplitResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.copy|copy(com.eignex.kumulant.stat.regression.tree.SerializableSplit;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.kumulant.stat.summary.WeightedVarianceResult){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.equals|equals(kotlin.Any?){}[0]
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/TreeSplitResult.toString|toString(){}[0]
 
@@ -7385,7 +7385,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbForestPosterior : com.ei
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbForestPosterior // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbForestPosterior.toString|toString(){}[0]
 }
@@ -7402,7 +7402,7 @@ final class com.eignex.kumulant.stat.regression.tree/UcbTreePosterior : com.eign
     final fun component2(): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.component2|component2(){}[0]
     final fun copy(kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression.tree/UcbTreePosterior // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.copy|copy(kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/UcbTreePosterior.toString|toString(){}[0]
 }
@@ -7532,12 +7532,12 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult : com.e
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.hashCode|hashCode(){}[0]
-    final fun logPosterior(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
-    final fun logPosteriorsInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosteriorsInto|logPosteriorsInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
-    final fun predict(com.eignex.koblas/VectorLike): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.VectorLike){}[0]
+    final fun logPosterior(com.eignex.koblas/Vector, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosterior|logPosterior(com.eignex.koblas.Vector;kotlin.Int){}[0]
+    final fun logPosteriorsInto(com.eignex.koblas/Vector, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.logPosteriorsInto|logPosteriorsInto(com.eignex.koblas.Vector;kotlin.DoubleArray){}[0]
+    final fun predict(com.eignex.koblas/Vector): kotlin/Int // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.predict|predict(com.eignex.koblas.Vector){}[0]
     final fun prior(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.prior|prior(kotlin.Int){}[0]
-    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
-    final fun probabilitiesInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
+    final fun probabilities(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilities|probabilities(com.eignex.koblas.Vector){}[0]
+    final fun probabilitiesInto(com.eignex.koblas/Vector, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.Vector;kotlin.DoubleArray){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult> { // com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult.$serializer|null[0]
@@ -7566,7 +7566,7 @@ final class com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat : com.eig
     final fun merge(com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.merge|merge(com.eignex.kumulant.stat.regression.GaussianNaiveBayesResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/GaussianNaiveBayesResult // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/GaussianNaiveBayesStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.regression/RmspropOptimizer : com.eignex.kumulant.stat.regression/Optimizer { // com.eignex.kumulant.stat.regression/RmspropOptimizer|null[0]
@@ -7629,11 +7629,11 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionResult : com.ei
     final fun copy(kotlin/Int = ..., kotlin/Int = ..., com.eignex.koblas/DenseMatrix = ..., com.eignex.koblas/DenseVector = ..., kotlin/Double = ..., kotlin/Long = ..., kotlin/Double = ...): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.copy|copy(kotlin.Int;kotlin.Int;com.eignex.koblas.DenseMatrix;com.eignex.koblas.DenseVector;kotlin.Double;kotlin.Long;kotlin.Double){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.hashCode|hashCode(){}[0]
-    final fun logit(com.eignex.koblas/VectorLike, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.VectorLike;kotlin.Int){}[0]
-    final fun logitsInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logitsInto|logitsInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
-    final fun predict(com.eignex.koblas/VectorLike, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.VectorLike;com.eignex.koblas.Workspace?){}[0]
-    final fun probabilities(com.eignex.koblas/VectorLike): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.VectorLike){}[0]
-    final fun probabilitiesInto(com.eignex.koblas/VectorLike, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.VectorLike;kotlin.DoubleArray){}[0]
+    final fun logit(com.eignex.koblas/Vector, kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logit|logit(com.eignex.koblas.Vector;kotlin.Int){}[0]
+    final fun logitsInto(com.eignex.koblas/Vector, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.logitsInto|logitsInto(com.eignex.koblas.Vector;kotlin.DoubleArray){}[0]
+    final fun predict(com.eignex.koblas/Vector, com.eignex.koblas/Workspace? = ...): kotlin/Int // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.predict|predict(com.eignex.koblas.Vector;com.eignex.koblas.Workspace?){}[0]
+    final fun probabilities(com.eignex.koblas/Vector): kotlin/DoubleArray // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilities|probabilities(com.eignex.koblas.Vector){}[0]
+    final fun probabilitiesInto(com.eignex.koblas/Vector, kotlin/DoubleArray) // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.probabilitiesInto|probabilitiesInto(com.eignex.koblas.Vector;kotlin.DoubleArray){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.eignex.kumulant.stat.regression/SoftmaxRegressionResult> { // com.eignex.kumulant.stat.regression/SoftmaxRegressionResult.$serializer|null[0]
@@ -7674,7 +7674,7 @@ final class com.eignex.kumulant.stat.regression/SoftmaxRegressionStat : com.eign
     final fun merge(com.eignex.kumulant.stat.regression/SoftmaxRegressionResult, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.merge|merge(com.eignex.kumulant.stat.regression.SoftmaxRegressionResult;com.eignex.koblas.Workspace?){}[0]
     final fun read(kotlin/Long): com.eignex.kumulant.stat.regression/SoftmaxRegressionResult // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.read|read(kotlin.Long){}[0]
     final fun reset() // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.reset|reset(){}[0]
-    final fun update(com.eignex.koblas/VectorLike, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.VectorLike;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun update(com.eignex.koblas/Vector, kotlin/Double, kotlin/Long, kotlin/Double, com.eignex.koblas/Workspace?) // com.eignex.kumulant.stat.regression/SoftmaxRegressionStat.update|update(com.eignex.koblas.Vector;kotlin.Double;kotlin.Long;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
 }
 
 final class com.eignex.kumulant.stat.score/AccuracyStat : com.eignex.kumulant.core/PairedStat<com.eignex.kumulant.stat.summary/WeightedMeanResult> { // com.eignex.kumulant.stat.score/AccuracyStat|null[0]
@@ -8855,7 +8855,7 @@ sealed class com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode : c
     abstract val arm // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm|{}arm[0]
         abstract fun <get-arm>(): com.eignex.kumulant.core/SeriesStat<com.eignex.kumulant.stat.regression.tree/ClassCountsResult> // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.arm.<get-arm>|<get-arm>(){}[0]
 
-    final fun findLeaf(com.eignex.koblas/VectorLike): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.VectorLike){}[0]
+    final fun findLeaf(com.eignex.koblas/Vector): com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode // com.eignex.kumulant.stat.regression.tree/ClassificationLeafNode.findLeaf|findLeaf(com.eignex.koblas.Vector){}[0]
 }
 
 final object com.eignex.kumulant.bandit.univariate/BetaPosterior : com.eignex.kumulant.bandit.univariate/Posterior<com.eignex.kumulant.stat.summary/BernoulliSumResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.bandit.univariate/BetaPosterior|null[0]
@@ -9187,9 +9187,9 @@ final object com.eignex.kumulant.schema.spec/Variance : com.eignex.kumulant.sche
 
 final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/DiagonalRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.DiagonalRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/FactorisedGaussian> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/FactorisedGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9198,9 +9198,9 @@ final object com.eignex.kumulant.stat.regression.glm/FactorisedGaussian : com.ei
 
 final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/LinUcb|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/LinUcb.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/LinUcb.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/LinUcb.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/LinUcb.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/LinUcb.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/LinUcb> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/LinUcb.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9209,9 +9209,9 @@ final object com.eignex.kumulant.stat.regression.glm/LinUcb : com.eignex.kumulan
 
 final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sample|sample(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/PrecisionRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.PrecisionRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/MultivariateGaussian> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/MultivariateGaussian.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9220,9 +9220,9 @@ final object com.eignex.kumulant.stat.regression.glm/MultivariateGaussian : com.
 
 final object com.eignex.kumulant.stat.regression.glm/PointPosterior : com.eignex.kumulant.stat.regression.glm/LinearPosterior<com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult>, kotlinx.serialization.internal/SerializerFactory { // com.eignex.kumulant.stat.regression.glm/PointPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.glm/PointPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.glm/PointPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.glm/PointPosterior.hashCode|hashCode(){}[0]
-    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/VectorLike // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
+    final fun sample(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/Double): com.eignex.koblas/Vector // com.eignex.kumulant.stat.regression.glm/PointPosterior.sample|sample(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.Double){}[0]
     final fun sampleInto(com.eignex.kumulant.stat.regression.glm/StochasticRegressionResult, kotlin.random/Random, kotlin/DoubleArray, kotlin/Double) // com.eignex.kumulant.stat.regression.glm/PointPosterior.sampleInto|sampleInto(com.eignex.kumulant.stat.regression.glm.StochasticRegressionResult;kotlin.random.Random;kotlin.DoubleArray;kotlin.Double){}[0]
     final fun serializer(): kotlinx.serialization/KSerializer<com.eignex.kumulant.stat.regression.glm/PointPosterior> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(){}[0]
     final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.eignex.kumulant.stat.regression.glm/PointPosterior.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -9249,14 +9249,14 @@ final object com.eignex.kumulant.stat.regression.tree/InformationGain : com.eign
 
 final object com.eignex.kumulant.stat.regression.tree/MeanForestPosterior : com.eignex.kumulant.stat.regression.tree/ForestPosterior { // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/ForestRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.ForestRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanForestPosterior.toString|toString(){}[0]
 }
 
 final object com.eignex.kumulant.stat.regression.tree/MeanTreePosterior : com.eignex.kumulant.stat.regression.tree/TreePosterior { // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.equals|equals(kotlin.Any?){}[0]
-    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/VectorLike, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.VectorLike;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
+    final fun evaluate(com.eignex.kumulant.stat.regression.tree/TreeRegressionResult, com.eignex.koblas/Vector, kotlin.random/Random, kotlin/Double, com.eignex.koblas/Workspace?): kotlin/Double // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.evaluate|evaluate(com.eignex.kumulant.stat.regression.tree.TreeRegressionResult;com.eignex.koblas.Vector;kotlin.random.Random;kotlin.Double;com.eignex.koblas.Workspace?){}[0]
     final fun hashCode(): kotlin/Int // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.eignex.kumulant.stat.regression.tree/MeanTreePosterior.toString|toString(){}[0]
 }
@@ -9288,7 +9288,7 @@ final fun (com.eignex.kumulant.bandit.univariate/RouletteWheelSpec).com.eignex.k
 final fun (com.eignex.kumulant.bandit.univariate/UnivariateBanditSpec).com.eignex.kumulant.bandit/materialize(kotlin.random/Random = ...): com.eignex.kumulant.bandit/Bandit // com.eignex.kumulant.bandit/materialize|materialize@com.eignex.kumulant.bandit.univariate.UnivariateBanditSpec(kotlin.random.Random){}[0]
 final fun (com.eignex.kumulant.core/Concurrency).com.eignex.kumulant.stream/lock(): com.eignex.kumulant.stream/Mutex // com.eignex.kumulant.stream/lock|lock@com.eignex.kumulant.core.Concurrency(){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/and(com.eignex.kumulant.schema.expr/BoolExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/and|and@com.eignex.kumulant.schema.expr.BoolExpr(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
-final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Boolean // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.BoolExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/Vector, com.eignex.kumulant.core/Result? = ...): kotlin/Boolean // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.BoolExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.Vector;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/not(): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/not|not@com.eignex.kumulant.schema.expr.BoolExpr(){}[0]
 final fun (com.eignex.kumulant.schema.expr/BoolExpr).com.eignex.kumulant.schema.expr/or(com.eignex.kumulant.schema.expr/BoolExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/or|or@com.eignex.kumulant.schema.expr.BoolExpr(com.eignex.kumulant.schema.expr.BoolExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/abs(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/abs|abs@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
@@ -9296,7 +9296,7 @@ final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schem
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/div(kotlin/Double): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/div|div@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eq(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/eq|eq@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eq(kotlin/Double): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/eq|eq@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
-final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/Double // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/Vector, com.eignex.kumulant.core/Result? = ...): kotlin/Double // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.Vector;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/exp(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/exp|exp@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/ge(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/ge|ge@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/ge(kotlin/Double): com.eignex.kumulant.schema.expr/BoolExpr // com.eignex.kumulant.schema.expr/ge|ge@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
@@ -9324,7 +9324,7 @@ final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schem
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/times(com.eignex.kumulant.schema.expr/ScalarExpr): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/times|times@com.eignex.kumulant.schema.expr.ScalarExpr(com.eignex.kumulant.schema.expr.ScalarExpr){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/times(kotlin/Double): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/times|times@com.eignex.kumulant.schema.expr.ScalarExpr(kotlin.Double){}[0]
 final fun (com.eignex.kumulant.schema.expr/ScalarExpr).com.eignex.kumulant.schema.expr/unaryMinus(): com.eignex.kumulant.schema.expr/ScalarExpr // com.eignex.kumulant.schema.expr/unaryMinus|unaryMinus@com.eignex.kumulant.schema.expr.ScalarExpr(){}[0]
-final fun (com.eignex.kumulant.schema.expr/VectorExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/VectorLike, com.eignex.kumulant.core/Result? = ...): kotlin/DoubleArray // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.VectorExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.VectorLike;com.eignex.kumulant.core.Result?){}[0]
+final fun (com.eignex.kumulant.schema.expr/VectorExpr).com.eignex.kumulant.schema.expr/eval(kotlin/Double = ..., kotlin/Double = ..., com.eignex.koblas/Vector, com.eignex.kumulant.core/Result? = ...): kotlin/DoubleArray // com.eignex.kumulant.schema.expr/eval|eval@com.eignex.kumulant.schema.expr.VectorExpr(kotlin.Double;kotlin.Double;com.eignex.koblas.Vector;com.eignex.kumulant.core.Result?){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materialize(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, *, *>> // com.eignex.kumulant.schema.runtime/materialize|materialize@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializeDiscrete(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/DiscreteStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializeDiscrete|materializeDiscrete@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
 final fun (com.eignex.kumulant.schema.runtime/StatSchemaDef).com.eignex.kumulant.schema.runtime/materializePaired(com.eignex.kumulant.core/Concurrency = ...): kotlin.collections/List<com.eignex.kumulant.schema.runtime/BoundStat<*, out com.eignex.kumulant.core/PairedStat<*>, *>> // com.eignex.kumulant.schema.runtime/materializePaired|materializePaired@com.eignex.kumulant.schema.runtime.StatSchemaDef(com.eignex.kumulant.core.Concurrency){}[0]
@@ -9340,8 +9340,8 @@ final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.k
 final fun (com.eignex.kumulant.stat.quantile/SparseHistogramResult).com.eignex.kumulant.stat.score/pitKsDistance(kotlin/Int): kotlin/Double // com.eignex.kumulant.stat.score/pitKsDistance|pitKsDistance@com.eignex.kumulant.stat.quantile.SparseHistogramResult(kotlin.Int){}[0]
 final fun (com.eignex.kumulant.stat.quantile/TDigestResult).com.eignex.kumulant.stat.quantile/toSparseHistogram(): com.eignex.kumulant.stat.quantile/SparseHistogramResult // com.eignex.kumulant.stat.quantile/toSparseHistogram|toSparseHistogram@com.eignex.kumulant.stat.quantile.TDigestResult(){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<*>).com.eignex.kumulant.stat.regression.tree/aggregate(): com.eignex.kumulant.stat.summary/WeightedVarianceResult // com.eignex.kumulant.stat.regression.tree/aggregate|aggregate@com.eignex.kumulant.stat.regression.tree.RegressionNode<*>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/VectorLike>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.VectorLike>(){}[0]
-final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/VectorLike>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.VectorLike>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.koblas.Workspace?){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionNode<com.eignex.koblas/Vector>).com.eignex.kumulant.stat.regression.tree/snapshot(): com.eignex.kumulant.stat.regression.tree/TreeNodeResult // com.eignex.kumulant.stat.regression.tree/snapshot|snapshot@com.eignex.kumulant.stat.regression.tree.RegressionNode<com.eignex.koblas.Vector>(){}[0]
+final fun (com.eignex.kumulant.stat.regression.tree/RegressionTree<com.eignex.koblas/Vector>).com.eignex.kumulant.stat.regression.tree/mergeSnapshot(com.eignex.kumulant.stat.regression.tree/TreeNodeResult, com.eignex.koblas/Workspace? = ...) // com.eignex.kumulant.stat.regression.tree/mergeSnapshot|mergeSnapshot@com.eignex.kumulant.stat.regression.tree.RegressionTree<com.eignex.koblas.Vector>(com.eignex.kumulant.stat.regression.tree.TreeNodeResult;com.eignex.koblas.Workspace?){}[0]
 final fun (com.eignex.kumulant.stat.regression.tree/SplitMetric).com.eignex.kumulant.stat.regression.tree/rank(com.eignex.kumulant.stat.summary/WeightedVarianceResult, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin.collections/List<com.eignex.kumulant.stat.summary/WeightedVarianceResult>, kotlin/Double, kotlin/Double): com.eignex.kumulant.stat.regression.tree/SplitInfo // com.eignex.kumulant.stat.regression.tree/rank|rank@com.eignex.kumulant.stat.regression.tree.SplitMetric(com.eignex.kumulant.stat.summary.WeightedVarianceResult;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.collections.List<com.eignex.kumulant.stat.summary.WeightedVarianceResult>;kotlin.Double;kotlin.Double){}[0]
 final fun (com.eignex.kumulant.stat.sketch/BloomFilterResult).com.eignex.kumulant.stat.sketch/contains(kotlin/Long): kotlin/Boolean // com.eignex.kumulant.stat.sketch/contains|contains@com.eignex.kumulant.stat.sketch.BloomFilterResult(kotlin.Long){}[0]
 final fun (com.eignex.kumulant.stat.sketch/CountMinSketchResult).com.eignex.kumulant.stat.sketch/estimate(kotlin/Long): kotlin/Long // com.eignex.kumulant.stat.sketch/estimate|estimate@com.eignex.kumulant.stat.sketch.CountMinSketchResult(kotlin.Long){}[0]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
@@ -109,7 +109,7 @@ interface UnivariateBandit : Bandit {
  *
  * The standard contextual lifecycle:
  *
- * 1. Caller observes `x: VectorLike` (e.g. a user feature vector).
+ * 1. Caller observes `x: Vector` (e.g. a user feature vector).
  * 2. Caller calls [choose] with `x`; the bandit picks an arm by combining
  *    the per-arm model with the context.
  * 3. Caller plays the arm and observes a reward.
@@ -133,14 +133,14 @@ interface ContextualBandit : Bandit {
      * configurable [com.eignex.kumulant.stat.regression.RegressionPosterior]
      * (or analogue) and returns the argmax / sampled choice.
      */
-    fun choose(x: VectorLike, workspace: Workspace? = null): Int
+    fun choose(x: Vector, workspace: Workspace? = null): Int
 
     /**
      * Fold a single `(x, reward)` observation into the arm at [armIndex].
      * The `weight` is the same observation-weight running through the
      * library; typically `1.0`, occasionally importance-weighted.
      */
-    fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double = 1.0, workspace: Workspace? = null)
+    fun update(armIndex: Int, x: Vector, reward: Double, weight: Double = 1.0, workspace: Workspace? = null)
 }
 
 /**
@@ -242,5 +242,5 @@ interface Scorable {
  */
 interface ContextualScorable {
     /** Score the arm at [armIndex] under the current state and context [x]. */
-    fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace? = null): Double
+    fun evaluate(armIndex: Int, x: Vector, workspace: Workspace? = null): Double
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/BanditFactory.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bandit.contextual.ContextualBanditSpec
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.KnnContextualSpec
@@ -183,7 +183,7 @@ fun RegressionContextualSpec.materialize(
 }
 
 /** Resolve a wire-named distance metric to the function that computes it. */
-private fun KnnDistance.resolve(): (VectorLike, VectorLike) -> Double = when (this) {
+private fun KnnDistance.resolve(): (Vector, Vector) -> Double = when (this) {
     KnnDistance.SquaredL2 -> KnnContextualBandit.Companion::squaredL2
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/Tracked.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -89,7 +89,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
         @Suppress("UNCHECKED_CAST")
         (updateArmRewardTemplate?.create(null) as PairedStat<Result>?)
 
-    override fun choose(x: VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
+    override fun choose(x: Vector, workspace: com.eignex.koblas.Workspace?): Int {
         x.requireFeatureSize(contextFeatureSize)
         val i = inner.choose(x, workspace)
         chooseStat?.update(x, i.toDouble(), nowNanos(), 1.0, workspace)
@@ -98,7 +98,7 @@ class TrackedContextualBandit<B : ContextualBandit>(
 
     override fun update(
         armIndex: Int,
-        x: VectorLike,
+        x: Vector,
         reward: Double,
         weight: Double,
         workspace: com.eignex.koblas.Workspace?,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/Exp4Bandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.MIN_PLAY_PROB
 import com.eignex.kumulant.bandit.Snapshotable
@@ -44,7 +44,7 @@ data class Exp4State(
  */
 fun interface Exp4Expert {
     /** Distribution over arms for [x]. Result must sum to 1 and have length `nbrArms`. */
-    fun advise(x: VectorLike, nbrArms: Int): DoubleArray
+    fun advise(x: Vector, nbrArms: Int): DoubleArray
 }
 
 /**
@@ -128,7 +128,7 @@ class Exp4Bandit(
     private val pendingPulls = IntArray(nbrArms)
 
     /** Build the round's play distribution and sample an arm. */
-    override fun choose(x: VectorLike, workspace: com.eignex.koblas.Workspace?): Int {
+    override fun choose(x: Vector, workspace: com.eignex.koblas.Workspace?): Int {
         playDistributionInto(x, lastDistribution)
         val chosen = random.sampleFromDistribution(lastDistribution)
         pendingPropensity[chosen] = lastDistribution[chosen]
@@ -138,7 +138,7 @@ class Exp4Bandit(
 
     /** Mean of expert distributions at [x] weighted by current weights, blended with
      *  uniform exploration via [gamma]. */
-    fun playDistribution(x: VectorLike): DoubleArray = DoubleArray(nbrArms).also {
+    fun playDistribution(x: Vector): DoubleArray = DoubleArray(nbrArms).also {
         playDistributionInto(x, it)
     }
 
@@ -149,7 +149,7 @@ class Exp4Bandit(
      *
      * The destination is caller-owned. It is not retained after this method returns.
      */
-    fun playDistributionInto(x: VectorLike, out: DoubleArray) {
+    fun playDistributionInto(x: Vector, out: DoubleArray) {
         require(out.size == nbrArms) { "out has ${out.size} probs, expected $nbrArms" }
         var wSum = 0.0
         for (i in experts.indices) {
@@ -178,7 +178,7 @@ class Exp4Bandit(
     /** Fold a `(context, reward)` observation back into the expert weights. */
     override fun update(
         armIndex: Int,
-        x: VectorLike,
+        x: Vector,
         reward: Double,
         weight: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -207,7 +207,7 @@ class Exp4Bandit(
      * Falls back to the distribution at [x] when the caller updates an arm it never chose, which is
      * the best available estimate and what an off-policy caller implicitly asks for.
      */
-    private fun propensityOf(armIndex: Int, x: VectorLike): Double {
+    private fun propensityOf(armIndex: Int, x: Vector): Double {
         if (pendingPulls[armIndex] <= 0) {
             playDistributionInto(x, lastDistribution)
             return lastDistribution[armIndex]

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBandit.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.bandit.contextual
 
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.VectorStorage
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.forEachStored
@@ -34,7 +34,7 @@ import kotlin.random.Random
 @Serializable
 @SerialName("KnnArmResult")
 data class KnnArmResult(
-    /** Retained contexts (each a copy of the submitted [VectorLike]). */
+    /** Retained contexts (each a copy of the submitted [Vector]). */
     val contexts: List<DoubleArray>,
     /** Per-sample rewards, parallel to [contexts]. */
     val rewards: DoubleArray,
@@ -132,7 +132,7 @@ class KnnContextualBandit(
     /** UCB-style exploration scale on `sqrt(ln(totalSteps) / armWeight)`; `0.0` disables. */
     val exploration: Double = 1.0,
     /** Pairwise distance between context vectors; defaults to squared L2. */
-    val distance: (VectorLike, VectorLike) -> Double = ::squaredL2,
+    val distance: (Vector, Vector) -> Double = ::squaredL2,
     /** Single source of randomness; used only for tie-breaking, currently deterministic. */
     override val random: Random = Random.Default,
 ) : ContextualBandit,
@@ -179,7 +179,7 @@ class KnnContextualBandit(
      * there is no scratch left to borrow.
      */
     @Suppress("UnusedParameter")
-    override fun choose(x: VectorLike, workspace: Workspace?): Int {
+    override fun choose(x: Vector, workspace: Workspace?): Int {
         requireFeatureSize(x.size)
         val bestIdx = argmaxArm(nbrArms) { armIndex -> score(armIndex, x) }
         step++
@@ -192,14 +192,14 @@ class KnnContextualBandit(
      * [workspace] is accepted for interface uniformity and ignored, as in [choose].
      */
     @Suppress("UnusedParameter")
-    override fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace?): Double {
+    override fun evaluate(armIndex: Int, x: Vector, workspace: Workspace?): Double {
         requireArmIndex(armIndex, nbrArms)
         requireFeatureSize(x.size)
         return score(armIndex, x)
     }
 
     /** Append `(x, reward, weight)` to arm [armIndex]'s history; oldest entry drops if full. */
-    override fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
+    override fun update(armIndex: Int, x: Vector, reward: Double, weight: Double, workspace: Workspace?) {
         requireArmIndex(armIndex, nbrArms)
         // An inert observation must not consume a history slot; the eviction below would drop real data.
         // A negative weight drops for the same reason rather than downdating: a bounded history has no
@@ -266,12 +266,12 @@ class KnnContextualBandit(
         return exploration * sqrt(ln(t) / w)
     }
 
-    private fun score(armIndex: Int, x: VectorLike): Double {
+    private fun score(armIndex: Int, x: Vector): Double {
         if (histories[armIndex].size < k) return coldStartScore + ucbBonus(armIndex)
         return knnMean(armIndex, x) + ucbBonus(armIndex)
     }
 
-    private fun knnMean(armIndex: Int, x: VectorLike): Double {
+    private fun knnMean(armIndex: Int, x: Vector): Double {
         val history = histories[armIndex]
         // Linear scan holding the k nearest seen so far. For typical maxHistoryPerArm values
         // (<= a few thousand) this is faster than maintaining a KD-tree under reweights.
@@ -325,7 +325,7 @@ class KnnContextualBandit(
          * stored entries and accumulates dense-only contributions via a baseline
          * pass; sparse/sparse iterates the union of stored indices on both sides.
          */
-        fun squaredL2(a: VectorLike, b: VectorLike): Double {
+        fun squaredL2(a: Vector, b: Vector): Double {
             require(a.size == b.size) { "size mismatch: ${a.size} vs ${b.size}" }
             return when {
                 a is DenseVector && b is DenseVector -> denseSquaredL2(a, b)
@@ -337,9 +337,9 @@ class KnnContextualBandit(
         }
 
         private fun denseSquaredL2(a: DenseVector, b: DenseVector): Double =
-            koblas.kernels.ssqd(a.data, 0, b.data, 0, a.size)
+            koblas.vectorKernels.ssqd(a.data, 0, b.data, 0, a.size)
 
-        private fun genericSquaredL2(a: VectorLike, b: VectorLike): Double {
+        private fun genericSquaredL2(a: Vector, b: Vector): Double {
             var s = 0.0
             for (i in 0 until a.size) {
                 val d = a[i] - b[i]
@@ -348,7 +348,7 @@ class KnnContextualBandit(
             return s
         }
 
-        private fun mixedSquaredL2(sparse: SparseVector, dense: VectorLike): Double {
+        private fun mixedSquaredL2(sparse: SparseVector, dense: Vector): Double {
             // Start from the dense side's full squared norm, then correct the sparse-indexed
             // entries to use (sparse_v - dense_v)^2 instead of dense_v^2.
             var s = 0.0
@@ -421,7 +421,7 @@ class KnnContextualBandit(
 //
 // Contexts stay in koblas storages rather than one flat buffer because koblas has no dense vector
 // over an (array, offset, length) slice: a window type declared here would be a third implementation
-// of VectorLike, which drops the scan out of squaredL2's dense/dense branch onto its generic one
+// of Vector, which drops the scan out of squaredL2's dense/dense branch onto its generic one
 // and costs more per choose than the flat layout saves per update.
 private class ArmHistory(private val capacity: Int) {
     var size: Int = 0
@@ -438,13 +438,13 @@ private class ArmHistory(private val capacity: Int) {
     fun weight(age: Int): Double = weights[slotOf(age)]
 
     /** The stored context at [age], oldest first. */
-    fun context(age: Int): VectorLike = contexts[slotOf(age)]!!
+    fun context(age: Int): Vector = contexts[slotOf(age)]!!
 
     /** The stored context at [age], densified into an array that outlives the slot. */
     fun contextCopy(age: Int): DoubleArray = contexts[slotOf(age)]!!.toDoubleArray()
 
     /** Admits `(x, reward, weight)` and returns the weight of the sample it evicted, `0.0` if none. */
-    fun add(x: VectorLike, reward: Double, weight: Double): Double {
+    fun add(x: Vector, reward: Double, weight: Double): Double {
         val slot: Int
         var dropped = 0.0
         if (size == capacity) {
@@ -476,7 +476,7 @@ private class ArmHistory(private val capacity: Int) {
 // The copy of x an arm keeps, reusing the dense buffer already in the slot when the widths agree so a
 // saturated arm evicts without allocating. A sparse sample always takes a fresh copy: its stored
 // length tracks the sample rather than the feature width, and the caller keeps arrays it may mutate.
-private fun retain(slot: VectorStorage?, x: VectorLike): VectorStorage {
+private fun retain(slot: VectorStorage?, x: Vector): VectorStorage {
     if (x is SparseVector) return SparseVector.wrap(x.size, x.copyIndices(), x.values.copyOf())
     if (slot is DenseVector && slot.size == x.size) {
         if (x is DenseVector) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBandit.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.bandit.ContextualBandit
 import com.eignex.kumulant.bandit.ContextualScorable
@@ -101,22 +101,22 @@ class RegressionContextualBandit<R : Result>(
     private val arms: Array<RegressionStat<R>> = Array(nbrArms) { template.create(null) }
     private val global: RegressionStat<R>? = globalTemplate?.create(null)
 
-    private fun globalMean(x: VectorLike, workspace: Workspace?): Double =
+    private fun globalMean(x: Vector, workspace: Workspace?): Double =
         global?.let { posterior.evaluate(it.read(0L), x, random, 0.0, workspace) } ?: 0.0
 
-    override fun choose(x: VectorLike, workspace: Workspace?): Int {
+    override fun choose(x: Vector, workspace: Workspace?): Int {
         val gMean = globalMean(x, workspace)
         return argmaxArm(
             nbrArms,
         ) { i -> gMean + posterior.evaluate(arms[i].read(0L), x, random, exploration, workspace) }
     }
 
-    override fun evaluate(armIndex: Int, x: VectorLike, workspace: Workspace?): Double {
+    override fun evaluate(armIndex: Int, x: Vector, workspace: Workspace?): Double {
         requireArmIndex(armIndex, nbrArms)
         return globalMean(x, workspace) + posterior.evaluate(arms[armIndex].read(0L), x, random, exploration, workspace)
     }
 
-    override fun update(armIndex: Int, x: VectorLike, reward: Double, weight: Double, workspace: Workspace?) {
+    override fun update(armIndex: Int, x: Vector, reward: Double, weight: Double, workspace: Workspace?) {
         requireArmIndex(armIndex, nbrArms)
         val g = global
         if (g == null) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/StatTraits.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.dot
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -217,7 +217,7 @@ interface HasShapeMoments : HasSampleVariance {
  */
 interface HasLinearModel : Result {
     /** Fitted weight per feature, indexed by the same `i` as the input `x[i]`. */
-    val weights: VectorLike
+    val weights: Vector
 
     /** Fitted bias / intercept term. */
     val bias: Double
@@ -230,7 +230,7 @@ interface HasLinearModel : Result {
      * For Gaussian regression this is the prediction; for non-identity GLMs
      * this is the linear predictor pre-link.
      */
-    fun predict(x: VectorLike): Double {
+    fun predict(x: Vector): Double {
         x.requireFeatureSize(weights.size)
         return bias + (x dot weights)
     }
@@ -251,7 +251,7 @@ interface HasSlope : HasLinearModel {
     /** Fitted intercept `c`. */
     val intercept: Double
 
-    override val weights: VectorLike get() = DenseVector.of(doubleArrayOf(slope))
+    override val weights: Vector get() = DenseVector.of(doubleArrayOf(slope))
     override val bias: Double get() = intercept
     override val featureSize: Int get() = 1
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Stats.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.core
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.stream.currentTimeNanos
 
@@ -285,7 +285,7 @@ interface PairedStat<R : Result> : Stat<R> {
  * ([DecisionTreeRegressionStat][com.eignex.kumulant.stat.regression.tree.DecisionTreeRegressionStat]).
  * They share the update shape and differ in what they expose on [read].
  *
- * Inputs are passed as [VectorLike] so callers can submit sparse feature
+ * Inputs are passed as [Vector] so callers can submit sparse feature
  * vectors without materialising them into dense arrays first. The
  * [DoubleArray] convenience overloads wrap the array in a [DenseVector]; the
  * sparse path goes through [com.eignex.koblas.SparseVector].
@@ -300,11 +300,11 @@ interface RegressionStat<R : Result> : Stat<R> {
     val featureSize: Int
 
     /** Record an `(x, y)` observation with the given [weight] at the current time. */
-    fun update(x: VectorLike, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
+    fun update(x: Vector, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
         update(x, y, currentTimeNanos(), weight, workspace)
 
     /** Record an `(x, y)` observation at [timestampNanos] with the given [weight]. */
-    fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double = 1.0, workspace: Workspace? = null)
+    fun update(x: Vector, y: Double, timestampNanos: Long, weight: Double = 1.0, workspace: Workspace? = null)
 
     /** Convenience overload that wraps `x` as a [DenseVector]. */
     fun update(x: DoubleArray, y: Double, weight: Double = 1.0, workspace: Workspace? = null) =
@@ -325,16 +325,16 @@ interface RegressionStat<R : Result> : Stat<R> {
  * detector
  * ([HalfSpaceTreesStat][com.eignex.kumulant.stat.anomaly.HalfSpaceTreesStat]).
  *
- * Like [RegressionStat], inputs are passed as [VectorLike] so sparse callers
+ * Like [RegressionStat], inputs are passed as [Vector] so sparse callers
  * don't pay for dense materialisation. The [DoubleArray] convenience
  * overloads wrap the array in a [DenseVector].
  */
 interface VectorStat<R : Result> : Stat<R> {
     /** Record a [vector] observation with the given [weight] at the current time. */
-    fun update(vector: VectorLike, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
+    fun update(vector: Vector, weight: Double = 1.0) = update(vector, currentTimeNanos(), weight)
 
     /** Record a [vector] observation at [timestampNanos] with the given [weight]. */
-    fun update(vector: VectorLike, timestampNanos: Long, weight: Double = 1.0)
+    fun update(vector: Vector, timestampNanos: Long, weight: Double = 1.0)
 
     /** Convenience overload that wraps [vector] as a [DenseVector]. */
     fun update(vector: DoubleArray, weight: Double = 1.0) = update(

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/Vectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.core
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 
 /**
  * Reject a context vector whose arity does not match the model's.
@@ -13,10 +13,10 @@ import com.eignex.koblas.VectorLike
  * spells its own check out instead, because its receiver is named `vector` and its message says so.
  *
  * @param expected the model's feature count.
- * @throws IllegalArgumentException if the [VectorLike] size differs from [expected].
+ * @throws IllegalArgumentException if the [Vector] size differs from [expected].
  */
 @Suppress("NOTHING_TO_INLINE") // as with the weight predicates; the non-JVM targets pay for the call
-internal inline fun VectorLike.requireFeatureSize(expected: Int) {
+internal inline fun Vector.requireFeatureSize(expected: Int) {
     require(size == expected) { "x.size=$size, expected $expected" }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/core/package.md
@@ -18,8 +18,8 @@ modality.
 | [SeriesStat] | `update(value: Double, weight: Double = 1.0)` | One scalar per observation |
 | [DiscreteStat] | `update(value: Long, weight: Double = 1.0)` | Opaque keys, integer counts |
 | [PairedStat] | `update(x: Double, y: Double, weight: Double = 1.0)` | Scalar `(x, y)` pairs |
-| [VectorStat] | `update(vector: VectorLike, weight: Double = 1.0)` | Multi-channel observations |
-| [RegressionStat] | `update(x: VectorLike, y: Double, weight: Double = 1.0)` | Vector covariate, scalar response |
+| [VectorStat] | `update(vector: Vector, weight: Double = 1.0)` | Multi-channel observations |
+| [RegressionStat] | `update(x: Vector, y: Double, weight: Double = 1.0)` | Vector covariate, scalar response |
 
 Every `update` overload has a sibling that takes an explicit
 `timestampNanos`; the no-timestamp form calls
@@ -28,8 +28,8 @@ silently drop the stamp. Stats that care about it (rates, windowed
 wrappers, decaying accumulators) treat it as the ordering signal; pass a
 monotonic stamp when replaying a log.
 
-[VectorStat] and [RegressionStat] both accept a `VectorLike`
-([com.eignex.koblas.VectorLike]) so sparse callers can feed
+[VectorStat] and [RegressionStat] both accept a `Vector`
+([com.eignex.koblas.Vector]) so sparse callers can feed
 sparse vectors without materialising them. Each also exposes a
 `DoubleArray` convenience overload that wraps the array in an
 `DenseVector` before forwarding.
@@ -64,7 +64,7 @@ and a multivariate one, or both a `MeanStat` and a `DecayingMeanStat`.
 | [HasRate] | `rate` (events per second), `per(duration)` |
 | [HasSampleVariance] | `totalWeights`, `variance`, `stdDev`, `sampleVariance`, `sampleStdDev` |
 | [HasShapeMoments] | extends `HasSampleVariance` with `m3`, `m4`, `skewness`, `kurtosis`, and the size-adjusted unbiased variants |
-| [HasLinearModel] | `weights: VectorLike`, `bias: Double`, `predict(VectorLike)` over a fitted hyperplane |
+| [HasLinearModel] | `weights: Vector`, `bias: Double`, `predict(Vector)` over a fitted hyperplane |
 | [HasSlope] | scalar special case: `slope`, `intercept`, `predict(Double)`; implements `HasLinearModel` |
 | [HasRegression] | `sse`, `ssr`, `mse`, `rmse`, `rSquared` on top of `HasSampleVariance` |
 | [HasCenterScale] | `center: Double`, `scale: Double`; consumed by standardize projections and the band wrapper |

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/Cholesky.kt
@@ -5,9 +5,9 @@ package com.eignex.kumulant.math
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.dense.Kernels
-import com.eignex.koblas.dense.trsv
+import com.eignex.koblas.dense.DenseVectorKernels
 import com.eignex.koblas.koblas
+import com.eignex.koblas.trsv
 import kotlin.math.abs
 import kotlin.math.hypot
 import kotlin.math.min
@@ -39,7 +39,7 @@ internal fun DenseMatrix.choleskyRankUpdate(v: DoubleArray, sigma: Double, works
     val n = rows
     if (n == 0 || sigma == 0.0) return
     val ld = data
-    val kernels = koblas.kernels
+    val kernels = koblas.vectorKernels
     val scale = sqrt(sigma)
     workspace.borrow(n) { x ->
         v.copyInto(x)
@@ -80,7 +80,7 @@ internal fun DenseMatrix.choleskyInvertInto(out: DenseMatrix, workspace: Workspa
     require(out.data !== data) { "inverse destination must not share the factor's storage" }
     val n = rows
     val ld = data
-    val kernels = koblas.kernels
+    val kernels = koblas.vectorKernels
     val invd = out.data
     workspace.borrow(n) { y ->
         for (j in 0 until n) {
@@ -118,7 +118,7 @@ internal fun DenseMatrix.choleskyInto(
     require(rows == cols) { "cholesky requires a square matrix" }
     require(out.rows == rows && out.cols == rows) { "cholesky destination must be ${rows}x$rows" }
     val n = rows
-    val kernels = koblas.kernels
+    val kernels = koblas.choleskyKernels()
     val ld = out.data
     // A reused destination arrives holding the previous factor where a fresh one arrives zeroed, so the
     // strict upper triangle is cleared rather than inherited.
@@ -126,8 +126,8 @@ internal fun DenseMatrix.choleskyInto(
         ld.fill(0.0, j * n, j * n + j)
         if (data !== ld) data.copyInto(ld, j + j * n, j + j * n, (j + 1) * n)
     }
-    if (n <= CHOLESKY_BLOCK || !kernels.supportsCholeskyPanels()) {
-        factorBlockColumn(kernels, ld, n, 0, n, policy)
+    if (n <= CHOLESKY_BLOCK) {
+        factorBlockColumn(kernels.vector, ld, n, 0, n, policy)
         return out
     }
     val minimumPivot = (policy as? CholeskyPolicy.Regularize)?.minimumPivot ?: 0.0
@@ -137,12 +137,12 @@ internal fun DenseMatrix.choleskyInto(
         val width = min(block, n - start)
         if (!tryCholeskyBlock(kernels, out, start, width, minimumPivot, workspace)) {
             // Regularization needs the entire corrected column to bound its multipliers.
-            factorBlockColumn(kernels, ld, n, start, width, policy)
+            factorBlockColumn(kernels.vector, ld, n, start, width, policy)
             if (columnsAreFinite(ld, n, start, width)) {
                 updateCholeskyTrailing(kernels, out, start, width, workspace)
             } else {
                 // A zero multiplier must skip infinite column entries instead of forming 0 * infinity.
-                subtractTrailingColumns(kernels, ld, n, start, width)
+                subtractTrailingColumns(kernels.vector, ld, n, start, width)
             }
         }
         start += width
@@ -157,7 +157,7 @@ private fun columnsAreFinite(data: DoubleArray, n: Int, start: Int, width: Int):
     return true
 }
 
-private fun subtractTrailingColumns(kernels: Kernels, data: DoubleArray, n: Int, start: Int, width: Int) {
+private fun subtractTrailingColumns(kernels: DenseVectorKernels, data: DoubleArray, n: Int, start: Int, width: Int) {
     for (p in start until start + width) {
         for (j in start + width until n) {
             val value = data[j + p * n]
@@ -167,7 +167,7 @@ private fun subtractTrailingColumns(kernels: Kernels, data: DoubleArray, n: Int,
 }
 
 private fun factorBlockColumn(
-    kernels: Kernels,
+    kernels: DenseVectorKernels,
     ld: DoubleArray,
     n: Int,
     start: Int,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CholeskyBlocks.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/math/CholeskyBlocks.kt
@@ -36,16 +36,15 @@
  * or implied, of The University of Texas at Austin.
  */
 
-@file:OptIn(com.eignex.koblas.ExperimentalKoblasApi::class)
-
 package com.eignex.kumulant.math
 
 import com.eignex.koblas.DenseMatrix
+import com.eignex.koblas.KoblasEngine
 import com.eignex.koblas.StridedVectorView
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
-import com.eignex.koblas.dense.Kernels
-import com.eignex.koblas.dense.PackedPanels
+import com.eignex.koblas.dense.DenseVectorKernels
+import com.eignex.koblas.dense.PackedKernels
 import com.eignex.koblas.koblas
 import com.eignex.koblas.view
 import kotlin.math.min
@@ -55,12 +54,13 @@ private const val CHOLESKY_LEAF = 16
 
 // Adapted from OpenBLAS potrf_L_single.c and potf2_L.c
 // at 632ef874379c16ca8646d9fa0f6c60449e47d960. Packing and compute leaves belong to koblas.
-internal fun Kernels.supportsCholeskyPanels(): Boolean =
-    gemmTileRows == PackedPanels.tileRows && gemmTileCols == PackedPanels.tileColumns
+internal data class CholeskyKernels(val vector: DenseVectorKernels, val packed: PackedKernels)
+
+internal fun KoblasEngine.choleskyKernels(): CholeskyKernels = CholeskyKernels(vectorKernels, packedKernels)
 
 // Staging preserves the input block for full-column regularization if a trial pivot needs repair.
 internal fun tryCholeskyBlock(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     matrix: DenseMatrix,
     start: Int,
     width: Int,
@@ -76,15 +76,15 @@ internal fun tryCholeskyBlock(
     if (!tryCholeskyDiagonal(kernels, diagonal, minimumPivot, workspace)) return@borrow false
     val end = start + width
     val height = n - end
-    workspace.borrow(PackedPanels.leftSize(height, width)) { panel ->
+    workspace.borrow(koblas.packedPanels.leftSize(height, width)) { panel ->
         if (height > 0) {
-            PackedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
+            koblas.packedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
             solveCholeskyPanel(kernels, diagonal, panel, height, workspace)
             if (!panel.all { it.isFinite() }) return@borrow false
         }
         for (j in 0 until width) data.copyInto(matrix.data, start + (start + j) * n, j * width, (j + 1) * width)
         if (height > 0) {
-            PackedPanels.writeLeft(panel, matrix, height, width, destinationRow = end, destinationColumn = start)
+            koblas.packedPanels.writeLeft(panel, matrix, height, width, destinationRow = end, destinationColumn = start)
             subtractCholeskyPanel(kernels, matrix, end, width, panel, workspace)
         }
         true
@@ -92,7 +92,7 @@ internal fun tryCholeskyBlock(
 }
 
 private fun tryCholeskyDiagonal(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     matrix: DenseMatrix,
     minimumPivot: Double,
     workspace: Workspace?,
@@ -110,17 +110,17 @@ private fun tryCholeskyDiagonal(
 }
 
 private fun solveCholeskyPanel(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     diagonal: DenseMatrix,
     panel: DoubleArray,
     height: Int,
     workspace: Workspace?,
 ) {
     val width = diagonal.rows
-    val rows = kernels.gemmTileRows
-    val columns = kernels.gemmTileCols
-    workspace.borrow(PackedPanels.rightSize(width, width)) { triangle ->
-        PackedPanels.packTriangularRight(diagonal, triangle, width, width, lower = true, transpose = true)
+    val rows = kernels.packed.gemmTileRows
+    val columns = kernels.packed.gemmTileCols
+    workspace.borrow(koblas.packedPanels.rightSize(width, width)) { triangle ->
+        koblas.packedPanels.packTriangularRight(diagonal, triangle, width, width, lower = true, transpose = true)
         var column = 0
         while (column < width) {
             val order = min(columns, width - column)
@@ -129,7 +129,7 @@ private fun solveCholeskyPanel(
             while (row < height) {
                 val validRows = min(rows, height - row)
                 val rowPanel = row * width
-                kernels.gemmTrsmTile(
+                kernels.packed.gemmTrsmTile(
                     column, validRows, order, panel, rowPanel, triangle, trianglePanel,
                     triangle, trianglePanel + column * columns, false, false, panel, rowPanel + column * rows,
                 )
@@ -138,11 +138,11 @@ private fun solveCholeskyPanel(
             column += columns
         }
     }
-    PackedPanels.clearLeftPadding(panel, height, width)
+    koblas.packedPanels.clearLeftPadding(panel, height, width)
 }
 
 internal fun updateCholeskyTrailing(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     matrix: DenseMatrix,
     start: Int,
     width: Int,
@@ -151,15 +151,15 @@ internal fun updateCholeskyTrailing(
     val end = start + width
     val height = matrix.rows - end
     if (height == 0) return
-    workspace.borrow(PackedPanels.leftSize(height, width)) { panel ->
-        PackedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
+    workspace.borrow(koblas.packedPanels.leftSize(height, width)) { panel ->
+        koblas.packedPanels.packLeft(matrix, panel, height, width, sourceRow = end, sourceColumn = start)
         subtractCholeskyPanel(kernels, matrix, end, width, panel, workspace)
     }
 }
 
 // The solved left panel remains packed after TRSM. Only its transposed right format needs packing for SYRK.
 private fun subtractCholeskyPanel(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     matrix: DenseMatrix,
     start: Int,
     width: Int,
@@ -167,11 +167,11 @@ private fun subtractCholeskyPanel(
     workspace: Workspace?,
 ) {
     val height = matrix.rows - start
-    val rows = kernels.gemmTileRows
-    val columns = kernels.gemmTileCols
-    kernels.scale(left, 0, -1.0, left.size)
-    workspace.borrow(PackedPanels.rightSize(width, height)) { right ->
-        PackedPanels.packRight(
+    val rows = kernels.packed.gemmTileRows
+    val columns = kernels.packed.gemmTileCols
+    kernels.vector.scale(left, 0, -1.0, left.size)
+    workspace.borrow(koblas.packedPanels.rightSize(width, height)) { right ->
+        koblas.packedPanels.packRight(
             matrix,
             right,
             width,
@@ -187,7 +187,7 @@ private fun subtractCholeskyPanel(
                 while (row < height) {
                     val destination = start + row + (start + column) * matrix.rows
                     if (row >= column + columns - 1 && row + rows <= height && column + columns <= height) {
-                        kernels.gemmTile(
+                        kernels.packed.gemmTile(
                             width,
                             left,
                             row * width,
@@ -200,7 +200,7 @@ private fun subtractCholeskyPanel(
                     } else {
                         // A diagonal or edge tile must preserve entries outside the stored lower triangle.
                         edge.fill(0.0)
-                        kernels.gemmTile(width, left, row * width, right, column * width, edge, 0, rows)
+                        kernels.packed.gemmTile(width, left, row * width, right, column * width, edge, 0, rows)
                         for (j in 0 until min(columns, height - column)) {
                             for (i in 0 until min(rows, height - row)) {
                                 if (row + i >= column + j) {
@@ -218,7 +218,7 @@ private fun subtractCholeskyPanel(
 }
 
 private fun tryCholeskyLeaf(
-    kernels: Kernels,
+    kernels: CholeskyKernels,
     matrix: DenseMatrix,
     minimumPivot: Double,
     workspace: Workspace?,
@@ -229,14 +229,14 @@ private fun tryCholeskyLeaf(
         for (j in 0 until n) {
             val base = j + j * n
             for (p in 0 until j) row[p] = data[j + p * n]
-            val pivot = data[base] - kernels.dot(row, 0, row, 0, j)
+            val pivot = data[base] - kernels.vector.dot(row, 0, row, 0, j)
             if (!pivot.isFinite() || pivot <= 0.0 || pivot < minimumPivot) return@borrow false
             val diagonal = sqrt(pivot)
             data[base] = diagonal
             val length = n - j - 1
             if (length > 0) {
                 if (j > 0) {
-                    koblas.blas.gemv(
+                    koblas.gemv(
                         -1.0,
                         matrix.view(j + 1, length, 0, j),
                         StridedVectorView(row, 0, j),
@@ -244,7 +244,7 @@ private fun tryCholeskyLeaf(
                         StridedVectorView(data, base + 1, length),
                     )
                 }
-                kernels.scale(data, base + 1, 1.0 / diagonal, length)
+                kernels.vector.scale(data, base + 1, 1.0 / diagonal, length)
                 for (i in base + 1 until base + 1 + length) if (!data[i].isFinite()) return@borrow false
             }
         }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Feedback.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.IndexedResult
 import com.eignex.kumulant.core.PairedStat
@@ -91,7 +91,7 @@ internal class FeedbackVectorStat<P : Result, I : Result>(
     WindowsInside<I, VectorStat<I>>,
     Stat<I> by inner {
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         primary.update(vector, timestampNanos, weight)
         val snapshot = primary.read(timestampNanos)
         val transformed = DoubleArray(vector.size) { i ->
@@ -133,7 +133,7 @@ internal class FeedbackRegressionStat<P : Result, R : Result>(
     override val featureSize: Int get() = inner.featureSize
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Filters.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -43,10 +43,10 @@ internal class FilterPairedStat<R : Result>(
 internal class FilterVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val predicate: (DoubleArray) -> Boolean = { true },
-    private val vectorPredicate: ((VectorLike) -> Boolean)? = null,
+    private val vectorPredicate: ((Vector) -> Boolean)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         if (vectorPredicate?.invoke(vector) ?: predicate(vector.toDoubleArray())) {
             delegate.update(vector, timestampNanos, weight)
         }
@@ -55,7 +55,7 @@ internal class FilterVectorStat<R : Result>(
         FilterVectorStat(delegate.create(concurrency), predicate, vectorPredicate)
 
     companion object {
-        fun <R : Result> vector(delegate: VectorStat<R>, predicate: (VectorLike) -> Boolean): FilterVectorStat<R> =
+        fun <R : Result> vector(delegate: VectorStat<R>, predicate: (Vector) -> Boolean): FilterVectorStat<R> =
             FilterVectorStat(delegate, vectorPredicate = predicate)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Folds.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -17,17 +17,17 @@ import com.eignex.kumulant.core.VectorStat
 internal class FoldVectorStat<R : Result>(
     private val delegate: SeriesStat<R>,
     private val transform: (DoubleArray) -> Double = { 0.0 },
-    private val vectorTransform: ((VectorLike) -> Double)? = null,
+    private val vectorTransform: ((Vector) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(vectorTransform?.invoke(vector) ?: transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
         FoldVectorStat(delegate.create(concurrency), transform, vectorTransform)
 
     companion object {
-        fun <R : Result> vector(delegate: SeriesStat<R>, transform: (VectorLike) -> Double): FoldVectorStat<R> =
+        fun <R : Result> vector(delegate: SeriesStat<R>, transform: (Vector) -> Double): FoldVectorStat<R> =
             FoldVectorStat(delegate, vectorTransform = transform)
     }
 }
@@ -48,11 +48,11 @@ internal class FoldVectorPairedStat<R : Result>(
     private val delegate: PairedStat<R>,
     private val foldX: (DoubleArray) -> Double = { 0.0 },
     private val foldY: (DoubleArray) -> Double = { 0.0 },
-    private val vectorFoldX: ((VectorLike) -> Double)? = null,
-    private val vectorFoldY: ((VectorLike) -> Double)? = null,
+    private val vectorFoldX: ((Vector) -> Double)? = null,
+    private val vectorFoldY: ((Vector) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         if (vectorFoldX != null && vectorFoldY != null) {
             delegate.update(vectorFoldX(vector), vectorFoldY(vector), timestampNanos, weight)
         } else {
@@ -66,8 +66,8 @@ internal class FoldVectorPairedStat<R : Result>(
     companion object {
         fun <R : Result> vector(
             delegate: PairedStat<R>,
-            foldX: (VectorLike) -> Double,
-            foldY: (VectorLike) -> Double,
+            foldX: (Vector) -> Double,
+            foldY: (Vector) -> Double,
         ): FoldVectorPairedStat<R> = FoldVectorPairedStat(delegate, vectorFoldX = foldX, vectorFoldY = foldY)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/MapResults.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -89,7 +89,7 @@ internal class MapResultVectorStat<R1 : Result, R2 : Result>(
     private val reverse: (R2) -> R1,
 ) : VectorStat<R2>,
     Stat<R2> by MappedResultCore(delegate, forward, reverse) {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) =
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) =
         delegate.update(vector, timestampNanos, weight)
     override fun create(concurrency: Concurrency?): VectorStat<R2> =
         MapResultVectorStat(delegate.create(concurrency), forward, reverse)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/RegressionOps.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.operation
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -18,11 +18,11 @@ import com.eignex.kumulant.core.requirePositiveFeatureSize
 // `com.eignex.kumulant.schema.Operations.kt` materialise to these wrappers.
 
 /** Forward only updates that pass [predicate]; the predicate sees `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.filter(predicate: (VectorLike, Double) -> Boolean): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.filter(predicate: (Vector, Double) -> Boolean): RegressionStat<R> =
     FilterRegressionStat(this, predicate)
 
 /** Rewrite y before update via [transform]; x and weight pass through unchanged. */
-internal fun <R : Result> RegressionStat<R>.transformY(transform: (VectorLike, Double) -> Double): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.transformY(transform: (Vector, Double) -> Double): RegressionStat<R> =
     TransformYRegressionStat(this, transform)
 
 /**
@@ -33,7 +33,7 @@ internal fun <R : Result> RegressionStat<R>.transformY(transform: (VectorLike, D
  */
 internal fun <R : Result> RegressionStat<R>.transformX(
     inputFeatureSize: Int? = null,
-    transform: (VectorLike, Double) -> DoubleArray,
+    transform: (Vector, Double) -> DoubleArray,
 ): RegressionStat<R> = TransformXRegressionStat(this, inputFeatureSize, transform)
 
 /**
@@ -46,7 +46,7 @@ internal fun <R : Result> RegressionStat<R>.withWeight(weight: Double): Regressi
     WithWeightRegressionStat(this, weight)
 
 /** Multiply each update's caller-supplied weight by [weighter] over `(x, y)`. */
-internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (VectorLike, Double) -> Double): RegressionStat<R> =
+internal fun <R : Result> RegressionStat<R>.weightBy(weighter: (Vector, Double) -> Double): RegressionStat<R> =
     WeightByRegressionStat(this, weighter)
 
 /** Forward only every [every]th update; drop the rest. */
@@ -70,17 +70,17 @@ internal fun <R : Result> RegressionStat<R>.sample(rate: Double, seed: Long): Re
  */
 internal fun <R : Result> SeriesStat<R>.foldRegression(
     featureSize: Int,
-    project: (VectorLike, Double) -> Double,
+    project: (Vector, Double) -> Double,
 ): RegressionStat<R> = FoldRegressionStat(this, featureSize, project)
 
 internal class FilterRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val predicate: (VectorLike, Double) -> Boolean,
+    private val predicate: (Vector, Double) -> Boolean,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -94,12 +94,12 @@ internal class FilterRegressionStat<R : Result>(
 
 internal class TransformYRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val transform: (VectorLike, Double) -> Double,
+    private val transform: (Vector, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -114,7 +114,7 @@ internal class TransformYRegressionStat<R : Result>(
 internal class TransformXRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
     private val inputFeatureSize: Int?,
-    private val transform: (VectorLike, Double) -> DoubleArray,
+    private val transform: (Vector, Double) -> DoubleArray,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     // The width expected in `x`, which is what RegressionStat.featureSize means - not the inner
@@ -124,7 +124,7 @@ internal class TransformXRegressionStat<R : Result>(
     override val featureSize: Int = inputFeatureSize ?: delegate.featureSize
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -145,7 +145,7 @@ internal class WithWeightRegressionStat<R : Result>(
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -161,12 +161,12 @@ internal class WithWeightRegressionStat<R : Result>(
 
 internal class WeightByRegressionStat<R : Result>(
     private val delegate: RegressionStat<R>,
-    private val weighter: (VectorLike, Double) -> Double,
+    private val weighter: (Vector, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -184,7 +184,7 @@ internal class ThrottleRegressionStat<R : Result>(private val delegate: Regressi
     override val featureSize: Int = delegate.featureSize
     private val gate = ThrottleGate(every, delegate.concurrency)
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -211,7 +211,7 @@ internal class SampleRegressionStat<R : Result>(
     private val gate = SampleGate(rate, seed, delegate.concurrency)
     override val featureSize: Int = delegate.featureSize
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -233,14 +233,14 @@ internal class SampleRegressionStat<R : Result>(
 internal class FoldRegressionStat<R : Result>(
     private val delegate: SeriesStat<R>,
     override val featureSize: Int,
-    private val project: (VectorLike, Double) -> Double,
+    private val project: (Vector, Double) -> Double,
 ) : RegressionStat<R>,
     Stat<R> by delegate {
     init {
         requirePositiveFeatureSize(featureSize)
     }
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Sampling.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -109,7 +109,7 @@ internal class ThrottleVectorStat<R : Result>(private val delegate: VectorStat<R
     WindowsInside<R, VectorStat<R>>,
     Stat<R> by delegate {
     private val gate = ThrottleGate(every, delegate.concurrency)
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }
@@ -195,7 +195,7 @@ internal class SampleVectorStat<R : Result>(
 ) : VectorStat<R>,
     Stat<R> by delegate {
     private val gate = SampleGate(rate, seed, delegate.concurrency)
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         if (weight.isInertWeight()) return
         if (gate.pass()) delegate.update(vector, timestampNanos, weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Selectors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.PairedStat
 import com.eignex.kumulant.core.Result
@@ -31,7 +31,7 @@ internal class AtYStat<R : Result>(private val delegate: SeriesStat<R>) :
 internal class AtIndexStat<R : Result>(private val delegate: SeriesStat<R>, private val index: Int) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(vector[index], timestampNanos, weight)
     }
 
@@ -44,7 +44,7 @@ internal class AtIndicesStat<R : Result>(
     private val indexY: Int,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(vector[indexX], vector[indexY], timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Transforms.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -50,20 +50,18 @@ internal class TransformPairStat<R : Result>(
 internal class TransformVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val transform: (DoubleArray) -> DoubleArray = { it },
-    private val vectorTransform: ((VectorLike) -> DoubleArray)? = null,
+    private val vectorTransform: ((Vector) -> DoubleArray)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(vectorTransform?.invoke(vector) ?: transform(vector.toDoubleArray()), timestampNanos, weight)
     }
     override fun create(concurrency: Concurrency?): VectorStat<R> =
         TransformVectorStat(delegate.create(concurrency), transform, vectorTransform)
 
     companion object {
-        fun <R : Result> vector(
-            delegate: VectorStat<R>,
-            transform: (VectorLike) -> DoubleArray,
-        ): TransformVectorStat<R> = TransformVectorStat(delegate, vectorTransform = transform)
+        fun <R : Result> vector(delegate: VectorStat<R>, transform: (Vector) -> DoubleArray): TransformVectorStat<R> =
+            TransformVectorStat(delegate, vectorTransform = transform)
     }
 }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/VectorizedStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.Result
@@ -35,7 +35,7 @@ internal class VectorizedStat<R : Result>(
 
     override val concurrency: Concurrency get() = template.concurrency
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         vector.requireFeatureSize(dimensions)
         if (skipZeros) {
             vector.forEachStored { i, v -> stats[i].update(v, timestampNanos, weight) }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/Weights.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -64,7 +64,7 @@ internal class WithWeightPairedStat<R : Result>(private val delegate: PairedStat
 internal class WithWeightVectorStat<R : Result>(private val delegate: VectorStat<R>, private val weight: Double) :
     VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(vector, timestampNanos, weight.orInert(this.weight))
     }
 
@@ -132,10 +132,10 @@ internal class WeightByPairedStat<R : Result>(
 internal class WeightByVectorStat<R : Result>(
     private val delegate: VectorStat<R>,
     private val weighter: (DoubleArray) -> Double = { 1.0 },
-    private val vectorWeighter: ((VectorLike) -> Double)? = null,
+    private val vectorWeighter: ((Vector) -> Double)? = null,
 ) : VectorStat<R>,
     Stat<R> by delegate {
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         delegate.update(
             vector,
             timestampNanos,
@@ -146,7 +146,7 @@ internal class WeightByVectorStat<R : Result>(
         WeightByVectorStat(delegate.create(concurrency), weighter, vectorWeighter)
 
     companion object {
-        fun <R : Result> vector(delegate: VectorStat<R>, weighter: (VectorLike) -> Double): WeightByVectorStat<R> =
+        fun <R : Result> vector(delegate: VectorStat<R>, weighter: (Vector) -> Double): WeightByVectorStat<R> =
             WeightByVectorStat(delegate, vectorWeighter = weighter)
     }
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/operation/WindowedStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.operation
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -164,7 +164,7 @@ internal class WindowedVectorStat<R : Result>(
     private val template = template.create(concurrency = this.concurrency)
     private val ring = SliceRing<R, VectorStat<R>>(windowDuration, slices, concurrency) { c -> this.template.create(c) }
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         ring.slotFor(timestampNanos)?.update(vector, timestampNanos, weight)
     }
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/expr/Expr.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.schema.expr
 
 import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.koblas
 import com.eignex.koblas.sum
@@ -508,7 +508,7 @@ internal data class VFold(
     val op: VFoldOp,
 ) : ScalarExpr {
     override fun eval(x: Double, y: Double, v: DoubleArray, primary: Result?): Double = when (op) {
-        VFoldOp.Sum -> koblas.kernels.sum(v, 0, v.size)
+        VFoldOp.Sum -> koblas.vectorKernels.sum(v, 0, v.size)
 
         VFoldOp.Product -> {
             var p = 1.0
@@ -518,7 +518,7 @@ internal data class VFold(
 
         VFoldOp.Mean -> {
             require(v.isNotEmpty()) { "VFold.Mean on empty vector" }
-            koblas.kernels.sum(v, 0, v.size) / v.size
+            koblas.vectorKernels.sum(v, 0, v.size) / v.size
         }
 
         VFoldOp.Min -> {
@@ -838,7 +838,7 @@ sealed interface VectorExpr {
  * bits, and a snapshot carrying such a value is only equal to another that was fed the same storage.
  * Every other fold is order-independent and agrees exactly whatever the storage.
  */
-fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): Double {
+fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: Vector, primary: Result? = null): Double {
     if (v is SparseVector) {
         when (this) {
             is VFold -> when (op) {
@@ -864,7 +864,7 @@ fun ScalarExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Re
     return evalVectorGeneric(x, y, v, primary)
 }
 
-private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: VectorLike, primary: Result?): Double = when (this) {
+private fun ScalarExpr.evalVectorGeneric(x: Double, y: Double, v: Vector, primary: Result?): Double = when (this) {
     X -> x
 
     Y -> y
@@ -1020,7 +1020,7 @@ private fun sparseMax(v: SparseVector): Double {
 }
 
 /** Evaluate this boolean expression against a borrowed KoBLAS vector without materialising it. */
-fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): Boolean = when (this) {
+fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: Vector, primary: Result? = null): Boolean = when (this) {
     is Gt -> l.eval(x, y, v, primary) > r.eval(x, y, v, primary)
 
     is Ge -> l.eval(x, y, v, primary) >= r.eval(x, y, v, primary)
@@ -1069,10 +1069,9 @@ fun BoolExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Resu
 }
 
 /** Evaluate this vector expression against a borrowed KoBLAS vector, allocating only its owned output. */
-fun VectorExpr.eval(x: Double = 0.0, y: Double = 0.0, v: VectorLike, primary: Result? = null): DoubleArray =
-    when (this) {
-        is VElements -> DoubleArray(exprs.size) { i -> exprs[i].eval(x, y, v, primary) }
-    }
+fun VectorExpr.eval(x: Double = 0.0, y: Double = 0.0, v: Vector, primary: Result? = null): DoubleArray = when (this) {
+    is VElements -> DoubleArray(exprs.size) { i -> exprs[i].eval(x, y, v, primary) }
+}
 
 /**
  * Build an output vector by evaluating each [ScalarExpr] in order. Output

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/ListStats.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -159,7 +159,7 @@ internal class VectorListStats<R : Result>(
             concurrency = concurrency,
         )
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         for ((_, stat) in entries) stat.update(vector, timestampNanos, weight)
     }
 
@@ -245,7 +245,7 @@ internal class RegressionListStats<R : Result>(
     }
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/schema/runtime/StatGroup.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema.runtime
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.DiscreteStat
 import com.eignex.kumulant.core.PairedStat
@@ -148,7 +148,7 @@ class VectorStatGroup(stats: List<BoundStat<*, out VectorStat<*>, *>>, concurren
     constructor(schema: StatSchema, concurrency: Concurrency = Concurrency.None) :
         this(stats = vectorSpecs(schema, concurrency), concurrency = concurrency)
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         for ((_, stat) in stats) stat.update(vector, timestampNanos, weight)
     }
 
@@ -197,7 +197,7 @@ class RegressionStatGroup(stats: List<BoundStat<*, out RegressionStat<*>, *>>, c
     }
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/anomaly/HalfSpaceTreesStat.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.anomaly
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.VectorStat
@@ -86,7 +86,7 @@ data class HalfSpaceTreesResult(
      * means [x] falls into densely populated regions of the reference window;
      * i.e. it looks normal. Lower score flags an anomaly.
      */
-    fun score(x: VectorLike): Double {
+    fun score(x: Vector): Double {
         x.requireFeatureSize(featureSize)
         var total = 0.0
         val depthFactor = 1 shl height
@@ -204,7 +204,7 @@ class HalfSpaceTreesStat(
     private val windowCounter: StreamLong = counterMode.newLong(0L)
     private val totalWeightsCell = massMode.newDouble(0.0)
 
-    override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) {
+    override fun update(vector: Vector, timestampNanos: Long, weight: Double) {
         require(vector.size == featureSize) { "vector.size=${vector.size}, expected $featureSize" }
         if (weight.isNotPositiveWeight()) return
         for (t in 0 until numTrees) {
@@ -318,7 +318,7 @@ private fun routeToLeaf(
     height: Int,
     numInternal: Int,
     treeIdx: Int,
-    x: VectorLike,
+    x: Vector,
 ): Int {
     val treeOffset = treeIdx * numInternal
     var node = 0

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/package.md
@@ -14,8 +14,8 @@ in the signature of `update`:
 | [com.eignex.kumulant.core.SeriesStat] | `update(value: Double, weight: Double = 1.0)` | One scalar per observation |
 | [com.eignex.kumulant.core.DiscreteStat] | `update(value: Long, weight: Double = 1.0)` | Opaque keys, integer counts |
 | [com.eignex.kumulant.core.PairedStat] | `update(x: Double, y: Double, weight: Double = 1.0)` | Scalar `(x, y)` pairs |
-| [com.eignex.kumulant.core.VectorStat] | `update(vector: VectorLike, weight: Double = 1.0)` | Multi-channel observations |
-| [com.eignex.kumulant.core.RegressionStat] | `update(x: VectorLike, y: Double, weight: Double = 1.0)` | Vector covariate, scalar response |
+| [com.eignex.kumulant.core.VectorStat] | `update(vector: Vector, weight: Double = 1.0)` | Multi-channel observations |
+| [com.eignex.kumulant.core.RegressionStat] | `update(x: Vector, y: Double, weight: Double = 1.0)` | Vector covariate, scalar response |
 
 Every `update` overload has a sibling that takes an explicit
 `timestampNanos`; the no-timestamp form calls `currentTimeNanos`. Stats
@@ -23,7 +23,7 @@ that ignore time silently drop the stamp; stats that care about it
 (rates, windowed wrappers, decaying accumulators) treat it as the
 ordering signal; pass a monotonic stamp when replaying a log.
 
-`VectorStat` and `RegressionStat` both accept a `VectorLike` so sparse
+`VectorStat` and `RegressionStat` both accept a `Vector` so sparse
 callers can feed sparse vectors without materialising them. Each
 interface also exposes a `DoubleArray` convenience overload that wraps
 the array in a `DenseVector`.
@@ -43,7 +43,7 @@ comes out of `read()` goes into `merge()` over the wire. Traits in
   `HasSampleVariance` with `m3`, `m4`, `skewness`, `kurtosis`, and the
   size-adjusted unbiased variants.
 - [com.eignex.kumulant.core.HasLinearModel]: `weights`, `bias`, and
-  `predict(VectorLike)` over a fitted hyperplane.
+  `predict(Vector)` over a fitted hyperplane.
 - [com.eignex.kumulant.core.HasSlope]: univariate special case with
   `slope`, `intercept`, scalar `predict(Double)`; implements
   `HasLinearModel` for free.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.HasObservationCount
 import com.eignex.kumulant.core.RegressionStat
@@ -70,7 +70,7 @@ data class GaussianNaiveBayesResult(
     fun prior(c: Int): Double = if (totalWeights > 0.0) classWeights[c] / totalWeights else 1.0 / numClasses
 
     /** Unnormalised log-posterior `log prior[c] + Sum_i log N(x_i | mu_c, var_c)`. */
-    fun logPosterior(x: VectorLike, c: Int): Double {
+    fun logPosterior(x: Vector, c: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = ln(prior(c).coerceAtLeast(SMALL_PROB))
         for (i in 0 until featureSize) {
@@ -83,7 +83,7 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Writes unnormalised log-posteriors for [x] into [destination]. */
-    fun logPosteriorsInto(x: VectorLike, destination: DoubleArray) {
+    fun logPosteriorsInto(x: Vector, destination: DoubleArray) {
         x.requireFeatureSize(featureSize)
         require(destination.size == numClasses) {
             "destination size ${destination.size} must match numClasses $numClasses"
@@ -92,16 +92,16 @@ data class GaussianNaiveBayesResult(
     }
 
     /** Normalised class probabilities via log-sum-exp on the log-posterior. */
-    fun probabilities(x: VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
+    fun probabilities(x: Vector): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
 
     /** Writes normalised class probabilities for [x] into [destination]. */
-    fun probabilitiesInto(x: VectorLike, destination: DoubleArray) {
+    fun probabilitiesInto(x: Vector, destination: DoubleArray) {
         logPosteriorsInto(x, destination)
         destination.softmaxInPlace()
     }
 
     /** Argmax class index for [x]. */
-    fun predict(x: VectorLike): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
+    fun predict(x: Vector): Int = argMaxOf(numClasses) { k -> logPosterior(x, k) }
 
     private companion object {
         const val SMALL_PROB: Double = 1e-300
@@ -153,7 +153,7 @@ class GaussianNaiveBayesStat(
     private val totalWeightCell: StreamDouble = mode.newDouble(0.0)
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/RegressionPosterior.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.core.Result
 import kotlin.random.Random
@@ -24,11 +24,5 @@ interface RegressionPosterior<R : Result> {
      * the posterior-variance scale (Thompson) or the UCB width (LinUcb-style);
      * `0.0` collapses to the point estimate.
      */
-    fun evaluate(
-        snapshot: R,
-        x: VectorLike,
-        rng: Random,
-        exploration: Double = 1.0,
-        workspace: Workspace? = null,
-    ): Double
+    fun evaluate(snapshot: R, x: Vector, rng: Random, exploration: Double = 1.0, workspace: Workspace? = null): Double
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStat.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
 import com.eignex.koblas.forEachStored
@@ -62,7 +62,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Linear predictor for class [k]: `biases[k] + weights[k] . x`. */
-    fun logit(x: VectorLike, k: Int): Double {
+    fun logit(x: Vector, k: Int): Double {
         x.requireFeatureSize(featureSize)
         var s = biases[k]
         // Walk what x stores rather than every feature index. Reading a sparse x position by
@@ -73,7 +73,7 @@ data class SoftmaxRegressionResult(
     }
 
     /** Writes the per-class logits for [x] into [destination]. */
-    fun logitsInto(x: VectorLike, destination: DoubleArray) {
+    fun logitsInto(x: Vector, destination: DoubleArray) {
         x.requireFeatureSize(featureSize)
         require(destination.size == numClasses) {
             "destination size ${destination.size} must match numClasses $numClasses"
@@ -83,10 +83,10 @@ data class SoftmaxRegressionResult(
     }
 
     /** Softmax probabilities across all classes for [x]; length [numClasses]. */
-    fun probabilities(x: VectorLike): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
+    fun probabilities(x: Vector): DoubleArray = DoubleArray(numClasses).also { probabilitiesInto(x, it) }
 
     /** Writes softmax probabilities for [x] into caller-owned [destination]. */
-    fun probabilitiesInto(x: VectorLike, destination: DoubleArray) {
+    fun probabilitiesInto(x: Vector, destination: DoubleArray) {
         logitsInto(x, destination)
         destination.softmaxInPlace()
     }
@@ -99,7 +99,7 @@ data class SoftmaxRegressionResult(
      * is a search through its stored indices. Without a [workspace] to borrow from, the single pass
      * costs one length-[numClasses] buffer, which is the cheaper side of that trade.
      */
-    fun predict(x: VectorLike, workspace: Workspace? = null): Int = workspace.borrow(numClasses) { logits ->
+    fun predict(x: Vector, workspace: Workspace? = null): Int = workspace.borrow(numClasses) { logits ->
         logitsInto(x, logits)
         argMaxOf(numClasses) { logits[it] }
     }
@@ -172,7 +172,7 @@ class SoftmaxRegressionStat(
     val crossEntropy: Double by crossEntropyCell
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -223,7 +223,7 @@ class SoftmaxRegressionStat(
         SoftmaxRegressionResult(
             featureSize = featureSize,
             numClasses = numClasses,
-            weights = DenseMatrix.of(
+            weights = DenseMatrix.ofRows(
                 Array(numClasses) { k -> w.copyOfRange(k * featureSize, (k + 1) * featureSize) },
             ),
             biases = DenseVector.of(b),

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStat.kt
@@ -6,16 +6,16 @@ package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.MatrixLike
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Matrix
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.axpy
 import com.eignex.koblas.borrow
 import com.eignex.koblas.copy
-import com.eignex.koblas.dense.trmv
 import com.eignex.koblas.dot
 import com.eignex.koblas.koblas
 import com.eignex.koblas.syr
+import com.eignex.koblas.trmv
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.isNotPositiveWeight
@@ -33,7 +33,7 @@ import com.eignex.kumulant.stream.guarded
 import com.eignex.kumulant.stream.serializedLock
 import kotlinx.serialization.Serializable
 
-private fun MatrixLike.copyDenseMatrix(): DenseMatrix = DenseMatrix.wrap(
+private fun Matrix.copyDenseMatrix(): DenseMatrix = DenseMatrix.wrap(
     rows,
     cols,
     DoubleArray(rows * cols) { index -> this[index % rows, index / rows] },
@@ -96,8 +96,8 @@ class BayesianRegressionStat(
     /** Canonical GLM link function; [Link.Identity] is the strict closed-form Gaussian posterior. */
     val link: Link = Link.Identity,
     override val concurrency: Concurrency = Concurrency.None,
-    priorMean: VectorLike? = null,
-    priorCovariance: MatrixLike? = null,
+    priorMean: Vector? = null,
+    priorCovariance: Matrix? = null,
 ) : RegressionStat<PrecisionRegressionResult> {
 
     init {
@@ -152,17 +152,11 @@ class BayesianRegressionStat(
     private var step: Long = 0L
     private var sse: Double = 0.0
 
-    override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) =
+    override fun update(x: Vector, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) =
         updateInternal(x, y, timestampNanos, weight, workspace)
 
     @Suppress("UnusedParameter")
-    private fun updateInternal(
-        x: VectorLike,
-        y: Double,
-        _timestampNanos: Long,
-        weight: Double,
-        workspace: Workspace?,
-    ) {
+    private fun updateInternal(x: Vector, y: Double, _timestampNanos: Long, weight: Double, workspace: Workspace?) {
         x.requireFeatureSize(featureSize)
         if (weight.isNotPositiveWeight()) return
         lock.guarded {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/DiagonalRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
@@ -86,7 +86,7 @@ class DiagonalRegressionStat(
     private var sse: Double = 0.0
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriors.kt
@@ -1,15 +1,15 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.axpy
 import com.eignex.koblas.borrow
 import com.eignex.koblas.copy
-import com.eignex.koblas.dense.trsv
 import com.eignex.koblas.dot
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.norm2
+import com.eignex.koblas.trsv
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
 import kotlinx.serialization.SerialName
@@ -36,7 +36,7 @@ import kotlin.random.Random
 sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosterior<R> {
     /** Draw a weight vector from the posterior at `exploration` variance scale.
      *  `exploration = 0.0` collapses to the point estimate; `1.0` is the calibrated posterior. */
-    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): VectorLike
+    fun sample(snapshot: R, rng: Random, exploration: Double = 1.0): Vector
 
     /** Writes an owned posterior draw into [destination]. */
     fun sampleInto(snapshot: R, rng: Random, destination: DoubleArray, exploration: Double = 1.0) {
@@ -60,13 +60,8 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
      * space, so the noise is added before the inverse link, never after: a score has to
      * come back on the same scale as the reward being maximised.
      */
-    override fun evaluate(
-        snapshot: R,
-        x: VectorLike,
-        rng: Random,
-        exploration: Double,
-        workspace: Workspace?,
-    ): Double = snapshot.link.invMean(snapshot.bias + (x dot sample(snapshot, rng, exploration)))
+    override fun evaluate(snapshot: R, x: Vector, rng: Random, exploration: Double, workspace: Workspace?): Double =
+        snapshot.link.invMean(snapshot.bias + (x dot sample(snapshot, rng, exploration)))
 }
 
 /**
@@ -77,7 +72,7 @@ sealed interface LinearPosterior<R : LinearRegressionResult> : RegressionPosteri
 @Serializable
 @SerialName("PointPosterior")
 data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
-    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): VectorLike {
+    override fun sample(snapshot: StochasticRegressionResult, rng: Random, exploration: Double): Vector {
         if (exploration <= 0.0) return snapshot.weights
         return DenseVector.wrap(
             DoubleArray(snapshot.weights.size).also { destination ->
@@ -107,7 +102,7 @@ data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
      *  are iid; one Gaussian draw instead of one per coordinate. */
     override fun evaluate(
         snapshot: StochasticRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -126,7 +121,7 @@ data object PointPosterior : LinearPosterior<StochasticRegressionResult> {
 @Serializable
 @SerialName("FactorisedGaussian")
 data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
-    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): VectorLike =
+    override fun sample(snapshot: DiagonalRegressionResult, rng: Random, exploration: Double): Vector =
         DenseVector.wrap(
             DoubleArray(snapshot.weights.size).also { destination ->
                 sampleInto(snapshot, rng, destination, exploration)
@@ -153,7 +148,7 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
     /** Sum of independent normals: `invMean(eta(x) + sqrt(exploration * Sum x_i^2 / precision[i]) * N(0,1))`. */
     override fun evaluate(
         snapshot: DiagonalRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -170,7 +165,7 @@ data object FactorisedGaussian : LinearPosterior<DiagonalRegressionResult> {
  * `sqrt(xT * Sigma * x) = ||L^-1 x||` for the precision factor `L` with `Sigma = (L * LT)^-1`.
  * One forward substitution, so the covariance is never formed.
  */
-private fun PrecisionRegressionResult.predictiveDeviation(x: VectorLike, workspace: Workspace?): Double =
+private fun PrecisionRegressionResult.predictiveDeviation(x: Vector, workspace: Workspace?): Double =
     workspace.borrow(featureSize) { v ->
         copy(x, DenseVector.wrap(v))
         precisionL.trsv(v, lower = true)
@@ -189,7 +184,7 @@ private fun PrecisionRegressionResult.predictiveDeviation(x: VectorLike, workspa
 @Serializable
 @SerialName("MultivariateGaussian")
 data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
-    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): VectorLike {
+    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): Vector {
         val n = snapshot.weights.size
         val sd = sqrt(exploration)
         val u = DoubleArray(n) { rng.nextNormal(0.0, sd) }
@@ -216,7 +211,7 @@ data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
      *  solve instead of sampling the full weight vector. */
     override fun evaluate(
         snapshot: PrecisionRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,
@@ -238,7 +233,7 @@ data object MultivariateGaussian : LinearPosterior<PrecisionRegressionResult> {
 @Serializable
 @SerialName("LinUcb")
 data object LinUcb : LinearPosterior<PrecisionRegressionResult> {
-    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): VectorLike =
+    override fun sample(snapshot: PrecisionRegressionResult, rng: Random, exploration: Double): Vector =
         snapshot.weights
 
     override fun sampleInto(
@@ -255,7 +250,7 @@ data object LinUcb : LinearPosterior<PrecisionRegressionResult> {
 
     override fun evaluate(
         snapshot: PrecisionRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: Workspace?,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/LinearRegressionResults.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.dot
 import com.eignex.kumulant.core.HasLinearModel
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
  *  - [PrecisionRegressionResult]: full posterior as the Cholesky factor of its precision.
  *
  * Sealed + `@Serializable`. Concrete weights round-trip as [DenseVector] today;
- * the public field is typed [VectorLike] so a sparse variant can swap in without
+ * the public field is typed [Vector] so a sparse variant can swap in without
  * breaking callers. Regression error metrics from [HasRegression] become
  * meaningful once [sse] is tracked; implementations that don't accumulate it
  * return `0.0`.
@@ -33,7 +33,7 @@ sealed interface LinearRegressionResult :
     Result,
     HasLinearModel,
     HasRegression {
-    override val weights: VectorLike
+    override val weights: Vector
 
     override val bias: Double
 
@@ -49,14 +49,14 @@ sealed interface LinearRegressionResult :
     val link: Link
 
     /** Linear predictor `eta = bias + x . weights`, before the inverse link. */
-    fun linearPredictor(x: VectorLike): Double {
+    fun linearPredictor(x: Vector): Double {
         x.requireFeatureSize(weights.size)
         return bias + (x dot weights)
     }
 
     /** Mean response: `link.invMean(linearPredictor(x))`. For [Link.Identity] this is
      *  the linear predictor itself, matching plain linear regression. */
-    override fun predict(x: VectorLike): Double = link.invMean(linearPredictor(x))
+    override fun predict(x: Vector): Double = link.invMean(linearPredictor(x))
 }
 
 /** SGD weight estimates with no posterior. Cheap, no uncertainty quantification.
@@ -74,7 +74,7 @@ data class StochasticRegressionResult(
     override val link: Link = Link.Identity,
     override val sse: Double = 0.0,
     /** Per-optimiser auxiliary state (e.g. Adam's `m`/`v`); empty for plain SGD. */
-    val updaterState: List<VectorLike> = emptyList(),
+    val updaterState: List<Vector> = emptyList(),
 ) : LinearRegressionResult
 
 /**

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/MatrixVector.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/MatrixVector.kt
@@ -2,12 +2,12 @@ package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.forEachStored
 import com.eignex.koblas.koblas
 
 /** Writes `matrix * x` to [destination] without materialising a vector for sparse or generic [x]. */
-internal fun DenseMatrix.multiplyInto(x: VectorLike, destination: DoubleArray) {
+internal fun DenseMatrix.multiplyInto(x: Vector, destination: DoubleArray) {
     require(x.size == cols) { "x size ${x.size} must match matrix columns $cols" }
     require(destination.size == rows) { "destination size ${destination.size} must match matrix rows $rows" }
     if (x is DenseVector) {

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/glm/StochasticRegressionStat.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.forEachStored
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
@@ -125,7 +125,7 @@ class StochasticRegressionStat(
     private fun requireSgdBiasRate(): ScalarExpr = sgdBiasRate ?: error("Sgd bias rate required")
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/package.md
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/package.md
@@ -17,7 +17,7 @@ fit either subfamily, plus the strategy types both rely on.
 | [GaussianNaiveBayesStat] | Regression | Per-class running Welford mean / variance of each feature plus class priors. The cheap non-parametric multiclass classifier. |
 
 Softmax and Naive Bayes implement [com.eignex.kumulant.core.RegressionStat]
-because that interface gives them `update(VectorLike, Double)`; the
+because that interface gives them `update(Vector, Double)`; the
 scalar `y` is the class index. Strictly they are classifiers, not
 regressors, but they share the input shape and the result is consumed
 the same way (a posterior over classes plus calibration / accuracy
@@ -49,7 +49,7 @@ per-feature-set; per-coordinate aux state honours the stat's
 
 [RegressionPosterior] is the scoring interface shared by every
 regression family. A posterior projects a [com.eignex.kumulant.core.Result]
-and a query [com.eignex.koblas.VectorLike] to a scalar score,
+and a query [com.eignex.koblas.Vector] to a scalar score,
 parametrised by an `exploration` knob and a `Random`. The contextual
 bandits ([com.eignex.kumulant.bandit.contextual.RegressionContextualBandit])
 consume posteriors at choose time.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTree.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.SeriesStat
 import com.eignex.kumulant.core.requireAtLeastTwoClasses
@@ -17,7 +17,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /** The classification instantiation of the node-shape SPI. */
 internal typealias ClassificationShapeSpi = TreeShape<
-    VectorLike,
+    Vector,
     SerializableSplit,
     ClassificationNode,
     ClassificationSplitNode,
@@ -57,22 +57,22 @@ class ClassificationTree(
     )
 
     /** Walk to the leaf [row] resolves to. */
-    fun findLeaf(row: VectorLike): ClassificationLeafNode = growth.root.findLeaf(row)
+    fun findLeaf(row: Vector): ClassificationLeafNode = growth.root.findLeaf(row)
 
     /** Live root node, for snapshotting. */
     fun rootNode(): ClassificationNode = growth.root
 
     /** Argmax class at the leaf [row] resolves to. */
-    fun predict(row: VectorLike): Int = findLeaf(row).arm.read(0L).predict()
+    fun predict(row: Vector): Int = findLeaf(row).arm.read(0L).predict()
 
     /** Probabilities at the leaf [row] resolves to. */
-    fun probabilities(row: VectorLike): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
+    fun probabilities(row: Vector): DoubleArray = findLeaf(row).arm.read(0L).probabilities()
 
     /** Number of internal + leaf nodes currently in the tree. */
     val nodeCount: Int get() = growth.nbrNodes.load()
 
     /** Fold an observation `(row, classLabel)` into the tree, possibly growing it. */
-    fun update(row: VectorLike, classLabel: Int, weight: Double = 1.0) {
+    fun update(row: Vector, classLabel: Int, weight: Double = 1.0) {
         if (classLabel !in 0 until numClasses) return
         growth.update(row, classLabel.toDouble(), weight)
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/ClassificationTreeNodes.kt
@@ -2,7 +2,7 @@
 
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.SeriesStat
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicLong
@@ -14,7 +14,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  */
 sealed interface ClassificationNode {
     /** Walk to the leaf this row resolves to. */
-    fun findLeaf(row: VectorLike): ClassificationLeafNode
+    fun findLeaf(row: Vector): ClassificationLeafNode
 }
 
 /** Split mirror; predicate routes to [pos] or [neg]; [carryover] absorbs orphan
@@ -35,7 +35,7 @@ class ClassificationSplitNode(
     @Volatile
     var carryover: SeriesStat<ClassCountsResult>? = carryover
 
-    override fun findLeaf(row: VectorLike): ClassificationLeafNode =
+    override fun findLeaf(row: Vector): ClassificationLeafNode =
         if (split.direction(row)) pos.findLeaf(row) else neg.findLeaf(row)
 }
 
@@ -43,7 +43,7 @@ class ClassificationSplitNode(
 sealed class ClassificationLeafNode : ClassificationNode {
     /** The leaf's class-count accumulator. */
     abstract val arm: SeriesStat<ClassCountsResult>
-    final override fun findLeaf(row: VectorLike): ClassificationLeafNode = this
+    final override fun findLeaf(row: Vector): ClassificationLeafNode = this
 }
 
 /** Frozen leaf; no further splits considered. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -85,7 +85,7 @@ class DecisionTreeClassifierStat(
     )
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/DecisionTreeRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.SeriesStat
@@ -77,9 +77,9 @@ class DecisionTreeRegressionStat(
     // path and rewritten by reset, so without it a concurrent updater can go on writing into the
     // pre-reset tree indefinitely, never observing the replacement.
     @Volatile
-    private var tree: RegressionTree<VectorLike> = newTree()
+    private var tree: RegressionTree<Vector> = newTree()
 
-    private fun newTree(): RegressionTree<VectorLike> = RegressionTree(
+    private fun newTree(): RegressionTree<Vector> = RegressionTree(
         splitCandidates,
         config,
         concurrency,
@@ -88,7 +88,7 @@ class DecisionTreeRegressionStat(
     )
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -127,5 +127,5 @@ class DecisionTreeRegressionStat(
     )
 
     /** Live underlying tree. Use for inspection / pretty-printing. */
-    fun tree(): RegressionTree<VectorLike> = tree
+    fun tree(): RegressionTree<Vector> = tree
 }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestClassifierStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -96,7 +96,7 @@ class RandomForestClassifierStat(
     )
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -179,7 +179,7 @@ data class ForestClassificationResult(
     }
 
     /** Average per-class probability across trees for the leaf each tree routes [x] to. */
-    fun probabilities(x: VectorLike): DoubleArray {
+    fun probabilities(x: Vector): DoubleArray {
         val acc = DoubleArray(numClasses)
         for (t in trees) {
             val p = t.probabilities(x)
@@ -191,7 +191,7 @@ data class ForestClassificationResult(
     }
 
     /** Argmax over [probabilities]. */
-    fun predict(x: VectorLike): Int {
+    fun predict(x: Vector): Int {
         val p = probabilities(x)
         return argMaxOf(numClasses) { k -> p[k] }
     }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RandomForestRegressionStat.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.core.Result
@@ -81,9 +81,9 @@ class RandomForestRegressionStat(
     // path and rewritten by reset, so without it a concurrent updater can go on writing into the
     // pre-reset tree indefinitely, never observing the replacement.
     @Volatile
-    private var trees: Array<RegressionTree<VectorLike>> = Array(nbrTrees) { newTree() }
+    private var trees: Array<RegressionTree<Vector>> = Array(nbrTrees) { newTree() }
 
-    private fun newTree(): RegressionTree<VectorLike> = RegressionTree(
+    private fun newTree(): RegressionTree<Vector> = RegressionTree(
         splitCandidates,
         this.config,
         concurrency,
@@ -92,7 +92,7 @@ class RandomForestRegressionStat(
     )
 
     override fun update(
-        x: VectorLike,
+        x: Vector,
         y: Double,
         timestampNanos: Long,
         weight: Double,
@@ -150,7 +150,7 @@ class RandomForestRegressionStat(
     )
 
     /** Live underlying trees. Use for inspection. */
-    fun trees(): List<RegressionTree<VectorLike>> = trees.toList()
+    fun trees(): List<RegressionTree<Vector>> = trees.toList()
 }
 
 /** Snapshot of a [RandomForestRegressionStat]: per-tree immutable snapshots. */
@@ -166,7 +166,7 @@ data class ForestRegressionResult(
 
     /** Merge the leaves that [x] routes to across every tree into a single weighted-
      *  variance aggregate. Useful for ensembled scoring. */
-    fun findLeafMerged(x: VectorLike): WeightedVarianceResult {
+    fun findLeafMerged(x: Vector): WeightedVarianceResult {
         // The `w2 <= 0.0` skip stays here rather than moving into mergeWVR, which short-circuits only
         // on an exactly-zero weight: a leaf left with negative total weight by an over-reaching
         // downdate would otherwise be folded in, and against a positive sibling of equal magnitude the
@@ -181,7 +181,7 @@ data class ForestRegressionResult(
     }
 
     /** Mean of [findLeafMerged]. */
-    fun predict(x: VectorLike): Double = findLeafMerged(x).mean
+    fun predict(x: Vector): Double = findLeafMerged(x).mean
 
     /** Sum of per-tree root totalWeights; `nbrTrees * underlyingWeight` under bagging. */
     val totalWeights: Double get() = trees.sumOf { it.totalWeights }

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/RegressionTree.kt
@@ -34,10 +34,10 @@ internal typealias RegressionShapeSpi<Row> = TreeShape<
  *
  * The engine is **generic over the feature representation**: it only ever inspects a row
  * by calling [Split.direction], so any feature type can drive growth by supplying its own
- * [Split]s (e.g. a dense [com.eignex.koblas.VectorLike] for the built-in stats, or
+ * [Split]s (e.g. a dense [com.eignex.koblas.Vector] for the built-in stats, or
  * a typed/constraint-coupled row from a downstream library). Wire-portable serialization
- * of a snapshot is only meaningful for the [com.eignex.koblas.VectorLike] case and
- * lives in `TreeRegressionResult.kt` as `VectorLike`-constrained extensions.
+ * of a snapshot is only meaningful for the [com.eignex.koblas.Vector] case and
+ * lives in `TreeRegressionResult.kt` as `Vector`-constrained extensions.
  *
  * Internal split nodes hold no live arm; subtree aggregates (`rootSnapshot`, the `value`
  * fields on the snapshot results) are derived by combining descendants at snapshot/merge

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/Split.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.schema.expr.BoolExpr
 import com.eignex.kumulant.schema.expr.eval
 import kotlinx.serialization.SerialName
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  *
  * The interface is intentionally **open and non-serializable**: it is the in-memory SPI
  * for growing trees over arbitrary features. Wire-portable splits over a dense
- * [VectorLike] context live under the [SerializableSplit] hierarchy, which the
+ * [Vector] context live under the [SerializableSplit] hierarchy, which the
  * serializable tree snapshots ([TreeNodeResult]) embed.
  */
 interface Split<in Row> {
@@ -23,13 +23,13 @@ interface Split<in Row> {
 }
 
 /**
- * Wire-portable [Split] over a dense [VectorLike] context. Sealed + serializable so tree
+ * Wire-portable [Split] over a dense [Vector] context. Sealed + serializable so tree
  * snapshots round-trip cleanly through `kotlinx.serialization`. Built-in implementations:
  * [ThresholdSplit] (numeric `x[i] <= t`) and [ExprSplit] (wrapping a [BoolExpr]); callers
  * needing custom predicates compose them as [BoolExpr] AST nodes and wrap in [ExprSplit].
  */
 @Serializable
-sealed interface SerializableSplit : Split<VectorLike>
+sealed interface SerializableSplit : Split<Vector>
 
 /** Route by `row[featureIndex] <= threshold`. Threshold is inclusive on the "pos" side. */
 @Serializable
@@ -40,7 +40,7 @@ data class ThresholdSplit(
     /** Inclusive threshold separating pos (<=) from neg (>). */
     val threshold: Double,
 ) : SerializableSplit {
-    override fun direction(row: VectorLike): Boolean = row[featureIndex] <= threshold
+    override fun direction(row: Vector): Boolean = row[featureIndex] <= threshold
     override fun toString(): String = "x[$featureIndex] <= $threshold"
 }
 
@@ -56,7 +56,7 @@ data class ExprSplit(
     /** Predicate expression over the context vector. */
     val expr: BoolExpr,
 ) : SerializableSplit {
-    override fun direction(row: VectorLike): Boolean {
+    override fun direction(row: Vector): Boolean {
         val x = if (row.size >= 1) row[0] else 0.0
         val y = if (row.size >= 2) row[1] else 0.0
         return expr.eval(x, y, row)

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeClassificationResult.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Result
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,13 +13,13 @@ data class TreeClassificationResult(
     val root: TreeClassificationNodeResult,
 ) : Result {
     /** Walk to the leaf the context [x] resolves to and return its class-count snapshot. */
-    fun findLeaf(x: VectorLike): ClassCountsResult = root.findLeaf(x)
+    fun findLeaf(x: Vector): ClassCountsResult = root.findLeaf(x)
 
     /** Class probabilities at the leaf [x] resolves to. */
-    fun probabilities(x: VectorLike): DoubleArray = findLeaf(x).probabilities()
+    fun probabilities(x: Vector): DoubleArray = findLeaf(x).probabilities()
 
     /** Argmax class index at the leaf [x] resolves to. */
-    fun predict(x: VectorLike): Int = findLeaf(x).predict()
+    fun predict(x: Vector): Int = findLeaf(x).predict()
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -35,7 +35,7 @@ sealed interface TreeClassificationNodeResult {
     val value: ClassCountsResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: VectorLike): ClassCountsResult
+    fun findLeaf(x: Vector): ClassCountsResult
 }
 
 /** Immutable classification split-node snapshot. */
@@ -50,15 +50,14 @@ data class TreeClassificationSplitResult(
     val neg: TreeClassificationNodeResult,
     override val value: ClassCountsResult,
 ) : TreeClassificationNodeResult {
-    override fun findLeaf(x: VectorLike): ClassCountsResult =
-        if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
+    override fun findLeaf(x: Vector): ClassCountsResult = if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
 /** Immutable classification leaf-node snapshot. */
 @Serializable
 @SerialName("TreeClassificationLeafResult")
 data class TreeClassificationLeafResult(override val value: ClassCountsResult) : TreeClassificationNodeResult {
-    override fun findLeaf(x: VectorLike): ClassCountsResult = value
+    override fun findLeaf(x: Vector): ClassCountsResult = value
 }
 
 /** Freeze a live classification-tree node into an immutable snapshot. */

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeInternals.kt
@@ -51,7 +51,7 @@ internal fun hoeffdingBound(delta: Double, n: Double, depth: Int, decay: Double)
  * offered different candidates.
  *
  * Generic in the split type because the regression tree is generic in its row type while the
- * classification tree is fixed to `VectorLike`.
+ * classification tree is fixed to `Vector`.
  *
  * @param S the split type, which differs between the two trees.
  * @param mtry subspace size, or null for the full pool.

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreePosteriors.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.math.nextNormal
 import com.eignex.kumulant.stat.regression.RegressionPosterior
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
@@ -27,7 +27,7 @@ sealed interface TreePosterior : RegressionPosterior<TreeRegressionResult>
 data object MeanTreePosterior : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -77,7 +77,7 @@ data class ThompsonTreePosterior(
 ) : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -103,7 +103,7 @@ data class UcbTreePosterior(
 ) : TreePosterior {
     override fun evaluate(
         snapshot: TreeRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -123,7 +123,7 @@ sealed interface ForestPosterior : RegressionPosterior<ForestRegressionResult>
 data object MeanForestPosterior : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -139,7 +139,7 @@ data class ThompsonForestPosterior(
 ) : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,
@@ -160,7 +160,7 @@ data class UcbForestPosterior(
 ) : ForestPosterior {
     override fun evaluate(
         snapshot: ForestRegressionResult,
-        x: VectorLike,
+        x: Vector,
         rng: Random,
         exploration: Double,
         workspace: com.eignex.koblas.Workspace?,

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/regression/tree/TreeRegressionResult.kt
@@ -1,18 +1,18 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.core.Result
 import com.eignex.kumulant.stat.summary.WeightedVarianceResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [VectorLike]
+ * Immutable, **wire-portable** snapshot of a [RegressionTree] over a dense [Vector]
  * context. Carries the tree structure ([SerializableSplit] predicates + per-node
  * weighted-variance aggregates) so callers can route a context vector to its leaf without
  * reaching back into the live stat.
  *
- * Serialization is only meaningful for the [VectorLike] feature representation (the splits
+ * Serialization is only meaningful for the [Vector] feature representation (the splits
  * must be wire-portable); trees grown over other [Split] row types use the live
  * [RegressionTree] directly and are not snapshotted to this type.
  *
@@ -26,10 +26,10 @@ data class TreeRegressionResult(
     val root: TreeNodeResult,
 ) : Result {
     /** Walk to the leaf the context resolves to. */
-    fun findLeaf(x: VectorLike): WeightedVarianceResult = root.findLeaf(x)
+    fun findLeaf(x: Vector): WeightedVarianceResult = root.findLeaf(x)
 
     /** Mean of the leaf the context resolves to. */
-    fun predict(x: VectorLike): Double = findLeaf(x).mean
+    fun predict(x: Vector): Double = findLeaf(x).mean
 
     /** Cumulative weight folded into the tree. */
     val totalWeights: Double get() = root.value.totalWeights
@@ -45,7 +45,7 @@ sealed interface TreeNodeResult {
     val value: WeightedVarianceResult
 
     /** Route [x] to the leaf this subtree assigns it to. */
-    fun findLeaf(x: VectorLike): WeightedVarianceResult
+    fun findLeaf(x: Vector): WeightedVarianceResult
 }
 
 /** Immutable split-node snapshot. */
@@ -60,7 +60,7 @@ data class TreeSplitResult(
     val neg: TreeNodeResult,
     override val value: WeightedVarianceResult,
 ) : TreeNodeResult {
-    override fun findLeaf(x: VectorLike): WeightedVarianceResult =
+    override fun findLeaf(x: Vector): WeightedVarianceResult =
         if (split.direction(x)) pos.findLeaf(x) else neg.findLeaf(x)
 }
 
@@ -68,19 +68,19 @@ data class TreeSplitResult(
 @Serializable
 @SerialName("TreeLeafResult")
 data class TreeLeafResult(override val value: WeightedVarianceResult) : TreeNodeResult {
-    override fun findLeaf(x: VectorLike): WeightedVarianceResult = value
+    override fun findLeaf(x: Vector): WeightedVarianceResult = value
 }
 
 /**
- * Freeze a live [VectorLike] tree node into an immutable, serializable snapshot. Internal
+ * Freeze a live [Vector] tree node into an immutable, serializable snapshot. Internal
  * split aggregates are derived from the snapshotted children so the wire format stays
  * stable even though live splits hold no arm.
  *
- * Snapshotting is `VectorLike`-only because the wire format requires [SerializableSplit];
- * a `VectorLike` tree is always grown from [SerializableSplit] candidates, so the cast on
+ * Snapshotting is `Vector`-only because the wire format requires [SerializableSplit];
+ * a `Vector` tree is always grown from [SerializableSplit] candidates, so the cast on
  * each split is safe by construction.
  */
-fun RegressionNode<VectorLike>.snapshot(): TreeNodeResult = when (this) {
+fun RegressionNode<Vector>.snapshot(): TreeNodeResult = when (this) {
     is RegressionSplitNode -> {
         val p = pos.snapshot()
         val n = neg.snapshot()
@@ -95,22 +95,22 @@ fun RegressionNode<VectorLike>.snapshot(): TreeNodeResult = when (this) {
 
 /**
  * Snapshot merge using only the immutable result. Mirrors [RegressionTree.merge] but the
- * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `VectorLike`
+ * "other" side is a [TreeNodeResult] tree-of-results rather than a live tree. `Vector`
  * only, for the same reason [snapshot] is.
  *
- * An extension rather than a member because it exists only at `Row = VectorLike`, which a member of a
+ * An extension rather than a member because it exists only at `Row = Vector`, which a member of a
  * generic class cannot be constrained to. The algorithm is [TreeGrowth.mergeSnapshot].
  */
-fun RegressionTree<VectorLike>.mergeSnapshot(other: TreeNodeResult, workspace: com.eignex.koblas.Workspace? = null) {
+fun RegressionTree<Vector>.mergeSnapshot(other: TreeNodeResult, workspace: com.eignex.koblas.Workspace? = null) {
     growth.mergeSnapshot(other, RegressionResultShape, workspace)
 }
 
 /** Reads the immutable regression snapshot hierarchy on the growth engine's behalf. */
 private object RegressionResultShape :
-    TreeResultShape<Split<VectorLike>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
+    TreeResultShape<Split<Vector>, TreeNodeResult, TreeSplitResult, WeightedVarianceResult> {
     override fun asSplitResult(node: TreeNodeResult): TreeSplitResult? = node as? TreeSplitResult
 
-    override fun splitOf(node: TreeSplitResult): Split<VectorLike> = node.split
+    override fun splitOf(node: TreeSplitResult): Split<Vector> = node.split
 
     override fun posOf(node: TreeSplitResult): TreeNodeResult = node.pos
 

--- a/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
+++ b/kumulant/src/commonMain/kotlin/com/eignex/kumulant/stat/score/ConfusionMatrixStat.kt
@@ -42,7 +42,7 @@ data class ConfusionMatrixResult(
     fun count(predicted: Int, truth: Int): Double = counts[predicted * numClasses + truth]
 
     /** Total weight across all cells. */
-    val totalWeights: Double get() = koblas.kernels.sum(counts, 0, counts.size)
+    val totalWeights: Double get() = koblas.vectorKernels.sum(counts, 0, counts.size)
 
     /** Sum of the diagonal (correctly classified weight). */
     val correct: Double get() {
@@ -55,7 +55,7 @@ data class ConfusionMatrixResult(
     val accuracy: Double get() = totalWeights.let { if (it > 0.0) correct / it else 0.0 }
 
     /** Predicted-class total: weight of all rows where prediction = [c]. */
-    fun predictedTotal(c: Int): Double = koblas.kernels.sum(counts, c * numClasses, numClasses)
+    fun predictedTotal(c: Int): Double = koblas.vectorKernels.sum(counts, c * numClasses, numClasses)
 
     /**
      * True-class total: weight of all columns where truth = [c].

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/ArmIndexContractSweepTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
 import com.eignex.kumulant.bandit.univariate.BernoulliArm
@@ -26,7 +26,7 @@ class ArmIndexContractSweepTest {
 
     private class Probe(val name: String, val calls: List<Pair<String, (Int) -> Any?>>)
 
-    private val x: VectorLike = feat(1.0, 1.0)
+    private val x: Vector = feat(1.0, 1.0)
 
     private fun probes(): List<Probe> {
         val multiArmed = MultiArmedBandit(ARMS, ThompsonSampling(BernoulliArm(), BetaPosterior), Random(0))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/BanditTuningTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.univariate.Exp3ArmResult
@@ -48,7 +48,7 @@ class BanditTuningTest {
         val alwaysFirst = Exp4Expert { _, k -> DoubleArray(k) { if (it == 0) 1.0 else 0.0 } }
         val alwaysSecond = Exp4Expert { _, k -> DoubleArray(k) { if (it == 1) 1.0 else 0.0 } }
         val bandit = Exp4Bandit(nbrArms = 2, experts = listOf(alwaysFirst, alwaysSecond), random = Random(3))
-        val x: VectorLike = DenseVector.of(doubleArrayOf(1.0))
+        val x: Vector = DenseVector.of(doubleArrayOf(1.0))
 
         repeat(500) {
             bandit.update(0, x, 1.0)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/StandaloneBanditExtraTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bandit.contextual.Exp4Bandit
 import com.eignex.kumulant.bandit.contextual.Exp4Expert
 import com.eignex.kumulant.bandit.contextual.KnnContextualBandit
@@ -73,7 +73,7 @@ class StandaloneBanditExtraTest {
     fun `Exp4 expertWeights sum to 1`() {
         val experts: List<Exp4Expert> = listOf(
             Exp4Expert { _, n -> DoubleArray(n) { 1.0 / n } },
-            Exp4Expert { _: VectorLike, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
+            Exp4Expert { _: Vector, n: Int -> DoubleArray(n).also { it[0] = 1.0 } },
         )
         val b = Exp4Bandit(nbrArms = 3, experts = experts, random = Random(1))
         repeat(20) { b.update(b.choose(feat(0.0)), feat(0.0), 1.0) }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/TrackedBanditTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.bandit
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.bandit.contextual.RegressionContextualBandit
@@ -33,7 +33,7 @@ class TrackedBanditTest {
     private class RecordingRegressionStat(private val recorder: WorkspaceRecorder) : RegressionStat<SumResult> {
         override val concurrency = Concurrency.None
         override val featureSize = 1
-        override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
+        override fun update(x: Vector, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
             recorder.workspace = workspace
         }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/Exp4BanditTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.bandit.contextual
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.feat
 import kotlin.math.abs
 import kotlin.random.Random
@@ -179,10 +179,10 @@ class Exp4BanditTest {
     @Test
     fun `context-aware experts win on context-dependent rewards`() {
         // Expert "left" picks arm 0 when x<0, arm 1 when x>=0; opposite for "right".
-        val left = Exp4Expert { x: VectorLike, n: Int ->
+        val left = Exp4Expert { x: Vector, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 0 else 1] = 1.0 }
         }
-        val right = Exp4Expert { x: VectorLike, n: Int ->
+        val right = Exp4Expert { x: Vector, n: Int ->
             DoubleArray(n).also { it[if (x[0] < 0.0) 1 else 0] = 1.0 }
         }
         val rng = Random(5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnContextualBanditTest.kt
@@ -257,7 +257,7 @@ class KnnContextualBanditTest {
             reused.update(arm, x, reward)
         }
         val x = SparseVector.of(3, intArrayOf(0), doubleArrayOf(0.5))
-        val workspace = Workspace().apply { reserve(6, 1) }
+        val workspace = Workspace()
 
         for (arm in 0 until 2) assertEquals(allocating.evaluate(arm, x), reused.evaluate(arm, x, workspace), 1e-12)
         assertEquals(allocating.choose(x), reused.choose(x, workspace))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/bandit/contextual/RegressionContextualBanditTest.kt
@@ -97,7 +97,7 @@ class RegressionContextualBanditTest {
         )
         bandit.update(0, feat(1.0, 0.0), 1.0)
         val x = feat(1.0, 0.0)
-        val workspace = Workspace().apply { reserve(2, 1) }
+        val workspace = Workspace()
 
         val contextual: ContextualBandit = bandit
         val scorable: ContextualScorable = bandit
@@ -148,7 +148,7 @@ class RegressionContextualBanditTest {
             posterior = MultivariateGaussian,
             random = Random(3),
         )
-        val workspace = Workspace().apply { reserve(2, 3) }
+        val workspace = Workspace()
         merged.merge(ba.snapshot(), workspace)
         merged.merge(bb.snapshot(), workspace)
         // Merged bandit should have higher total weight per arm than either replica.

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/math/CholeskyTest.kt
@@ -277,7 +277,7 @@ class CholeskyTest {
 
     @Test
     fun `rank one update represents the weighted outer product without changing its input`() {
-        for (workspace in listOf(null, Workspace().apply { reserve(3, 2) })) {
+        for (workspace in listOf(null, Workspace())) {
             val factor = DenseMatrix.diagonal(3, 2.0).cholesky()
             val v = doubleArrayOf(1.0, -2.0, 3.0)
 
@@ -342,7 +342,7 @@ class CholeskyTest {
 
     @Test
     fun `inverse overwrites both triangles and preserves the factor with reused scratch`() {
-        for (workspace in listOf(null, Workspace().apply { reserve(2, 1) })) {
+        for (workspace in listOf(null, Workspace())) {
             val factor = DenseMatrix.wrap(2, 2, doubleArrayOf(4.0, 2.0, 2.0, 5.0)).cholesky()
             val original = factor.data.copyOf()
             val out = DenseMatrix.wrap(2, 2, DoubleArray(4) { Double.NaN })

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/ExprTest.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.schema
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.koblas.StridedVectorView
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
 import com.eignex.kumulant.core.ResultList
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
 
 class ExprTest {
 
-    private class NoMaterializeVector(private val values: DoubleArray) : VectorLike {
+    private class NoMaterializeVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("expression materialised its vector input")
@@ -59,7 +59,7 @@ class ExprTest {
         val predicate = (V(0) gt 0.0) and (V(2) lt 0.0)
         val vector = VElements(listOf(V(2), V(0) + V(1)))
 
-        for (input in listOf<VectorLike>(dense, sparse, strided, custom)) {
+        for (input in listOf<Vector>(dense, sparse, strided, custom)) {
             assertEquals(-7.0, scalar.eval(v = input), DELTA)
             assertTrue(predicate.eval(v = input))
             assertTrue(vector.eval(v = input).contentEquals(doubleArrayOf(-3.0, 2.0)))
@@ -419,7 +419,7 @@ class ExprTest {
         val folds = VFoldOp.entries.map(::VFold)
 
         for (array in values) {
-            val representations = listOf<VectorLike>(
+            val representations = listOf<Vector>(
                 DenseVector.of(array),
                 sparse(array),
                 StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
@@ -465,7 +465,7 @@ class ExprTest {
         for ((array, weights) in cases.zip(weightSets)) {
             val expr = VDot(weights)
             val expected = expr.eval(0.0, 0.0, array)
-            for (input in listOf<VectorLike>(
+            for (input in listOf<Vector>(
                 DenseVector.of(array),
                 sparse(array),
                 StridedVectorView(DoubleArray(array.size * 2) { array[it / 2] }, 0, array.size, 2),
@@ -521,7 +521,7 @@ class ExprTest {
             assertEquals(expr.eval(0.0, 0.0, values), expr.eval(v = NoMaterializeVector(values)))
         }
 
-        class CountingVector(private val values: DoubleArray) : VectorLike {
+        class CountingVector(private val values: DoubleArray) : Vector {
             var reads = 0
             override val size: Int get() = values.size
             override fun get(i: Int): Double = values[i].also { reads++ }

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/RegressionListStatsTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
@@ -31,7 +31,7 @@ class RegressionListStatsTest {
         override val featureSize = 1
         var workspace: Workspace? = null
 
-        override fun update(x: VectorLike, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
+        override fun update(x: Vector, y: Double, timestampNanos: Long, weight: Double, workspace: Workspace?) {
             this.workspace = workspace
         }
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/schema/StatGroupTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.DELTA
 import com.eignex.kumulant.core.Concurrency
@@ -659,7 +659,7 @@ class VectorStatGroupTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: Vector, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>, workspace: com.eignex.koblas.Workspace?) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())
@@ -776,7 +776,7 @@ class VectorListStatsTest {
 
         val tracking = object : VectorStat<ResultList<SumResult>> {
             override val concurrency: Concurrency = Concurrency.None
-            override fun update(vector: VectorLike, timestampNanos: Long, weight: Double) = Unit
+            override fun update(vector: Vector, timestampNanos: Long, weight: Double) = Unit
             override fun merge(values: ResultList<SumResult>, workspace: com.eignex.koblas.Workspace?) = Unit
             override fun reset() = Unit
             override fun read(timestampNanos: Long) = ResultList<SumResult>(emptyList())

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesResultTest.kt
@@ -23,8 +23,8 @@ class GaussianNaiveBayesResultTest {
     ) = GaussianNaiveBayesResult(
         featureSize = featureSize,
         numClasses = numClasses,
-        means = DenseMatrix.of(means),
-        variances = DenseMatrix.of(variances),
+        means = DenseMatrix.ofRows(means),
+        variances = DenseMatrix.ofRows(variances),
         classWeights = DenseVector.of(classWeights),
         totalWeights = totalWeights,
         varianceFloor = varianceFloor,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/GaussianNaiveBayesStatTest.kt
@@ -3,7 +3,7 @@ package com.eignex.kumulant.stat.regression
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.koblas.StridedVectorView
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.DELTA
 import kotlin.math.abs
 import kotlin.random.Random
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
 
 class GaussianNaiveBayesStatTest {
 
-    private class CustomVector(private val values: DoubleArray) : VectorLike {
+    private class CustomVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -129,7 +129,7 @@ class GaussianNaiveBayesStatTest {
         val custom = CustomVector(doubleArrayOf(0.5, 0.0, -1.0))
         val expected = result.probabilities(dense)
 
-        for (x in listOf<VectorLike>(sparse, strided, custom)) {
+        for (x in listOf<Vector>(sparse, strided, custom)) {
             val logs = DoubleArray(2)
             val probabilities = DoubleArray(2)
             result.logPosteriorsInto(x, logs)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/RegressionWeightContractTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.stat.regression.glm.BayesianRegressionStat
 import com.eignex.kumulant.stat.regression.glm.DiagonalRegressionStat
 import com.eignex.kumulant.stat.regression.glm.StochasticRegressionStat
@@ -29,7 +29,7 @@ class RegressionWeightContractTest {
     private class Model(
         val name: String,
         val y: Double,
-        val update: (VectorLike, Double, Double) -> Unit,
+        val update: (Vector, Double, Double) -> Unit,
         val snapshot: () -> String,
     )
 

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionResultTest.kt
@@ -3,14 +3,14 @@ package com.eignex.kumulant.stat.regression
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class SoftmaxRegressionResultTest {
 
-    private class StridedVector(private val backing: DoubleArray) : VectorLike {
+    private class StridedVector(private val backing: DoubleArray) : Vector {
         override val size: Int get() = backing.size / 2
         override fun get(i: Int): Double = backing[i * 2]
         override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
@@ -20,7 +20,7 @@ class SoftmaxRegressionResultTest {
         SoftmaxRegressionResult(
             featureSize = weights[0].size,
             numClasses = weights.size,
-            weights = DenseMatrix.of(weights),
+            weights = DenseMatrix.ofRows(weights),
             biases = DenseVector.of(biases),
             totalWeights = 0.0,
             step = 0L,
@@ -57,7 +57,7 @@ class SoftmaxRegressionResultTest {
         val strided = StridedVector(doubleArrayOf(2.0, 9.0, 0.0, 9.0, -1.0, 9.0, 0.0, 9.0))
 
         val expected = r.probabilities(dense)
-        for (x in listOf<VectorLike>(sparse, strided)) {
+        for (x in listOf<Vector>(sparse, strided)) {
             val actual = r.probabilities(x)
             assertEquals(expected[0], actual[0], 1e-12)
             assertEquals(expected[1], actual[1], 1e-12)
@@ -73,7 +73,7 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 3,
                 numClasses = 2,
-                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                weights = DenseMatrix.ofRows(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
                 biases = DenseVector.of(doubleArrayOf(0.0, 0.0)),
                 totalWeights = 0.0,
                 step = 0L,
@@ -88,7 +88,7 @@ class SoftmaxRegressionResultTest {
             SoftmaxRegressionResult(
                 featureSize = 2,
                 numClasses = 2,
-                weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
+                weights = DenseMatrix.ofRows(arrayOf(doubleArrayOf(1.0, 2.0), doubleArrayOf(3.0, 4.0))),
                 biases = DenseVector.of(doubleArrayOf(0.0)),
                 totalWeights = 0.0,
                 step = 0L,

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxRegressionStatTest.kt
@@ -4,7 +4,7 @@ import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.koblas.StridedVectorView
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.schema.optimizer.Sgd
 import com.eignex.kumulant.stat.regression.glm.ConstantRate
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 
 class SoftmaxRegressionStatTest {
 
-    private class CustomVector(private val values: DoubleArray) : VectorLike {
+    private class CustomVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -28,7 +28,7 @@ class SoftmaxRegressionStatTest {
         val r = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = DenseMatrix.of(
+            weights = DenseMatrix.ofRows(
                 arrayOf(
                     doubleArrayOf(1.0, 0.0),
                     doubleArrayOf(0.0, 1.0),
@@ -52,7 +52,7 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = DenseMatrix.of(
+            weights = DenseMatrix.ofRows(
                 arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0), doubleArrayOf(-1.0, 1.0)),
             ),
             biases = DenseVector.of(doubleArrayOf(0.2, -0.1, 0.4)),
@@ -61,7 +61,7 @@ class SoftmaxRegressionStatTest {
             crossEntropy = 0.0,
         )
         val x = DenseVector.of(doubleArrayOf(2.0, -1.0))
-        val workspace = Workspace().apply { reserve(3, 1) }
+        val workspace = Workspace()
         val probabilities = DoubleArray(3)
 
         result.probabilitiesInto(x, probabilities)
@@ -78,7 +78,7 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = DenseMatrix.of(
+            weights = DenseMatrix.ofRows(
                 arrayOf(doubleArrayOf(1.0, -1.0), doubleArrayOf(2.0, 0.5), doubleArrayOf(-0.5, 1.5)),
             ),
             biases = DenseVector.of(doubleArrayOf(0.1, 0.2, -0.3)),
@@ -92,11 +92,11 @@ class SoftmaxRegressionStatTest {
         val custom = CustomVector(doubleArrayOf(0.25, -0.5))
         val expected = result.probabilities(dense)
 
-        for (x in listOf<VectorLike>(sparse, strided, custom)) {
+        for (x in listOf<Vector>(sparse, strided, custom)) {
             val actual = DoubleArray(3)
             result.probabilitiesInto(x, actual)
             assertTrue(actual.contentEquals(expected))
-            assertEquals(result.predict(dense), result.predict(x, Workspace().apply { reserve(3, 1) }))
+            assertEquals(result.predict(dense), result.predict(x, Workspace()))
         }
     }
 
@@ -105,13 +105,13 @@ class SoftmaxRegressionStatTest {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 2,
-            weights = DenseMatrix.of(arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0))),
+            weights = DenseMatrix.ofRows(arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0))),
             biases = DenseVector.of(doubleArrayOf(0.0, 0.0)),
             totalWeights = 0.0,
             step = 0L,
             crossEntropy = 0.0,
         )
-        val workspace = Workspace().apply { reserve(2, 1) }
+        val workspace = Workspace()
 
         assertFailsWith<IllegalArgumentException> { result.predict(DenseVector.of(doubleArrayOf(1.0)), workspace) }
         assertEquals(0, result.predict(DenseVector.of(doubleArrayOf(1.0, 0.0)), workspace))

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatPriorTest.kt
@@ -29,7 +29,7 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `custom prior seeds the initial weights and covariance`() {
         val mean = DenseVector.of(doubleArrayOf(0.5, -1.0, 2.0))
-        val cov = DenseMatrix.of(
+        val cov = DenseMatrix.ofRows(
             arrayOf(
                 doubleArrayOf(1.0, 0.3, 0.0),
                 doubleArrayOf(0.3, 1.0, 0.0),
@@ -52,7 +52,7 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `non positive definite prior covariance is rejected at construction`() {
         // Diagonal with a negative entry - immediately non-PD.
-        val bad = DenseMatrix.of(
+        val bad = DenseMatrix.ofRows(
             arrayOf(
                 doubleArrayOf(1.0, 0.0),
                 doubleArrayOf(0.0, -0.1),
@@ -114,7 +114,7 @@ class BayesianRegressionStatPriorTest {
         // a single instance trained on the union - independent of the prior, as long
         // as both branches start from the same prior.
         val priorMean = DenseVector.of(doubleArrayOf(0.2, -0.1))
-        val priorCov = DenseMatrix.of(
+        val priorCov = DenseMatrix.ofRows(
             arrayOf(
                 doubleArrayOf(0.5, 0.1),
                 doubleArrayOf(0.1, 0.5),
@@ -154,7 +154,7 @@ class BayesianRegressionStatPriorTest {
     @Test
     fun `merging an empty custom prior state preserves the populated posterior`() {
         val priorMean = DenseVector.of(doubleArrayOf(0.4, -0.7))
-        val priorCovariance = DenseMatrix.of(
+        val priorCovariance = DenseMatrix.ofRows(
             arrayOf(
                 doubleArrayOf(0.8, 0.2),
                 doubleArrayOf(0.2, 0.6),

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianRegressionStatTest.kt
@@ -2,7 +2,7 @@ package com.eignex.kumulant.stat.regression.glm
 
 import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.kumulant.core.RegressionStat
 import com.eignex.kumulant.fitLine
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 class BayesianRegressionStatTest {
 
-    private class StridedVector(private val backing: DoubleArray) : VectorLike {
+    private class StridedVector(private val backing: DoubleArray) : Vector {
         override val size: Int get() = backing.size / 2
         override fun get(i: Int): Double = backing[i * 2]
         override fun toDoubleArray(): DoubleArray = DoubleArray(size) { this[it] }
@@ -63,7 +63,7 @@ class BayesianRegressionStatTest {
     fun `workspace updates and merge match allocating paths`() {
         val allocated = BayesianRegressionStat(featureSize = 2)
         val reused = BayesianRegressionStat(featureSize = 2)
-        val workspace = Workspace().apply { reserve(2, 3) }
+        val workspace = Workspace()
         repeat(20) { i ->
             val x = DenseVector.of(doubleArrayOf(i.toDouble() / 20.0, 1.0))
             allocated.update(x, x[0] + 2.0)
@@ -82,7 +82,7 @@ class BayesianRegressionStatTest {
 
     @Test
     fun `regression stat interface accepts nullable workspace for update and merge`() {
-        val workspace = Workspace().apply { reserve(2, 3) }
+        val workspace = Workspace()
         val receiver: RegressionStat<PrecisionRegressionResult> = BayesianRegressionStat(featureSize = 2)
         val source: RegressionStat<PrecisionRegressionResult> = BayesianRegressionStat(featureSize = 2)
 
@@ -280,7 +280,7 @@ class BayesianRegressionStatTest {
                         featureSize = 2,
                         priorVariance = 1.0,
                         priorMean = DenseVector.of(doubleArrayOf(0.25, -0.5)),
-                        priorCovariance = DenseMatrix.of(
+                        priorCovariance = DenseMatrix.ofRows(
                             arrayOf(doubleArrayOf(2.0, 0.5), doubleArrayOf(0.5, 1.5)),
                         ),
                     ).also { stat ->

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/glm/LinearPosteriorsTest.kt
@@ -4,7 +4,7 @@ import com.eignex.koblas.DenseMatrix
 import com.eignex.koblas.DenseVector
 import com.eignex.koblas.SparseVector
 import com.eignex.koblas.StridedVectorView
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.koblas.Workspace
 import com.eignex.koblas.borrow
 import com.eignex.kumulant.math.nextNormal
@@ -17,7 +17,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 class LinearPosteriorsTest {
 
-    private class CustomVector(private val values: DoubleArray) : VectorLike {
+    private class CustomVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = values.copyOf()
@@ -60,7 +60,7 @@ class LinearPosteriorsTest {
     fun `workspace covariance evaluation matches allocating evaluation and preserves random draws`() {
         val snapshot = bayesianSnapshot()
         val x = SparseVector.of(size = 2, indices = intArrayOf(0), values = doubleArrayOf(0.3))
-        val workspace = Workspace().apply { reserve(2, 1) }
+        val workspace = Workspace()
 
         val allocated = MultivariateGaussian.evaluate(snapshot, x, Random(9), exploration = 0.7)
         val reused = MultivariateGaussian.evaluate(snapshot, x, Random(9), exploration = 0.7, workspace = workspace)
@@ -74,7 +74,7 @@ class LinearPosteriorsTest {
         val dense = DenseVector.of(doubleArrayOf(0.3, -0.2))
         val strided = StridedVectorView(doubleArrayOf(0.3, 7.0, -0.2, 7.0), 0, 2, 2)
         val custom = CustomVector(doubleArrayOf(0.3, -0.2))
-        val workspace = Workspace().apply { reserve(2, 1) }
+        val workspace = Workspace()
 
         val expected = LinUcb.evaluate(snapshot, dense, Random(0), exploration = 0.7, workspace = workspace)
         assertEquals(
@@ -93,7 +93,7 @@ class LinearPosteriorsTest {
     fun `sampleInto matches an owned multivariate sample without aliasing later borrows`() {
         val snapshot = bayesianSnapshot()
         val destination = DoubleArray(2)
-        val workspace = Workspace().apply { reserve(2, 1) }
+        val workspace = Workspace()
 
         MultivariateGaussian.sampleInto(snapshot, Random(21), destination, exploration = 0.4)
         val expected = MultivariateGaussian.sample(snapshot, Random(21), exploration = 0.4)
@@ -235,7 +235,7 @@ class LinearPosteriorsTest {
             biasPrecision = 1.0,
             totalWeights = 0.0,
             step = 0L,
-            precisionL = DenseMatrix.of(arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(3.0, 4.0))),
+            precisionL = DenseMatrix.ofRows(arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(3.0, 4.0))),
         )
         val expectedRng = Random(7)
         val u0 = expectedRng.nextNormal(0.0, 0.5)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/SplitTest.kt
@@ -1,7 +1,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.koblas.SparseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.feat
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.X
@@ -68,7 +68,7 @@ class SplitTest {
         assertFalse(s.direction(NoMaterializeVector(doubleArrayOf(0.0, -1.0))))
     }
 
-    private class NoMaterializeVector(private val values: DoubleArray) : VectorLike {
+    private class NoMaterializeVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("split materialised its context")

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeGrowthParityTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.stat.regression.tree
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.feat
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +21,7 @@ class TreeGrowthParityTest {
 
     private val candidates = listOf(ThresholdSplit(0, 0.5), ThresholdSplit(1, 0.5))
 
-    private fun regressionStructure(node: RegressionNode<VectorLike>): String = when (node) {
+    private fun regressionStructure(node: RegressionNode<Vector>): String = when (node) {
         is RegressionSplitNode -> "(${node.split} ? ${regressionStructure(node.pos)}" +
             " : ${regressionStructure(node.neg)})"
 
@@ -35,8 +35,8 @@ class TreeGrowthParityTest {
         is ClassificationLeafNode -> "leaf"
     }
 
-    private fun grownPair(observations: Int): Pair<RegressionTree<VectorLike>, ClassificationTree> {
-        val regression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 7)
+    private fun grownPair(observations: Int): Pair<RegressionTree<Vector>, ClassificationTree> {
+        val regression = RegressionTree<Vector>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(
             numClasses = 2,
             splitCandidates = candidates,
@@ -71,7 +71,7 @@ class TreeGrowthParityTest {
 
     @Test
     fun `neither tree splits while the candidates carry no signal`() {
-        val regression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 7)
+        val regression = RegressionTree<Vector>(splitCandidates = candidates, randomSeed = 7)
         val classification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 7)
         // A constant label leaves every candidate at zero impurity reduction, so shouldSplit must refuse
         // in both trees no matter how much weight piles up.
@@ -88,7 +88,7 @@ class TreeGrowthParityTest {
     fun `snapshot merge into a fresh tree reproduces the grown shape on both sides`() {
         val (regression, classification) = grownPair(observations = 4000)
 
-        val freshRegression = RegressionTree<VectorLike>(splitCandidates = candidates, randomSeed = 9)
+        val freshRegression = RegressionTree<Vector>(splitCandidates = candidates, randomSeed = 9)
         freshRegression.mergeSnapshot(regression.rootNode().snapshot())
 
         val freshClassification = ClassificationTree(numClasses = 2, splitCandidates = candidates, randomSeed = 9)

--- a/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
+++ b/kumulant/src/commonTest/kotlin/com/eignex/kumulant/stat/regression/tree/TreeNodeTest.kt
@@ -3,7 +3,7 @@
 package com.eignex.kumulant.stat.regression.tree
 
 import com.eignex.koblas.DenseVector
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.stat.summary.VarianceStat
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 
 class TreeNodeTest {
 
-    private fun wvLeaf(): RegressionTerminalLeaf<VectorLike> = RegressionTerminalLeaf(VarianceStat())
+    private fun wvLeaf(): RegressionTerminalLeaf<Vector> = RegressionTerminalLeaf(VarianceStat())
     private fun ccLeaf(numClasses: Int = 2) = ClassificationTerminalLeaf(ClassCountsStat(numClasses))
 
     @Test

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/bandit/contextual/KnnWorkspaceAllocationTest.kt
@@ -28,7 +28,7 @@ class KnnWorkspaceAllocationTest {
         val bare = populatedBandit()
         val reused = populatedBandit()
         val x = DenseVector.of(DoubleArray(FEATURES) { it * 0.25 })
-        val workspace = Workspace().apply { reserve(3 * K, 1) }
+        val workspace = Workspace()
 
         // The scan buffer is owned by the bandit, so there is nothing left for a workspace to save
         // and nothing left to allocate when one is absent. A buffer coming back would be a

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/schema/ExprAllocationTest.kt
@@ -1,6 +1,6 @@
 package com.eignex.kumulant.schema
 
-import com.eignex.koblas.VectorLike
+import com.eignex.koblas.Vector
 import com.eignex.kumulant.bytesPerCall
 import com.eignex.kumulant.schema.expr.V
 import com.eignex.kumulant.schema.expr.VElements
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 class ExprAllocationTest {
 
-    private class Vector(private val values: DoubleArray) : VectorLike {
+    private class AllocationVector(private val values: DoubleArray) : Vector {
         override val size: Int get() = values.size
         override fun get(i: Int): Double = values[i]
         override fun toDoubleArray(): DoubleArray = error("unexpected materialisation")
@@ -23,13 +23,13 @@ class ExprAllocationTest {
         val scalar = V(0) + V(1)
         val predicate = V(0) gt 0.0
         val vector = VElements(listOf(V(0)))
-        fun evaluate(input: VectorLike) {
+        fun evaluate(input: Vector) {
             scalar.eval(v = input)
             predicate.eval(v = input)
             vector.eval(v = input)
         }
         val widths = intArrayOf(8, 32, 128, 512)
-        val inputs = widths.map { width -> Vector(DoubleArray(width) { 1.0 }) }
+        val inputs = widths.map { width -> AllocationVector(DoubleArray(width) { 1.0 }) }
 
         val bytes = bytesPerCall(
             { evaluate(inputs[0]) },

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/SoftmaxWorkspaceAllocationTest.kt
@@ -13,11 +13,11 @@ import kotlin.test.assertTrue
 class SoftmaxWorkspaceAllocationTest {
 
     @Test
-    fun `reserved workspace removes softmax update logits allocation`() {
+    fun `workspace reuses softmax update logits allocation`() {
         val allocating = SoftmaxRegressionStat(featureSize = 8, numClasses = 4, optimizer = Sgd(ConstantRate(0.05)))
         val reused = SoftmaxRegressionStat(featureSize = 8, numClasses = 4, optimizer = Sgd(ConstantRate(0.05)))
         val x = DenseVector.of(DoubleArray(8) { (it + 1).toDouble() / 8.0 })
-        val workspace = Workspace().apply { reserve(4, 1) }
+        val workspace = Workspace()
 
         val (allocatedBytes, workspaceBytes) = bytesPerCall(
             { allocating.update(x, 1.0) },
@@ -31,11 +31,11 @@ class SoftmaxWorkspaceAllocationTest {
     }
 
     @Test
-    fun `a reserved workspace removes the logits buffer softmax prediction otherwise allocates`() {
+    fun `a workspace reuses the logits buffer softmax prediction otherwise allocates`() {
         val result = SoftmaxRegressionResult(
             featureSize = 2,
             numClasses = 3,
-            weights = DenseMatrix.of(
+            weights = DenseMatrix.ofRows(
                 arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 1.0), doubleArrayOf(-1.0, -1.0)),
             ),
             biases = DenseVector.of(doubleArrayOf(0.0, 0.0, 0.0)),
@@ -44,7 +44,7 @@ class SoftmaxWorkspaceAllocationTest {
             crossEntropy = 0.0,
         )
         val x = DenseVector.of(doubleArrayOf(1.0, 0.5))
-        val workspace = Workspace().apply { reserve(3, 1) }
+        val workspace = Workspace()
 
         val (defaultBytes, nullBytes, workspaceBytes) = bytesPerCall(
             { result.predict(x) },

--- a/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianWorkspaceAllocationTest.kt
+++ b/kumulant/src/jvmTest/kotlin/com/eignex/kumulant/stat/regression/glm/BayesianWorkspaceAllocationTest.kt
@@ -14,10 +14,10 @@ class BayesianWorkspaceAllocationTest {
     }
 
     @Test
-    fun `reserved workspace removes merge vector scratch allocation`() {
+    fun `workspace reuses merge vector scratch allocation`() {
         val merged = populatedStat().read()
         val allocated = populatedStat()
-        val workspace = Workspace().apply { reserve(8, 8) }
+        val workspace = Workspace()
         val reused = populatedStat()
 
         val (allocatedBytes, workspaceBytes) = bytesPerCall(


### PR DESCRIPTION
## What changed

- Migrate vector, matrix, kernel, packed-panel, and workspace calls to the latest Koblas API.
- Refresh ABI snapshots and benchmarks.

## Why

Koblas renamed its public vector and matrix contracts and reorganized its dense-kernel APIs.

## Testing

./gradlew check lintDocs --rerun-tasks